### PR TITLE
feat: 支持任意 OpenAI 兼容 LLM API（reasoning_style 方言 + tier extra_body）

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,16 @@ language:
 # ── LLM：DeepSeek 三档（经 OpenAI SDK 调 https://api.deepseek.com）─────────
 # strong/cheap 开 thinking（求质量的判断类任务）；fast 关 thinking（机械任务，
 # thinking 推理 token 按输出计费，关掉大幅省钱提速）。缺档按 fast→cheap→strong 回退。
+#
+# 也支持任意 OpenAI 兼容 API（OpenAI 官方 / OpenRouter / vLLM / Ollama 等）：
+#   provider: openai
+#   base_url: https://openrouter.ai/api/v1
+#   api_key_env: OPENROUTER_API_KEY
+#   reasoning_style: openrouter  # 思考参数方言：auto | deepseek | openrouter | openai | none
+#   tiers 里的 model 换成对应平台的模型 ID（如 anthropic/claude-opus-4.6）；
+#   个别厂商私有参数可在 tier 里用 extra_body 追加（如 {"enable_thinking": true}）。
 llm:
-  provider: deepseek # deepseek | fake（fake 用于离线测试，不发网络请求）
+  provider: deepseek # deepseek | openai | openai-compatible | fake（fake 离线测试）
   base_url: https://api.deepseek.com
   api_key_env: DEEPSEEK_API_KEY # 从该环境变量读取 key
   timeout: 600 # 单次请求超时（秒），思考模式耗时较长

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -66,3 +66,69 @@ class TestFakeClient(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestBuildRequestKwargs(unittest.TestCase):
+    def _cfg(self, **kw):
+        from trans_novel.config import LLMConfig
+        return LLMConfig(**kw)
+
+    def _tier(self, **kw):
+        from trans_novel.config import TierConfig
+        return TierConfig(model="m", **kw)
+
+    def _build(self, cfg, tcfg, **kw):
+        from trans_novel.llm.base import build_request_kwargs
+        return build_request_kwargs(cfg, tcfg, [{"role": "user", "content": "x"}], **kw)
+
+    def test_deepseek_style_unchanged(self):
+        k = self._build(self._cfg(), self._tier(thinking=True, reasoning_effort="high"))
+        self.assertEqual(k["reasoning_effort"], "high")
+        self.assertEqual(k["extra_body"], {"thinking": {"type": "enabled"}})
+
+    def test_openrouter_auto_by_base_url(self):
+        cfg = self._cfg(base_url="https://openrouter.ai/api/v1")
+        k = self._build(cfg, self._tier(thinking=True, reasoning_effort="high"))
+        self.assertNotIn("reasoning_effort", k)
+        self.assertEqual(k["extra_body"], {"reasoning": {"effort": "high"}})
+        k2 = self._build(cfg, self._tier(thinking=False))
+        self.assertEqual(k2["extra_body"], {"reasoning": {"enabled": False}})
+
+    def test_openai_style(self):
+        cfg = self._cfg(provider="openai", base_url="https://api.openai.com/v1")
+        k = self._build(cfg, self._tier(thinking=True, reasoning_effort="low"))
+        self.assertEqual(k["reasoning_effort"], "low")
+        self.assertNotIn("extra_body", k)
+
+    def test_none_style_sends_nothing(self):
+        cfg = self._cfg(provider="openai", reasoning_style="none")
+        k = self._build(cfg, self._tier(thinking=True))
+        self.assertNotIn("reasoning_effort", k)
+        self.assertNotIn("extra_body", k)
+
+    def test_explicit_style_overrides_auto(self):
+        cfg = self._cfg(base_url="https://openrouter.ai/api/v1", reasoning_style="deepseek")
+        k = self._build(cfg, self._tier(thinking=True))
+        self.assertIn("reasoning_effort", k)
+
+    def test_tier_extra_body_merges_and_overrides(self):
+        cfg = self._cfg(provider="openai", reasoning_style="none")
+        t = self._tier(thinking=True, extra_body={"enable_thinking": True})
+        k = self._build(cfg, t)
+        self.assertEqual(k["extra_body"], {"enable_thinking": True})
+
+    def test_max_tokens_floor_with_thinking(self):
+        k = self._build(self._cfg(), self._tier(thinking=True), max_tokens=100)
+        self.assertEqual(k["max_tokens"], 4096)
+        k2 = self._build(self._cfg(), self._tier(thinking=False), max_tokens=100)
+        self.assertEqual(k2["max_tokens"], 100)
+
+    def test_deepseek_client_alias(self):
+        from trans_novel.llm.base import DeepSeekClient, OpenAICompatClient
+        self.assertIs(DeepSeekClient, OpenAICompatClient)
+
+    def test_build_client_accepts_openai_provider(self):
+        from trans_novel.config import Config
+        from trans_novel.llm.base import OpenAICompatClient, build_client
+        cfg = Config.from_dict({"llm": {"provider": "openai", "tiers": {"strong": {"model": "m"}}}})
+        self.assertIsInstance(build_client(cfg), OpenAICompatClient)

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -13,14 +13,19 @@ class TierConfig(BaseModel):
     model: str
     reasoning_effort: str = "high"
     thinking: bool = True
+    # 逃生舱：该档请求 extra_body 追加/覆盖的厂商私有参数（如 {"enable_thinking": true}）
+    extra_body: dict[str, Any] | None = None
 
 
 class LLMConfig(BaseModel):
-    provider: str = "deepseek"
+    provider: str = "deepseek"  # deepseek | openai | openai-compatible | fake
     base_url: str = "https://api.deepseek.com"
     api_key_env: str = "DEEPSEEK_API_KEY"
     timeout: int = 600
     max_retries: int = 4
+    # 思考参数方言：auto | deepseek | openrouter | openai | none
+    # auto：provider=deepseek 走 deepseek；base_url 含 openrouter 走 openrouter；其余 openai
+    reasoning_style: str = "auto"
     tiers: dict[str, TierConfig] = Field(default_factory=dict)
 
     @property
@@ -78,6 +83,7 @@ class Config(BaseModel):
             api_key_env=llm_raw.get("api_key_env", "DEEPSEEK_API_KEY"),
             timeout=llm_raw.get("timeout", 600),
             max_retries=llm_raw.get("max_retries", 4),
+            reasoning_style=llm_raw.get("reasoning_style", "auto"),
             tiers=tiers,
         )
         segment = SegmentConfig.model_validate(raw.get("segment", {}) or {})

--- a/trans_novel/llm/base.py
+++ b/trans_novel/llm/base.py
@@ -7,8 +7,10 @@
   thinking 推理 token 按输出计费，机械任务关掉可大幅省钱提速）。
   缺档时按回退链向"更便宜优先"回退（fast→cheap→strong），老双档配置行为不变。
 - complete() 返回纯文本；complete_json() 强制 JSON 输出并 loose 解析。
-- DeepSeekClient 经由 OpenAI SDK 调 https://api.deepseek.com，openai 惰性导入；
-  未装 openai 时仍可用 FakeClient 跑通离线流程（切分/对齐/术语库/状态机）。
+- OpenAICompatClient 经 OpenAI SDK 调任意 OpenAI 兼容端点（DeepSeek 原生 /
+  OpenAI 官方 / OpenRouter / vLLM 等），思考参数按 reasoning_style 方言生成；
+  DeepSeekClient 保留为向后兼容别名。openai 惰性导入，未装时仍可用 FakeClient
+  跑通离线流程（切分/对齐/术语库/状态机）。
 """
 
 from __future__ import annotations
@@ -103,8 +105,70 @@ class LLMClient(ABC):
         return parse_json_loose(text)
 
 
-# ── DeepSeek（OpenAI SDK 兼容）────────────────────────────────────────────
-class DeepSeekClient(LLMClient):
+# ── OpenAI 兼容客户端（DeepSeek / OpenAI / OpenRouter / vLLM 等）──────────
+def resolve_reasoning_style(cfg: LLMConfig) -> str:
+    """确定思考参数方言。
+
+    显式配置优先；auto 时按现状推断：provider=deepseek 且 base_url 非
+    OpenRouter 走 deepseek 方言（历史行为不变），base_url 含 openrouter
+    走 openrouter 统一参数，其余走 openai 标准参数。
+    """
+    style = (cfg.reasoning_style or "auto").lower()
+    if style != "auto":
+        return style
+    if "openrouter" in (cfg.base_url or ""):
+        return "openrouter"
+    if cfg.provider.lower() == "deepseek":
+        return "deepseek"
+    return "openai"
+
+
+def build_request_kwargs(
+    cfg: LLMConfig,
+    tcfg: TierConfig,
+    messages: Messages,
+    *,
+    json_mode: bool = False,
+    max_tokens: Optional[int] = None,
+) -> dict[str, Any]:
+    """组装 chat.completions.create 参数（纯函数，便于测试）。
+
+    思考参数按方言生成：
+    - deepseek:   reasoning_effort + extra_body.thinking（DeepSeek 原生）
+    - openrouter: extra_body.reasoning.effort / enabled=false（OpenRouter 统一格式，
+                  由其翻译成各家原生参数；免思考档显式关闭防混合推理模型默认开启）
+    - openai:     reasoning_effort（GPT-5 / o 系列官方参数）
+    - none:       不发任何思考参数（vLLM / Ollama 等会拒绝未知参数的端点）
+    tier 配置里的 extra_body 最后浅合并，可覆盖/补充任意厂商私有参数。
+    """
+    kwargs: dict[str, Any] = {
+        "model": tcfg.model,
+        "messages": messages,
+        "stream": False,
+    }
+    style = resolve_reasoning_style(cfg)
+    if tcfg.thinking:
+        if style == "deepseek":
+            kwargs["reasoning_effort"] = tcfg.reasoning_effort
+            kwargs["extra_body"] = {"thinking": {"type": "enabled"}}
+        elif style == "openrouter":
+            kwargs["extra_body"] = {"reasoning": {"effort": tcfg.reasoning_effort}}
+        elif style == "openai":
+            kwargs["reasoning_effort"] = tcfg.reasoning_effort
+    elif style == "openrouter":
+        kwargs["extra_body"] = {"reasoning": {"enabled": False}}
+    if tcfg.extra_body:
+        kwargs["extra_body"] = {**kwargs.get("extra_body", {}), **tcfg.extra_body}
+    if json_mode:
+        kwargs["response_format"] = {"type": "json_object"}
+    if max_tokens:
+        # thinking 模式下 max_tokens 含推理 token（总输出上限）。
+        # 带紧上限的调用若经回退链落到 thinking 档，抬到安全下限防推理被截断。
+        kwargs["max_tokens"] = max(max_tokens, 4096) if tcfg.thinking else max_tokens
+    return kwargs
+
+
+class OpenAICompatClient(LLMClient):
     def __init__(self, cfg: LLMConfig):
         self.cfg = cfg
         if not cfg.tiers:
@@ -127,7 +191,7 @@ class DeepSeekClient(LLMClient):
             api_key = self.cfg.api_key
             if not api_key:
                 raise RuntimeError(
-                    f"未设置环境变量 {self.cfg.api_key_env}（DeepSeek API key）"
+                    f"未设置环境变量 {self.cfg.api_key_env}（LLM API key）"
                 )
             self._client = OpenAI(
                 api_key=api_key,
@@ -146,21 +210,9 @@ class DeepSeekClient(LLMClient):
     ) -> str:
         tcfg = resolve_tier(self.cfg.tiers, tier)
         client = self._ensure_client()
-
-        kwargs: dict[str, Any] = {
-            "model": tcfg.model,
-            "messages": messages,
-            "stream": False,
-        }
-        if tcfg.thinking:
-            kwargs["reasoning_effort"] = tcfg.reasoning_effort
-            kwargs["extra_body"] = {"thinking": {"type": "enabled"}}
-        if json_mode:
-            kwargs["response_format"] = {"type": "json_object"}
-        if max_tokens:
-            # DeepSeek thinking 模式下 max_tokens 含推理 token（总输出上限）。
-            # 带紧上限的调用若经回退链落到 thinking 档，抬到安全下限防推理被截断。
-            kwargs["max_tokens"] = max(max_tokens, 4096) if tcfg.thinking else max_tokens
+        kwargs = build_request_kwargs(
+            self.cfg, tcfg, messages, json_mode=json_mode, max_tokens=max_tokens
+        )
 
         # 网络/限流/超时 → tenacity 指数退避重试（最多 max_retries 次重试）
         @retry(
@@ -203,10 +255,16 @@ class FakeClient(LLMClient):
         return "[]" if json_mode else ""
 
 
+# 向后兼容旧名
+DeepSeekClient = OpenAICompatClient
+
+
 def build_client(config: Config) -> LLMClient:
     provider = config.llm.provider.lower()
-    if provider == "deepseek":
-        return DeepSeekClient(config.llm)
+    if provider in ("deepseek", "openai", "openai-compatible"):
+        return OpenAICompatClient(config.llm)
     if provider == "fake":
         return FakeClient()
-    raise ValueError(f"未知 provider：{provider}（支持 deepseek / fake）")
+    raise ValueError(
+        f"未知 provider：{provider}（支持 deepseek / openai / openai-compatible / fake）"
+    )


### PR DESCRIPTION
现有客户端已经走 OpenAI SDK 且 `base_url` 可配置，接入其它服务的唯一障碍是思考参数写死了 DeepSeek 私有格式（`reasoning_effort` + `extra_body.thinking`）。本 PR 把请求参数组装抽成纯函数 `build_request_kwargs`，按 `reasoning_style` 方言生成思考参数：

| 方言 | 行为 | 适用 |
|---|---|---|
| `deepseek` | 现行为，完全不变 | DeepSeek 原生（默认配置零影响） |
| `openrouter` | 统一 `reasoning` 参数；免思考档显式关闭 | OpenRouter 上任意模型 |
| `openai` | 官方 `reasoning_effort` | GPT-5 / o 系列 |
| `none` | 不发思考参数 | vLLM / Ollama 等严格端点 |

- `reasoning_style` 缺省 `auto`：按 provider / base_url 推断，现有配置行为完全不变，向后兼容。
- tier 级 `extra_body` 逃生舱：任意厂商私有参数一行配置追加（如 Qwen 系 `enable_thinking`），不用等代码适配。
- `provider` 新增 `openai` / `openai-compatible`；`DeepSeekClient` 保留为向后兼容别名。
- config.yaml 内附使用示例注释，换两三行即可用 OpenRouter 上任意模型跑全流程。

**已实测**：用 claude-opus-4.6 / gpt-5.6-sol / gemini-3.1-pro / qwen3.7-max / grok-4.5 / kimi-k2.6 / deepseek-v4-pro 七个模型经 OpenRouter 跑通完整翻译流程（预扫→翻译→润色→审校，英文+日文两部公版作品）。新增单测 9 个，全套通过（94 个）。

Co-Authored-By: Claude <noreply@anthropic.com>
