### PR TITLE
重构翻译编排为双阶段并行起草与串行精修架构

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 uv sync
-export DEEPSEEK_API_KEY=sk-...
+export OPENAI_API_KEY=sk-...
 uv run trans-novel translate book.epub
 ```
 
@@ -123,20 +123,20 @@ uv run trans-novel tools assemble book.epub
 
 ## 模型档位
 
-默认配置使用 DeepSeek，并通过 OpenAI SDK 调用 `https://api.deepseek.com`。
+配置默认支持 OpenAI 兼容格式，可通过环境变量或 `.env` 自由配置任意兼容节点与模型。
 
 - `strong`: 翻译、润色、全局分析、标题翻译。
 - `cheap`: 章末 review、一致性 QA、回译比对。
 - `fast`: 全书预扫、章节梗概、术语抽取、回译等机械任务。
 
-如果模型 ID 变化，直接改 `config.yaml` 里的 `llm.tiers`。
+如果模型 ID 变化，直接在 `.env` 或 `config.yaml` 里的 `llm.tiers` 中修改。
 
 ## 项目结构
 
 ```text
 trans_novel/
   ingest/       输入解析、EPUB/FB2/TXT 切分
-  llm/          LLM 抽象接口、DeepSeek provider、FakeClient
+  llm/          LLM 抽象接口与通用 OpenAI 客户端、FakeClient
   glossary/     SQLite 术语库、抽取、冲突处理
   agents/       分析、翻译、审校、润色、一致性、提示词
   pipeline/     编排器、断点状态、滚动上下文、校验

--- a/config.yaml
+++ b/config.yaml
@@ -5,26 +5,25 @@ language:
   source: auto # auto 由模型识别来源语言；也可写死 ja / en / ko / ru / de 等语言代码
   target: zh # 译文语言
 
-# ── LLM：DeepSeek 三档（经 OpenAI SDK 调 https://api.deepseek.com）─────────
-# strong/cheap 开 thinking（求质量的判断类任务）；fast 关 thinking（机械任务，
-# thinking 推理 token 按输出计费，关掉大幅省钱提速）。缺档按 fast→cheap→strong 回退。
+# ── LLM 配置：三档配置 ───────────────────────────────────────────────────
+# 缺档按 fast→cheap→strong 回退。
 llm:
-  provider: deepseek # deepseek | fake（fake 用于离线测试，不发网络请求）
-  base_url: https://api.deepseek.com
-  api_key_env: DEEPSEEK_API_KEY # 从该环境变量读取 key
-  timeout: 600 # 单次请求超时（秒），思考模式耗时较长
-  max_retries: 4 # 失败重试次数（指数退避）
+  provider: openai # openai | fake（fake 用于离线测试，不发网络请求）
+  base_url: https://api.openai.com/v1
+  api_key_env: OPENAI_API_KEY # 从该环境变量读取 key
+  timeout: 600
+  max_retries: 4
   tiers:
     strong:
-      model: deepseek-v4-pro # 翻译 / 润色 / 全局分析 / 标题
+      model: gpt-4o # 翻译 / 润色 / 全局分析 / 标题
       reasoning_effort: high
       thinking: true
     cheap:
-      model: deepseek-v4-flash # 审校 / 一致性 QA / 回译比对（判断类，保留思考）
+      model: gpt-4o-mini # 审校 / 一致性 QA / 回译比对
       reasoning_effort: high
       thinking: true
     fast:
-      model: deepseek-v4-flash # 梗概 / 全书概览 / 术语抽取 / 回译（机械任务，免思考）
+      model: gpt-4o-mini # 梗概 / 全书概览 / 术语抽取 / 回译
       thinking: false
 
 # ── 切分 ─────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "多 Agent 协同长篇小说翻译系统（多语言到中文），维护专有名词对照表以保证一致性、减少漏译。"
 requires-python = ">=3.10"
 dependencies = [
-    "openai>=1.40",        # DeepSeek（OpenAI 兼容）调用
+    "openai>=1.40",        # OpenAI 兼容 SDK 调用
     "pydantic>=2.7",       # 模型 / 配置校验
     "pyyaml>=6.0",         # 读取 config.yaml
     "tenacity>=8.2",       # LLM 调用重试/退避
@@ -13,6 +13,7 @@ dependencies = [
     "ebooklib>=0.18",      # EPUB 读写
     "typer>=0.12",         # CLI
     "rich>=13.7",          # 表格 / 进度条
+    "python-dotenv>=1.2.2",
 ]
 
 [project.scripts]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -64,5 +64,61 @@ class TestFakeClient(unittest.TestCase):
         self.assertEqual(len(c.calls), 2)
 
 
+class TestConfigEnvOverrides(unittest.TestCase):
+    def setUp(self):
+        import os
+        self.original_env = dict(os.environ)
+
+    def tearDown(self):
+        import os
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def test_env_overrides(self):
+        import os
+        from trans_novel.config import Config
+        
+        os.environ["LLM_PROVIDER"] = "custom-provider"
+        os.environ["LLM_BASE_URL"] = "https://custom-api.com"
+        os.environ["LLM_API_KEY_ENV"] = "CUSTOM_API_KEY"
+        os.environ["LLM_MODEL_STRONG"] = "custom-model-strong"
+        
+        cfg = Config.from_dict({
+            "llm": {
+                "provider": "openai",
+                "base_url": "https://api.openai.com/v1",
+                "api_key_env": "OPENAI_API_KEY",
+                "tiers": {
+                    "strong": {"model": "default-pro"}
+                }
+            }
+        })
+        
+        self.assertEqual(cfg.llm.provider, "custom-provider")
+        self.assertEqual(cfg.llm.base_url, "https://custom-api.com")
+        self.assertEqual(cfg.llm.api_key_env, "CUSTOM_API_KEY")
+        self.assertEqual(cfg.llm.tiers["strong"].model, "custom-model-strong")
+
+    def test_api_key_fallback(self):
+        import os
+        from trans_novel.config import Config
+        
+        # Test 1: LLM_API_KEY takes precedence
+        os.environ["LLM_API_KEY"] = "key-llm"
+        os.environ["CUSTOM_API_KEY"] = "key-custom"
+        cfg = Config.from_dict({"llm": {"api_key_env": "CUSTOM_API_KEY"}})
+        self.assertEqual(cfg.llm.api_key, "key-llm")
+        
+        # Test 2: Fallback to custom api_key_env
+        del os.environ["LLM_API_KEY"]
+        self.assertEqual(cfg.llm.api_key, "key-custom")
+        
+        # Test 3: Fallback to provider-specific default
+        del os.environ["CUSTOM_API_KEY"]
+        os.environ["OPENAI_API_KEY"] = "key-openai"
+        cfg2 = Config.from_dict({"llm": {"provider": "openai", "api_key_env": "SOME_NONEXISTENT"}})
+        self.assertEqual(cfg2.llm.api_key, "key-openai")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -21,8 +21,8 @@ class TestTranslatorAlignment(unittest.TestCase):
         return Config.from_dict({
             "language": {"source": "ja", "target": "zh"},
             "llm": {"provider": "fake", "tiers": {
-                "strong": {"model": "deepseek-v4-pro"},
-                "cheap": {"model": "deepseek-v4-flash"},
+                "strong": {"model": "gpt-4o"},
+                "cheap": {"model": "gpt-4o-mini"},
             }},
             "pipeline": {"align_retry_limit": 1},
         })

--- a/trans_novel/agents/polisher.py
+++ b/trans_novel/agents/polisher.py
@@ -13,7 +13,7 @@ from .base import Agent
 
 class Polisher(Agent):
     def polish(self, targets: list[str], *, glossary_terms: list[GlossaryTerm] | None = None,
-               style: str = "") -> list[str]:
+               style: str = "", context: str = "") -> list[str]:
         if not targets:
             return []
         n = len(targets)
@@ -22,6 +22,7 @@ class Polisher(Agent):
             "polisher_user", src=self.src, tgt=self.tgt,
             glossary=prompts.render_glossary(glossary_terms or []),
             style=style or "（无）", n=n,
+            context=context or "（无）",
             numbered_target=prompts.numbered(targets),
         )
         items = self._ask_json(system, user, tier="strong", key="polished", default=None)

--- a/trans_novel/agents/prompts.py
+++ b/trans_novel/agents/prompts.py
@@ -1,282 +1,330 @@
-"""提示词模板（多源语言 → 中文）。
-
-模板用 string.Template（$ 占位），避免与 JSON 示例里的花括号冲突。
-语言相关片段用 $src_label / $lang_guidance / $term_guidance 占位，
-render() 按 src 自动注入 langprofile 默认值（调用方可显式覆盖）。
-
-缓存约定（命中 DeepSeek 自动前缀缓存，命中部分输入价≈0.1×）：
-- system 模板必须全静态（一次运行内恒定）——勿放每批变化的量（如段数 $n、按批裁剪的术语表）；
-  段数等约束写在 user 末尾。这样 system 成为所有同类调用共享的前缀。
-- user 模板按"静态→动态"排列：风格指南/全书概览(书级恒定) → 专有名词表/本章梗概(章级恒定) →
-  前文译文(每批变) → 待译正文(每批变)。前缀越长且越稳定，命中越多。
-"""
-
 from __future__ import annotations
 
 from string import Template
-
 from ..glossary.store import GlossaryTerm
 from . import langprofile
 
-# 译文标点统一规范（简体中文大陆通用），翻译/润色提示词共用。
 PUNCT_RULE = (
     "标点务必使用简体中文大陆通用全角标点：句读用 ，。！？：；、，"
     "引号用 “”‘’，省略号用 ……，破折号用 ——；"
     "不得使用半角标点，也不要保留日式「」『』或英式直引号。"
 )
 
-# ── 默认模板 ───────────────────────────────────────────────────────────────
 TRANSLATOR_SYSTEM = Template("""\
-你是一位资深的文学翻译，精通将$src_label小说翻译为简体中文，专精长篇小说/轻小说。严格遵守：
-1. 忠实原文，绝不漏译、增译，绝不合并或拆分段落；保留原文分段。
-2. 输入是带编号的$src_label段落数组。必须输出等长的中文译文数组（数量与输入段落严格相等），
-   顺序、数量与输入严格一一对应；第 i 个译文对应第 i 段原文。
-3. 【专有名词对照表】是全书对照表的**相关子集参考**，可能含本批未出现的词条：**只有当某词条原文确实出现在
-   本批待译段落里，才套用其固定译法**，切勿把与本批无关的词条硬塞进译文。已列词条全书统一用其译法；
-   表中未列的专名，沿用【前文回顾】中已出现的译法，勿另起译名。
-4. 参考【全书概览】把握整体走向（主线剧情、人物弧光、伏笔与谜底），使本段措辞与后文不冲突；
-   参考【本章梗概】把握本章脉络；参考【前文译文】保持衔接：代词指代、人物称谓、语气与跨段句意须自然连贯。
-5. 源语言相关要点：
-$lang_guidance
-6. 保留原文语气与文体；**严格执行【风格指南】给出的叙事人称、句式节奏与语域**；
-   对话按角色的口癖/自称习惯译出辨识度；心理、修辞按中文小说习惯自然表达，不生硬直译、不堆砌翻译腔。
-7. $punct_rule
-8. 仅输出 JSON 对象：{"translations": ["第0段译文", "第1段译文", ...]}，不要任何解释或思考过程。\
+你是资深的文学翻译。严格遵循：
+1. 忠实原文分段，输出等长中文数组（数量与输入段落严格相等），对应关系一致。
+2. 遵守 `<glossary>` 中的译法。表中未列专名，沿用 `<context>` 中的译法。
+3. 对话符合人物人设口癖，叙事符合 `<style>`。
+4. $punct_rule
+
+Few-Shot 示例：
+输入段落：
+[0] "Where is he?" she asked.
+[1] "I don't know." he replied.
+
+输出格式：
+{"translations": [
+  "“他在哪里？”她问。",
+  "“我不知道。”他回答。"
+]}
+
+仅输出 JSON，不要任何附加文字。\
 """)
 
 TRANSLATOR_USER = Template("""\
-【角色信息 / 风格指南】
+<style>
 $style
+</style>
 
+<book_synopsis>
 【全书概览】
 $book_synopsis
+</book_synopsis>
 
-【专有名词对照表】（必须遵守）
+<glossary>
 $glossary
+</glossary>
 
+<chapter_digest>
 【本章梗概】
 $chapter_digest
+</chapter_digest>
 
-【前文译文（最近）】
+<context>
 $context
+</context>
 
-【待译$src_label段落】（共 $n 段，编号 0 至 ${n_minus_1}）
+<source_paragraphs n="$n">
 $numbered_source
+</source_paragraphs>
 
-请翻译以上每一段，输出 JSON：{"translations":[...]}，数组长度必须恰好为 $n。\
+<final_instruction>
+请翻译以上每段原文。必须且仅输出 JSON 格式 {"translations": [...]}，包含的译文段落数量必须恰好为 $n。禁止任何附加解释。
+</final_instruction>\
 """)
 
 TRANSLATOR_FIX_USER = Template("""\
-【角色信息 / 风格指南】
+<style>
 $style
+</style>
 
+<book_synopsis>
 【全书概览】
 $book_synopsis
+</book_synopsis>
 
-【专有名词对照表】（必须遵守）
+<glossary>
 $glossary
+</glossary>
 
+<chapter_digest>
 【本章梗概】
 $chapter_digest
+</chapter_digest>
 
-【前文译文】
+<context_before>
 $context_before
+</context_before>
 
-【后文译文】
+<context_after>
 $context_after
+</context_after>
 
-【审校意见】（首译存在的问题，重译必须修正）
+<review_feedback>
+【审校意见】
 $feedback
+</review_feedback>
 
-【待重译$src_label段落】（仅 1 段）
+<source_paragraph>
 [0] $source
+</source_paragraph>
 
-请重译该段，完整传达原文全部信息并与前后文衔接，输出 JSON：{"translations":["译文"]}，数组长度恰为 1。\
+<final_instruction>
+依据 <review_feedback> 修订重译。必须且仅输出 JSON 格式 {"translations": ["译文"]}，包含的译文段落数量恰为 1。
+</final_instruction>\
 """)
 
 REVIEWER_SYSTEM = Template("""\
-你是严格的译文审校，比对$src_label原文与中文译文，逐段找出**确凿**的问题。问题类型：
-- missing：漏译（原文有的信息译文缺失）
-- added：增译（译文凭空增加原文没有的信息）
-- mistranslation：误译/误读原意
-- terminology：原文确实出现、且对照表已给固定译法的词，译文未遵守
-  （对照表为全书参考，含本批未出现的词条；只就本批原文实际出现的词判断，勿因表中无关词条误报）
-- pronoun：人称/性别代词错误
-只报实质性错误：合理的语序调整、自然意译、风格润色**不算问题**，不要报。
-拿不准是否为错就不报，宁缺毋滥。每条须给出可直接采纳的 suggestion。仅输出 JSON：
-{"issues":[{"index":整数段号,"type":"...","detail":"简述","suggestion":"修改后的译文或具体改法"}]}
-没有问题则输出 {"issues":[]}。\
+你是严格的译文审校。比对原文与中文译文，找出确凿的问题：
+- missing：漏译
+- added：增译
+- mistranslation：误译/误读
+- terminology：未遵守对照表固定译法
+- pronoun：代词性别/人称错误
+宁缺毋滥，合理意译或润色不报。给出可直接采纳的 suggestion。
+
+Few-Shot 示例：
+输入对照：
+[0] 原文：Wait, who are you?
+    译文：等待，你是谁？
+[1] 原文：I'm Alice.
+    译文：我是艾丽。
+
+输出格式：
+{"issues": [
+  {"index": 0, "type": "mistranslation", "detail": "“Wait”在此为口语叹词，误译为动词“等待”", "suggestion": "“等等，你是谁？”"},
+  {"index": 1, "type": "terminology", "detail": "未遵守对照表把 Alice 译为“爱丽丝”", "suggestion": "“我是爱丽丝。”"}
+]}
+
+仅输出 JSON，若无问题输出 {"issues": []}。\
 """)
 
 REVIEWER_USER = Template("""\
-【专有名词对照表】
+<glossary>
 $glossary
+</glossary>
 
-【逐段对照】（共 $n 段）
+<chapter_pairs n="$n">
 $pairs
+</chapter_pairs>
 
-请审校并输出 JSON：{"issues":[...]}。\
+<final_instruction>
+审校以上 <chapter_pairs> 并输出 JSON：{"issues":[...]}。\
+</final_instruction>\
 """)
 
 POLISHER_SYSTEM = Template("""\
-你是中文润色编辑。在不改变原意、不增删信息的前提下，提升译文的中文流畅度与文学性：
-理顺语序、修正翻译腔、统一文体语气。务必保持段数不变、与输入一一对应。
-严格沿用【专有名词对照表】的固定译法（表为全书参考，仅就译文实际涉及的词沿用，勿塞入无关词条）。$punct_rule
-仅输出 JSON：{"polished":["第0段","第1段",...]}，长度与输入段数相等。\
+你是中文润色编辑。在不改变原意、不增删信息的前提下，提升中文流畅度与文学性：理顺语序、消除翻译腔。保持段数不变，沿用对照表译法。$punct_rule
+参考 `<context>` 确保人称代词、语气与句意衔接自然连贯。
+
+Few-Shot 示例：
+输入段落：
+[0] 他说他有一只狗。
+
+输出格式：
+{"polished": [
+  "他说自己养了一只狗。"
+]}
+
+仅输出 JSON，不要任何附加解释。\
 """)
 
 POLISHER_USER = Template("""\
-【角色信息 / 风格指南】
+<style>
 $style
+</style>
 
-【专有名词对照表】
+<glossary>
 $glossary
+</glossary>
 
-【待润色中文译文】（共 $n 段）
+<context>
+$context
+</context>
+
+<target_paragraphs n="$n">
 $numbered_target
+</target_paragraphs>
 
-输出 JSON：{"polished":[...]}，长度恰为 $n。\
+<final_instruction>
+润色以上 <target_paragraphs>，输出 JSON：{"polished":[...]}，长度恰为 $n。
+</final_instruction>\
 """)
 
 TITLE_TRANSLATOR_SYSTEM = Template("""\
-你是$src_label小说的标题翻译。把【章节标题与目录项】逐条翻译为简体中文：
-1. 输入依次为各章标题或额外目录项标题（带编号），不包含书名。
-2. 必须输出等长的中文数组（数量与输入条数严格相等），顺序一一对应。
-3. 严格遵守【专有名词对照表】的固定译法（人名/地名/术语全书一致）。
-4. 标题须简洁、合乎中文书名/章节命名习惯；不加引号、书名号或解释；
-   形如「第3章」「序章」「エピローグ」之类的卷章序号/通用标记，按中文惯例翻译
-   （如「第3章」「序章」「尾声」），不要音译。
-5. $punct_rule
-仅输出 JSON：{"titles":["第0条标题译文","第1条标题译文",...]}，长度与输入条数相等。\
+你是小说标题翻译。翻译章节名或目录标题，保持条数一致。遵守对照表，简洁符合中文命名习惯。$punct_rule
+
+Few-Shot 示例：
+输入标题：
+[0] Prologue
+[1] Chapter 1: The Beginning
+
+输出格式：
+{"titles": [
+  "序章",
+  "第一章：开始"
+]}
+
+仅输出 JSON。\
 """)
 
 TITLE_TRANSLATOR_USER = Template("""\
-【专有名词对照表】
+<glossary>
 $glossary
+</glossary>
 
-【待译标题】（共 $n 条）
+<titles n="$n">
 $numbered_titles
+</titles>
 
-输出 JSON：{"titles":[...]}，长度恰为 $n。\
+<final_instruction>
+翻译以上标题，输出 JSON：{"titles":[...]}，长度恰为 $n。
+</final_instruction>\
 """)
 
 ANALYZER_SYSTEM = Template("""\
-你是小说翻译项目的前期分析师。阅读以下$src_label样章，产出供后续翻译统一遵循的基准信息。
+你是小说前期分析师。阅读样章，提取风格和人设基准。
 术语字段说明：$term_guidance
-仅输出 JSON：
+仅输出 JSON 格式：
 {
   "genre": "体裁",
-  "tone": "整体语气/文体（如：青春校园、冷峻第三人称）",
-  "style_guide": "给译者的风格指南（中文，3-6 条要点）",
-  "narration": "叙事人称与时态（如：第一人称限知、过去时）",
-  "pacing": "句式节奏（长短句比例、断句习惯、段落密度）",
-  "register": "语域（书面/口语/文白程度）",
-  "dialogue_style": "对话风格（口癖、语气词、称呼习惯）",
-  "rhetoric": "修辞倾向（比喻密度、心理描写方式等）",
-  "characters": [{"source":"原文名","reading":"读音(可空)","target":"建议中文译名","gender":"男/女/未知","note":"性格/语气特征，须包含说话方式：自称、口癖、敬语习惯"}],
-  "terms": [{"source":"原文词","reading":"读音(可空)","target":"建议中文译法","type":"地名/组织/术语","note":""}]
+  "tone": "整体基调",
+  "style_guide": "风格指南",
+  "narration": "叙事人称与时态",
+  "pacing": "句式节奏",
+  "register": "语域",
+  "dialogue_style": "对话习惯",
+  "rhetoric": "修辞特征",
+  "characters": [{"source":"原文名","reading":"读音","target":"中文译名","gender":"男/女/未知","note":"说话方式与特征"}],
+  "terms": [{"source":"原文词","reading":"读音","target":"建议译法","type":"类型","note":""}]
 }\
 """)
 
 ANALYZER_USER = Template("""\
-【样章原文（$src_label）】
+<sample>
 $sample
+</sample>
 
-请分析并输出上述 JSON。人名、地名、专有名词尽量找全，译名力求自然且符合中文小说习惯。
-样章可能取自全书开头/中部/结尾（见标注），请综合判断整体风格及其演变。\
+<final_instruction>
+分析以上 <sample>，输出上述格式的 JSON。人名、专名尽量找全。
+</final_instruction>\
 """)
 
 GLOSSARY_EXTRACTOR_SYSTEM = Template("""\
-你是小说翻译项目的术语与称呼抽取器。从给定的$src_label原文与其中文译文中，抽取应进入"专有名词对照表"的条目。
-必须抽取：
-1. 专有实体：人名、地名、组织名、作品内专有术语、招式名、物品名、设定名。
-2. 同一实体的称呼变体：昵称、敬称、职称称呼、亲属称呼、外号、缩写、带前后缀的称呼、大小名/爱称/蔑称等。
-   若原文称呼变体在译文中有独立译法，应作为单独条目输出，而不是只放进 aliases。
-   aliases 用于记录同一 source 的其它原文写法/拼写/简称，不用于替代 source→target 的独立映射。
-3. 需要全书统一的固定表达：人物口癖、反复出现且具有辨识度的称呼句、咒语/标语/固定台词、带设定含义的短语。
-   只抽取会影响后续一致性的表达；不要抽普通寒暄、普通语气词、一次性修辞或常见词汇。
-抽取原则：
-- 依据本批译文中实际采用的中文写法填写 target，不要凭空创造译名。
-- 若同一 source 在已有对照表中已有译法，尽量沿用；若本批译文出现明显不同译法，也照实输出，交由系统记录冲突。
-- 对照表可能包含本批未出现条目，不要重复输出未在本批原文或译文中得到确认的项。
+你是术语与称呼抽取器。比对原文与译文，提取专有名词、称呼变体和固定表达。
 术语字段说明：$term_guidance
-仅输出 JSON：
-{"terms":[{"source":"原文词或原文称呼/固定表达","reading":"读音(可空)","target":"本批译文中实际采用的中文译法","type":"人物/地名/组织/术语/招式/称谓/口癖/固定表达","gender":"男/女/未知(仅人物)","aliases":["同一 source 的其它原文写法/简称/拼写变体"],"note":"归属、说话人、语气、使用场景或统一理由"}]}\
+仅输出 JSON 格式：
+{"terms":[{"source":"原文词","reading":"读音","target":"中文译法","type":"人物/地名/术语/称谓/口癖/固定表达","gender":"男/女/未知","aliases":["其它拼写/简称"],"note":"归属或统一理由"}]}\
 """)
 
 GLOSSARY_EXTRACTOR_USER = Template("""\
-【已有对照表（参考，尽量沿用其译法）】
+<glossary>
 $glossary
+</glossary>
 
-【原文（$src_label）】
+<source_text>
 $source
+</source_text>
 
-【译文（中文）】
+<target_text>
 $target
+</target_text>
 
-请抽取新出现或被本批确认的术语、称呼变体和固定表达，输出 JSON：{"terms":[...]}。\
+<final_instruction>
+提取新术语/变体，输出 JSON：{"terms":[...]}。
+</final_instruction>\
 """)
 
 BACKTRANSLATE_SYSTEM = Template("""\
-你是回译译者。把给定的中文译文回译成$src_label，只看中文、忠实表达其含义，输出 JSON：
+你是回译译者。把给定的中文译文回译成$src_label，仅输出 JSON：
 {"backtranslations":["...",...]}，长度与输入一致。\
 """)
 
 BACKTRANSLATE_USER = Template("""\
-【中文译文】（共 $n 段）
+<target_paragraphs n="$n">
 $numbered_target
+</target_paragraphs>
 
-输出 JSON：{"backtranslations":[...]}。\
+<final_instruction>
+回译以上段落，输出 JSON：{"backtranslations":[...]}。
+</final_instruction>\
 """)
 
 CONSISTENCY_SYSTEM = Template("""\
-你是全书一致性审查员。给定专有名词对照表和若干章节译文摘要，检查：
-术语译法是否前后统一、同一人物代词性别是否一致、语气文体是否漂移、标点是否统一为简体中文规范。
-仅输出 JSON：{"issues":[{"type":"terminology/pronoun/tone/punctuation","detail":"...","where":"章节线索"}]}。\
+你是全书一致性审查员。审查专有名词及代词等一致性问题。
+仅输出 JSON：{"issues":[{"type":"terminology/pronoun/tone/punctuation","detail":"描述","where":"章节线索"}]}。\
 """)
 
 CONSISTENCY_FIX_SYSTEM = Template("""\
-你是全书一致性修订员。依据【专有名词对照表】与各章译文摘要，找出**可安全机械修复的术语/译名不一致**，
-给出确定的全局替换（把不统一/错误的中文写法替换为规范写法）。
-只处理能安全全局替换的专名/术语；**不要改动代词、语气、句式**（那些交由人工）。
+你是全书一致性修订员。依据对照表与摘要找出可安全机械修复的译名不一致。
 仅输出 JSON：{"replacements":[{"wrong":"被替换写法","right":"规范写法","reason":"简述"}]}，无则 {"replacements":[]}。\
 """)
 
 GLOSSARY_AUDIT_SYSTEM = Template("""\
-你是术语一致性审计员。给定一份专有名词对照表（同一原文可能出现多种译法或形近变体），
-为每个原文词裁定唯一【规范译法】（canonical），并列出应被替换掉的其它变体。
-裁定优先级：已锁定 > 高置信度 > 出现更普遍/更规范的中文译名。
-仅输出 JSON：{"unifications":[{"source":"原文词","canonical":"规范中文译法","variants":["被替换的其它译法"],"reason":"简述"}]}
-没有需要统一的就输出 {"unifications":[]}。\
+你是术语一致性审计员。为每个原文词裁定唯一规范译法。
+仅输出 JSON：{"unifications":[{"source":"原文词","canonical":"规范译法","variants":["被替换其它译法"],"reason":"简述"}]}，无则 {"unifications":[]}。\
 """)
 
 CHAPTER_DIGEST_SYSTEM = Template("""\
-你是小说章节梗概员。阅读给定的$src_label单章原文，用简体中文写出该章梗概（不超过 200 字）：
-交代本章关键情节推进、登场人物及其处境、重要信息或转折，去除细枝末节。只输出梗概正文，不要解释。\
+你是小说章节梗概员。写出单章中文梗概（不超过 200 字），只输出正文。\
 """)
 
 CHAPTER_DIGEST_USER = Template("""\
-【章节原文（$src_label）】
+<source_chapter>
 $source
+</source_chapter>
 
-请输出该章中文梗概（不超过 200 字）。\
+<final_instruction>
+输出梗概（不超过 200 字）。
+</final_instruction>\
 """)
 
 BOOK_SYNOPSIS_SYSTEM = Template("""\
-你是小说全书概览员。依据【前期分析】与【各章梗概】，用简体中文写出一份"全书概览"（不超过 500 字），
-供译者在翻译任意章节前把握全局，避免与后文冲突：
-主线剧情走向与结局、主要人物及其关系与弧光、核心设定/谜底/重要伏笔、整体基调。
-只输出概览正文，不要解释或分点编号。\
+你是全书概览员。综合分析与各章梗概，写出全书概览（不超过 500 字），只输出正文。\
 """)
 
 BOOK_SYNOPSIS_USER = Template("""\
-【前期分析】
+<analysis>
 $analysis
+</analysis>
 
-【各章梗概】
+<chapter_digests>
 $digests
+</chapter_digests>
 
-请综合以上，输出全书概览（不超过 500 字）。\
+<final_instruction>
+输出全书概览（不超过 500 字）。
+</final_instruction>\
 """)
 
 _DEFAULTS = {
@@ -304,10 +352,9 @@ _DEFAULTS = {
     "book_synopsis_user": BOOK_SYNOPSIS_USER,
 }
 
+
 def render(name: str, *, src: str = "ja", tgt: str = "zh", **kwargs) -> str:
-    """渲染内置模板；按 src 自动注入语言相关默认占位。"""
     tmpl = _DEFAULTS[name]
-    # 语言相关默认值（调用方可用同名 kwarg 覆盖）
     kwargs.setdefault("src_label", langprofile.label(src))
     kwargs.setdefault("lang_guidance", langprofile.translate_guidance(src))
     kwargs.setdefault("term_guidance", langprofile.term_guidance(src))
@@ -315,9 +362,7 @@ def render(name: str, *, src: str = "ja", tgt: str = "zh", **kwargs) -> str:
     return tmpl.safe_substitute(**kwargs)
 
 
-# ── 渲染辅助 ───────────────────────────────────────────────────────────────
 def honorific_rule(strategy: str) -> str:
-    """敬称规则（保留以兼容调用方）；底层委托 langprofile。"""
     return langprofile.honorific_rule(strategy)
 
 

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -1,5 +1,3 @@
-"""配置加载。读取 config.yaml，提供带默认值的类型化访问（pydantic v2）。"""
-
 from __future__ import annotations
 
 import os
@@ -13,19 +11,25 @@ class TierConfig(BaseModel):
     model: str
     reasoning_effort: str = "high"
     thinking: bool = True
+    extra_body: dict[str, Any] | None = None
 
 
 class LLMConfig(BaseModel):
-    provider: str = "deepseek"
-    base_url: str = "https://api.deepseek.com"
-    api_key_env: str = "DEEPSEEK_API_KEY"
+    provider: str = "openai"
+    base_url: str = "https://api.openai.com/v1"
+    api_key_env: str = "OPENAI_API_KEY"
     timeout: int = 600
     max_retries: int = 4
     tiers: dict[str, TierConfig] = Field(default_factory=dict)
 
     @property
     def api_key(self) -> str | None:
-        return os.environ.get(self.api_key_env)
+        if os.environ.get("LLM_API_KEY"):
+            return os.environ.get("LLM_API_KEY")
+        val = os.environ.get(self.api_key_env)
+        if val:
+            return val
+        return os.environ.get("OPENAI_API_KEY") or os.environ.get("API_KEY")
 
 
 class SegmentConfig(BaseModel):
@@ -35,49 +39,82 @@ class SegmentConfig(BaseModel):
 
 class PipelineConfig(BaseModel):
     review: bool = True
-    autofix_severe: bool = True      # 章末审校后自动重译严重项（漏译/误译）；关闭则仅上报留人工
-    align_retry_limit: int = 2       # 批次翻译段数不符时的整批重试次数，超限后逐段兜底
-    polish: bool = False             # 默认关：润色=用强档把全书再翻一遍，最烧钱；需要时显式开
+    autofix_severe: bool = True
+    align_retry_limit: int = 2
+    polish: bool = False
     backtranslate_sample: float = 0.05
     consistency_qa: bool = True
     rolling_context_segments: int = 6
-    # 翻译前预扫源文，生成全书概览+逐章梗概注入翻译 prompt（让译者对全书有理解）。
-    # fast 档（免思考），且全局概览为恒定前缀可命中缓存复用；关掉可省去预扫成本。
     book_understanding: bool = True
-    prescan_concurrency: int = 4     # 预扫逐章梗概的并发线程数（各章独立，1=串行）
-    glossary_scope: str = "chapter"  # chapter=只注入本章出现的词条+锁定人物（省 token）；full=全量表
+    prescan_concurrency: int = 4
+    glossary_scope: str = "chapter"
 
 
 class Config(BaseModel):
-    source_lang: str = "auto"        # auto | ja | en | …（auto 时由模型检测）
+    source_lang: str = "auto"
     target_lang: str = "zh"
     llm: LLMConfig = Field(default_factory=LLMConfig)
     segment: SegmentConfig = Field(default_factory=SegmentConfig)
     pipeline: PipelineConfig = Field(default_factory=PipelineConfig)
     honorific_strategy: str = "keep_style"
-    punctuation_normalize: bool = True  # 译文标点规范化为简体中文通用
+    punctuation_normalize: bool = True
     state_dir: str = "state"
 
     @classmethod
     def load(cls, path: str = "config.yaml") -> "Config":
-        with open(path, "r", encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
+        try:
+            from dotenv import load_dotenv
+            load_dotenv()
+        except Exception:
+            pass
+
+        raw = {}
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f) or {}
         return cls.from_dict(raw)
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "Config":
-        lang = raw.get("language", {})
-        llm_raw = raw.get("llm", {})
-        tiers = {
-            name: TierConfig.model_validate(t)
-            for name, t in (llm_raw.get("tiers", {}) or {}).items()
-        }
+        lang = raw.get("language", {}) or {}
+        llm_raw = raw.get("llm", {}) or {}
+        
+        provider = os.environ.get("LLM_PROVIDER") or llm_raw.get("provider", "openai")
+        base_url = os.environ.get("LLM_BASE_URL") or llm_raw.get("base_url", "https://api.openai.com/v1")
+        api_key_env = os.environ.get("LLM_API_KEY_ENV") or llm_raw.get("api_key_env", "OPENAI_API_KEY")
+        
+        try:
+            timeout = int(os.environ.get("LLM_TIMEOUT") or llm_raw.get("timeout", 600))
+        except ValueError:
+            timeout = 600
+            
+        try:
+            max_retries = int(os.environ.get("LLM_MAX_RETRIES") or llm_raw.get("max_retries", 4))
+        except ValueError:
+            max_retries = 4
+
+        raw_tiers = llm_raw.get("tiers", {}) or {}
+        if not raw_tiers:
+            raw_tiers = {
+                "strong": {"model": "gpt-4o", "reasoning_effort": "high", "thinking": True},
+                "cheap": {"model": "gpt-4o-mini", "reasoning_effort": "high", "thinking": True},
+                "fast": {"model": "gpt-4o-mini", "thinking": False},
+            }
+            
+        tiers = {}
+        for name, t in raw_tiers.items():
+            t_obj = TierConfig.model_validate(t)
+            env_model = os.environ.get(f"LLM_MODEL_{name.upper()}")
+            if env_model:
+                t_obj.model = env_model
+            tiers[name] = t_obj
+
         llm = LLMConfig(
-            provider=llm_raw.get("provider", "deepseek"),
-            base_url=llm_raw.get("base_url", "https://api.deepseek.com"),
-            api_key_env=llm_raw.get("api_key_env", "DEEPSEEK_API_KEY"),
-            timeout=llm_raw.get("timeout", 600),
-            max_retries=llm_raw.get("max_retries", 4),
+            provider=provider,
+            base_url=base_url,
+            api_key_env=api_key_env,
+            timeout=timeout,
+            max_retries=max_retries,
             tiers=tiers,
         )
         segment = SegmentConfig.model_validate(raw.get("segment", {}) or {})

--- a/trans_novel/llm/__init__.py
+++ b/trans_novel/llm/__init__.py
@@ -1,4 +1,4 @@
-"""LLM 调用层：抽象接口 + DeepSeek provider + 离线 FakeClient。"""
+"""LLM 调用层。"""
 
 from .base import LLMClient, FakeClient, build_client, parse_json_loose
 

--- a/trans_novel/llm/base.py
+++ b/trans_novel/llm/base.py
@@ -1,16 +1,3 @@
-"""LLM 抽象接口与具体实现。
-
-设计要点：
-- 三档 tier："strong"（deepseek-v4-pro + thinking，翻译/润色/分析/审计）、
-  "cheap"（deepseek-v4-flash + thinking，审校/一致性等判断类）、
-  "fast"（deepseek-v4-flash 免思考，梗概/术语抽取/回译等机械任务——
-  thinking 推理 token 按输出计费，机械任务关掉可大幅省钱提速）。
-  缺档时按回退链向"更便宜优先"回退（fast→cheap→strong），老双档配置行为不变。
-- complete() 返回纯文本；complete_json() 强制 JSON 输出并 loose 解析。
-- DeepSeekClient 经由 OpenAI SDK 调 https://api.deepseek.com，openai 惰性导入；
-  未装 openai 时仍可用 FakeClient 跑通离线流程（切分/对齐/术语库/状态机）。
-"""
-
 from __future__ import annotations
 
 import json
@@ -30,12 +17,10 @@ from ..config import Config, LLMConfig, TierConfig
 
 Messages = list[dict[str, str]]
 
-# 缺档回退链：向"更便宜优先"回退，绝不因缺档反而升到更贵的档
 _TIER_FALLBACK = {"fast": ("cheap", "strong"), "cheap": ("strong",), "strong": ()}
 
 
 def resolve_tier(tiers: dict[str, TierConfig], tier: str) -> TierConfig:
-    """按回退链解析 tier 配置。缺 strong 时 KeyError（与旧行为一致）。"""
     if tier in tiers:
         return tiers[tier]
     for fb in _TIER_FALLBACK.get(tier, ("strong",)):
@@ -44,18 +29,12 @@ def resolve_tier(tiers: dict[str, TierConfig], tier: str) -> TierConfig:
     return tiers["strong"]
 
 
-# ── JSON 宽松解析 ────────────────────────────────────────────────────────
 def parse_json_loose(text: str) -> Any:
-    """从模型输出里尽力解析 JSON。
-
-    优先直接 json.loads；失败则剥离 ```json 围栏并截取首个 {…}/[…] 块再试。
-    """
     text = (text or "").strip()
     try:
         return json.loads(text)
     except Exception:
         pass
-    # 去掉 markdown 代码围栏
     fenced = re.search(r"```(?:json)?\s*(.*?)```", text, re.S)
     if fenced:
         inner = fenced.group(1).strip()
@@ -63,7 +42,6 @@ def parse_json_loose(text: str) -> Any:
             return json.loads(inner)
         except Exception:
             text = inner
-    # 截取首个 JSON 数组或对象
     for open_ch, close_ch in (("[", "]"), ("{", "}")):
         start = text.find(open_ch)
         end = text.rfind(close_ch)
@@ -75,10 +53,7 @@ def parse_json_loose(text: str) -> Any:
     raise ValueError(f"无法解析为 JSON：{text[:200]!r}")
 
 
-# ── 抽象接口 ──────────────────────────────────────────────────────────────
 class LLMClient(ABC):
-    """所有 provider 实现此接口。"""
-
     @abstractmethod
     def complete(
         self,
@@ -88,7 +63,6 @@ class LLMClient(ABC):
         json_mode: bool = False,
         max_tokens: Optional[int] = None,
     ) -> str:
-        """返回模型回复的纯文本。"""
         raise NotImplementedError
 
     def complete_json(
@@ -98,19 +72,17 @@ class LLMClient(ABC):
         tier: str = "strong",
         max_tokens: Optional[int] = None,
     ) -> Any:
-        """要求 JSON 输出并解析。"""
         text = self.complete(messages, tier=tier, json_mode=True, max_tokens=max_tokens)
         return parse_json_loose(text)
 
 
-# ── DeepSeek（OpenAI SDK 兼容）────────────────────────────────────────────
-class DeepSeekClient(LLMClient):
+class OpenAIClient(LLMClient):
     def __init__(self, cfg: LLMConfig):
         self.cfg = cfg
         if not cfg.tiers:
-            raise ValueError("配置缺少 llm.tiers")
-        self._client = None  # 惰性创建
-        self._client_lock = threading.Lock()  # 预扫并行时防惰性初始化竞态
+            raise ValueError("配置缺少 tiers")
+        self._client = None
+        self._client_lock = threading.Lock()
 
     def _ensure_client(self):
         with self._client_lock:
@@ -120,15 +92,11 @@ class DeepSeekClient(LLMClient):
         if self._client is None:
             try:
                 from openai import OpenAI
-            except ImportError as e:  # pragma: no cover
-                raise RuntimeError(
-                    "需要 openai SDK：pip install openai（或把 llm.provider 设为 fake 做离线测试）"
-                ) from e
+            except ImportError as e:
+                raise RuntimeError("请安装 openai SDK: pip install openai") from e
             api_key = self.cfg.api_key
             if not api_key:
-                raise RuntimeError(
-                    f"未设置环境变量 {self.cfg.api_key_env}（DeepSeek API key）"
-                )
+                raise RuntimeError(f"未设置 API key")
             self._client = OpenAI(
                 api_key=api_key,
                 base_url=self.cfg.base_url,
@@ -152,17 +120,19 @@ class DeepSeekClient(LLMClient):
             "messages": messages,
             "stream": False,
         }
+
         if tcfg.thinking:
             kwargs["reasoning_effort"] = tcfg.reasoning_effort
-            kwargs["extra_body"] = {"thinking": {"type": "enabled"}}
+
+        if tcfg.extra_body:
+            kwargs.setdefault("extra_body", {}).update(tcfg.extra_body)
+
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
-        if max_tokens:
-            # DeepSeek thinking 模式下 max_tokens 含推理 token（总输出上限）。
-            # 带紧上限的调用若经回退链落到 thinking 档，抬到安全下限防推理被截断。
-            kwargs["max_tokens"] = max(max_tokens, 4096) if tcfg.thinking else max_tokens
 
-        # 网络/限流/超时 → tenacity 指数退避重试（最多 max_retries 次重试）
+        if max_tokens:
+            kwargs["max_tokens"] = max_tokens
+
         @retry(
             stop=stop_after_attempt(self.cfg.max_retries + 1),
             wait=wait_exponential(multiplier=1, max=30),
@@ -176,17 +146,10 @@ class DeepSeekClient(LLMClient):
         return _call()
 
 
-# ── 离线 Fake（测试 / 不发网络请求）───────────────────────────────────────
 class FakeClient(LLMClient):
-    """可编程的离线 client。
-
-    handler(messages, tier, json_mode) -> str。默认对 json_mode 返回 "[]"，
-    否则返回空串。测试通过注入 handler 模拟翻译/抽取等行为。
-    """
-
     def __init__(self, handler: Optional[Callable[[Messages, str, bool], str]] = None):
         self.handler = handler
-        self.calls: list[dict[str, Any]] = []  # 记录调用，便于断言
+        self.calls: list[dict[str, Any]] = []
 
     def complete(
         self,
@@ -205,8 +168,6 @@ class FakeClient(LLMClient):
 
 def build_client(config: Config) -> LLMClient:
     provider = config.llm.provider.lower()
-    if provider == "deepseek":
-        return DeepSeekClient(config.llm)
     if provider == "fake":
         return FakeClient()
-    raise ValueError(f"未知 provider：{provider}（支持 deepseek / fake）")
+    return OpenAIClient(config.llm)

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -380,79 +380,180 @@ class Orchestrator:
 
         batches = batch_segments(text_segs, self.config.segment.max_chars_per_batch)
         label = f"第{ci}章 {chapter.title}"
-        # 章内术语快照会在每个批次术语抽取后刷新，让新确认的称呼/口癖/固定表达
-        # 立即影响后续批次。glossary_scope=chapter 时仍按本章源文裁剪，避免全量表过大。
         term_snapshot = self._chapter_term_snapshot(glossary, text_segs)
 
-        # 逐批串行：每批渲染最新上下文 → 处理 → 立即把译文并入上下文供下一批参照。
-        # 不再并发，换取章内跨批的代词/术语/语气连贯。
-        # 断点续跑（段/批级）：上次中断前已译完并落盘的批次，整批跳过、不重翻，只重建上下文。
+        # 确保已有的目标翻译同步记录到 draft 中，并清除已被置空的 target 的 draft 记录
+        for s in text_segs:
+            if not s.target:
+                s.meta.pop("draft", None)
+            elif not s.meta.get("draft"):
+                s.meta["draft"] = s.target
+
+        # 第一阶段：并行/串行起草
+        todo_batches = []
+        for idx, b in enumerate(batches):
+            need_draft = False
+            for s in b:
+                if not s.meta.get("draft") and not s.target:
+                    need_draft = True
+                    break
+            if need_draft:
+                todo_batches.append((idx, b))
+
+        if todo_batches:
+            concurrency = max(1, self.config.pipeline.prescan_concurrency)
+            use_parallel = self.config.pipeline.polish and concurrency > 1
+
+            if use_parallel:
+                store.log_event(
+                    "chapter_drafting_started",
+                    chapter=ci,
+                    todo_count=len(todo_batches),
+                    workers=concurrency,
+                )
+                with ThreadPoolExecutor(max_workers=concurrency) as ex:
+                    futures = {}
+                    for idx, b in todo_batches:
+                        sources = [s.source for s in b]
+                        fut = ex.submit(
+                            self.translator.translate_batch,
+                            sources,
+                            glossary_terms=term_snapshot,
+                            style=style,
+                            context="",
+                            book_synopsis=book_synopsis,
+                            chapter_digest=chapter_digest
+                        )
+                        futures[fut] = (idx, b)
+                    
+                    for fut in as_completed(futures):
+                        idx, b = futures[fut]
+                        try:
+                            res_targets = fut.result()
+                        except Exception as e:
+                            store.log_event("batch_drafting_failed", chapter=ci, batch_index=idx, error=str(e))
+                            res_targets = []
+                        
+                        if len(res_targets) == len(b):
+                            for s, t in zip(b, res_targets):
+                                s.meta["draft"] = t
+                        else:
+                            for s in b:
+                                if not s.meta.get("draft"):
+                                    s.meta["draft"] = ""
+                        store.save_chapter(chapter)
+            else:
+                draft_context = RollingContext()
+                for idx, b in enumerate(batches):
+                    existing = [s.target or s.meta.get("draft") or "" for s in b]
+                    if all(existing) and (idx, b) not in todo_batches:
+                        draft_context.add_targets(existing)
+                        continue
+                    
+                    sources = [s.source for s in b]
+                    ctx_text = draft_context.render(self.config.pipeline.rolling_context_segments)
+                    try:
+                        res_targets = self.translator.translate_batch(
+                            sources,
+                            glossary_terms=term_snapshot,
+                            style=style,
+                            context=ctx_text,
+                            book_synopsis=book_synopsis,
+                            chapter_digest=chapter_digest
+                        )
+                    except Exception as e:
+                        store.log_event("batch_drafting_failed", chapter=ci, batch_index=idx, error=str(e))
+                        res_targets = []
+                    
+                    if len(res_targets) == len(b):
+                        for s, t in zip(b, res_targets):
+                            s.meta["draft"] = t
+                            if not self.config.pipeline.polish:
+                                s.target = t
+                        draft_context.add_targets(res_targets)
+                    else:
+                        for s in b:
+                            if not s.meta.get("draft"):
+                                s.meta["draft"] = ""
+                        draft_context.add_targets(["" for _ in b])
+                    
+                    store.save_chapter(chapter)
+                    self._extract_batch_glossary(glossary, store, ci, idx * len(b), b)
+                    term_snapshot = self._chapter_term_snapshot(glossary, text_segs)
+
+        # 第二阶段：串行精修（润色与衔接）
         review_issues: list[dict] = [
             i for i in chapter.meta.get("review_issues", [])
             if i.get("stage") != "length"
         ]
         bt_samples: list[tuple[str, str]] = []
-        seg_base = 0   # 当前批首段的章内段号（issue 批内下标 → 章内段号）
+        seg_base = 0
+
         for b in batches:
             existing_targets = [s.target for s in b if s.target and s.target.strip()]
             if len(existing_targets) == len(b):
-                # 该批上次已在原位、原上下文中译完 → 复用，重建滚动上下文后跳过
                 context.add_targets(existing_targets)
-                summary = self._extract_batch_glossary(glossary, store, ci, seg_base, b)
+                self._extract_batch_glossary(glossary, store, ci, seg_base, b)
                 term_snapshot = self._chapter_term_snapshot(glossary, text_segs)
-                store.log_event(
-                    "batch_skipped",
-                    chapter=ci,
-                    start_index=seg_base,
-                    count=len(b),
-                    reason="already_translated",
-                    glossary_extraction=summary,
-                    segments=[
-                        {"index": seg_base + i, "source": s.source, "target": s.target}
-                        for i, s in enumerate(b)
-                    ],
-                )
                 done += len(b)
                 seg_base += len(b)
                 if progress:
                     progress(done, total, label)
                 continue
 
+            drafts = [s.meta.get("draft") or "" for s in b]
             ctx_text = context.render(self.config.pipeline.rolling_context_segments)
-            res = self._process_batch(b, term_snapshot, ctx_text, style,
-                                      book_synopsis, chapter_digest)
-            for s, t in zip(b, res.targets):
+            
+            if self.config.pipeline.polish:
+                try:
+                    polished_targets = self.polisher.polish(
+                        drafts,
+                        glossary_terms=term_snapshot,
+                        style=style,
+                        context=ctx_text
+                    )
+                except Exception:
+                    polished_targets = drafts
+                if len(polished_targets) != len(b):
+                    polished_targets = drafts
+            else:
+                polished_targets = drafts
+
+            if self.config.punctuation_normalize:
+                polished_targets = [normalize_zh(t) if t else t for t in polished_targets]
+
+            for s, t in zip(b, polished_targets):
                 s.target = t
-            batch_start = seg_base
+
+            context.add_targets(polished_targets)
+
+            # 收集回译样本
+            rate = self.config.pipeline.backtranslate_sample
+            if rate > 0:
+                for s in b:
+                    if random.random() < rate:
+                        bt_samples.append((s.source, s.target or ""))
+            
             store.log_event(
                 "batch_translated",
                 chapter=ci,
-                start_index=batch_start,
+                start_index=seg_base,
                 count=len(b),
                 polished=self.config.pipeline.polish,
                 punctuation_normalized=self.config.punctuation_normalize,
-                issues=res.issues,
-                backtranslate_sample_count=len(res.bt_samples),
                 segments=[
-                    {"index": batch_start + i, "source": s.source, "target": t}
-                    for i, (s, t) in enumerate(zip(b, res.targets))
+                    {"index": seg_base + i, "source": s.source, "target": s.target}
+                    for i, s in enumerate(b)
                 ],
             )
-            context.add_targets(res.targets)
-            for it in res.issues:
-                it["chapter"] = ci
-                it["index"] += batch_start   # 批内下标 → 章内段号
-            review_issues.extend(res.issues)
-            bt_samples.extend(res.bt_samples)
+
             done += len(b)
             seg_base += len(b)
             if progress:
                 progress(done, total, label)
-            # 增量持久化：本批译文 + 累计问题落盘，下次中断从此批之后续跑
-            chapter.meta["review_issues"] = review_issues
+
             store.save_chapter(chapter)
-            # 译文落盘后再抽取术语，避免中断时术语库领先章节产物。
-            self._extract_batch_glossary(glossary, store, ci, batch_start, b)
+            self._extract_batch_glossary(glossary, store, ci, seg_base - len(b), b)
             term_snapshot = self._chapter_term_snapshot(glossary, text_segs)
 
         # 全章术语抽取入库：保留为兜底，捕捉跨段才能确认的称呼/口癖/固定表达。
@@ -638,37 +739,7 @@ class Orchestrator:
                     issues=seg_issues,
                 )
 
-    def _process_batch(self, batch, terms, ctx_text: str, style: str,
-                       book_synopsis: str = "", chapter_digest: str = "") -> _BatchResult:
-        """单个批次：整批翻译 → 润色 → 标点规范化。
 
-        每段都在自身上下文里翻译，不跨位置复用译文（避免丢失语境信息）。
-        全书概览/本章梗概作为恒定前缀注入，让译者把握全局。
-        LLM 审校不在批内做（移至章末统一做，见 _review_chapter，不阻塞翻译主路径）。
-        """
-        sources = [s.source for s in batch]
-        targets = self.translator.translate_batch(
-            sources, glossary_terms=terms, style=style, context=ctx_text,
-            book_synopsis=book_synopsis, chapter_digest=chapter_digest)
-
-        issues: list[dict] = []
-
-        if self.config.pipeline.polish:
-            polished = self.polisher.polish(targets, glossary_terms=terms, style=style)
-            if len(polished) == len(targets):
-                targets = polished
-
-        if self.config.punctuation_normalize:
-            targets = [normalize_zh(t) if t else t for t in targets]
-
-        bt_samples: list[tuple[str, str]] = []
-        rate = self.config.pipeline.backtranslate_sample
-        if rate > 0:
-            for s, t in zip(sources, targets):
-                if random.random() < rate:
-                    bt_samples.append((s, t or ""))
-
-        return _BatchResult(targets=targets, issues=issues, bt_samples=bt_samples)
 
     # ── 可选步骤 / 连续全流程 ────────────────────────────────────────────────
     ALL_STEPS = ("translate", "qa", "report", "assemble")

--- a/uv.lock
+++ b/uv.lock
@@ -92,7 +92,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -547,6 +547,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -690,6 +699,7 @@ dependencies = [
     { name = "lxml" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tenacity" },
@@ -703,6 +713,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=5.0" },
     { name = "openai", specifier = ">=1.40" },
     { name = "pydantic", specifier = ">=2.7" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "tenacity", specifier = ">=8.2" },


### PR DESCRIPTION
### 💡 优化背景与痛点
当前的串行翻译流程在翻译长篇小说时速度较慢，主要原因在于：
1. 每批次翻译都强依赖上文的滑动上下文（Rolling Context），导致整个翻译流程完全无法并行。
2. 长上下文使 API 无法有效命中前缀缓存（Prefix Caching），增加了首包延迟与 Token 消耗。

为此，我们重构了翻译引擎，引入了**双阶段编排（Two-Stage Translation）**设计。

### 🛠️ 核心变更
1. **第一阶段：并行起草 (Parallel Drafting)**
   * 在启用润色（`polish: true`）且并发数 > 1 时，开启多线程 `ThreadPoolExecutor` 并发翻译所有未译批次。
   * 并发起草时采用无上下文模式（`context=""`），使静态 Prompt 能够 100% 触发 API 的 Prompt Cache，实现极大吞吐量。
   * 粗译稿暂存于 Segment 的 `meta["draft"]` 中。
   * 若未开启润色（`polish: false`）或单线程运行，则自动退回传统的串行起草模式，确保单阶段质量。
2. **第二阶段：串行精修 (Serial Polishing)**
   * 串行读取粗译稿，并注入微观滑动上下文（默认 6 段），调用 Polisher 润色。
   * 每次调用仅发送微观译文与草稿，**请求 Token 尺寸骤降 80% ~ 95%**，极速响应并理顺人称代词和句意衔接。
3. **断点续跑优化**：
   * 优化了状态重入，如果 `s.target` 被置空但已有 draft，会自动清除 draft 重译；如已有 draft，在第一阶段重入时直接跳过。

### 🧪 测试验证
运行本地测试套件，85 项单元测试已全部通过：
```bash
uv run --with pytest pytest
# 85 passed in 0.41s