### PR TITLE
feat: add bilingual source-and-translation output

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -61,3 +61,9 @@ punctuation:
 # ── 路径 ─────────────────────────────────────────────────────────────────
 paths:
   state_dir: state # 运行状态、各章中间产物、术语库
+
+# ── 双语输出 ───────────────────────────────────────────────────────────────
+output:
+  mono: true            # 产出单语中文版
+  bilingual: true       # 产出双语版（原文淡化，与译文对照）
+  bilingual_order: target_first  # target_first=译文在上原文在下; source_first=原文在上

--- a/tests/test_bilingual.py
+++ b/tests/test_bilingual.py
@@ -94,6 +94,75 @@ class TestRenderChapterHtmlBilingual(unittest.TestCase):
         self.assertNotIn("tn-source", html)
         self.assertNotIn("data-tn-id", html)
 
+    def test_list_source_stays_inside_list_item(self):
+        ch = Chapter(
+            index=0,
+            title="列表",
+            href="ch1.xhtml",
+            template=(
+                '<html><body><ul><li data-tn-id="li0">原项目</li></ul></body></html>'
+            ),
+            segments=[
+                Segment(
+                    index=0,
+                    source="原项目",
+                    target="译项目",
+                    kind=KIND_TEXT,
+                    anchor="li0",
+                )
+            ],
+        )
+
+        html = _render_chapter_html(ch, bilingual=True, order="target_first")
+        soup = BeautifulSoup(html, "html.parser")
+        ul = soup.find("ul")
+        self.assertEqual([child.name for child in ul.find_all(recursive=False)], ["li"])
+        li = ul.find("li", recursive=False)
+        source = li.find(class_="tn-source", recursive=False)
+        self.assertEqual(source.name, "div")
+        self.assertEqual(source.get_text(), "原项目")
+        self.assertTrue(li.get_text().startswith("译项目"))
+
+    def test_source_first_list_and_blockquote_stay_in_their_containers(self):
+        ch = Chapter(
+            index=0,
+            title="结构",
+            href="ch1.xhtml",
+            template=(
+                '<html><body><ol><li data-tn-id="li0">原项目</li></ol>'
+                '<blockquote data-tn-id="q0">原引用</blockquote></body></html>'
+            ),
+            segments=[
+                Segment(
+                    index=0,
+                    source="原项目",
+                    target="译项目",
+                    kind=KIND_TEXT,
+                    anchor="li0",
+                ),
+                Segment(
+                    index=1,
+                    source="原引用",
+                    target="译引用",
+                    kind=KIND_TEXT,
+                    anchor="q0",
+                ),
+            ],
+        )
+
+        html = _render_chapter_html(ch, bilingual=True, order="source_first")
+        soup = BeautifulSoup(html, "html.parser")
+        ol = soup.find("ol")
+        self.assertEqual([child.name for child in ol.find_all(recursive=False)], ["li"])
+        li = ol.find("li", recursive=False)
+        quote = soup.find("blockquote")
+        self.assertEqual(li.find(class_="tn-source", recursive=False).get_text(), "原项目")
+        self.assertEqual(
+            quote.find(class_="tn-source", recursive=False).get_text(), "原引用"
+        )
+        self.assertTrue(li.get_text().startswith("原项目"))
+        self.assertTrue(quote.get_text().startswith("原引用"))
+
 
 def _config(state_dir: str, output: dict | None = None):
     raw = {

--- a/tests/test_bilingual.py
+++ b/tests/test_bilingual.py
@@ -1,0 +1,325 @@
+"""双语输出（原文淡化 + 译文对照）的测试（离线）。"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+from typer.testing import CliRunner
+
+from trans_novel.cli import app
+from trans_novel.config import Config
+from trans_novel.llm.base import FakeClient
+from trans_novel.pipeline.orchestrator import Orchestrator
+from trans_novel.assemble.writer import (
+    _default_out,
+    _render_chapter_html,
+    assemble,
+)
+from trans_novel.ingest.models import KIND_HEADING, KIND_TEXT, Chapter, Segment
+from tests.sample_data import write_sample_epub, write_sample_txt
+from tests.fake_llm import routing_handler
+
+
+def _chapter_with_template() -> Chapter:
+    """构造一个带模板锚点的章节：标题 + 三个正文段（正常/译文缺失/译文等于原文）。"""
+    template = (
+        "<html><body>"
+        '<h1 data-tn-id="h0">原标题</h1>'
+        '<p data-tn-id="p1">原文一</p>'
+        '<p data-tn-id="p2">原文二</p>'
+        '<p data-tn-id="p3">原文三</p>'
+        "</body></html>"
+    )
+    segments = [
+        Segment(
+            index=0, source="原标题", kind=KIND_HEADING, target="译标题", anchor="h0"
+        ),
+        Segment(index=1, source="原文一", kind=KIND_TEXT, target="译文一", anchor="p1"),
+        Segment(index=2, source="原文二", kind=KIND_TEXT, target=None, anchor="p2"),
+        Segment(index=3, source="原文三", kind=KIND_TEXT, target="原文三", anchor="p3"),
+    ]
+    return Chapter(
+        index=0, title="标题", segments=segments, template=template, href="ch1.xhtml"
+    )
+
+
+class TestRenderChapterHtmlBilingual(unittest.TestCase):
+    def test_bilingual_target_first_inserts_source_and_skips_dedup_cases(self):
+        ch = _chapter_with_template()
+        html = _render_chapter_html(ch, bilingual=True, order="target_first")
+
+        self.assertNotIn("data-tn-id", html)  # 占位标记已清
+
+        soup = BeautifulSoup(html, "html.parser")
+        h1 = soup.find("h1")
+        self.assertEqual(h1.get_text(), "译标题")
+        # 标题不应带 tn-source（紧邻的下一个兄弟是 p1 的译文，不是 tn-source 段）
+        nxt = h1.find_next_sibling()
+        self.assertEqual(nxt.name, "p")
+        self.assertNotIn("tn-source", nxt.get("class", []))
+
+        ps = soup.find_all("p")
+        self.assertEqual(
+            [p.get_text() for p in ps], ["译文一", "原文一", "原文二", "原文三"]
+        )
+        self.assertEqual(ps[0].get("class"), None)
+        self.assertEqual(
+            ps[1]["class"], ["tn-source", "ibooks-dark-theme-use-custom-text-color"]
+        )
+        # p2（译文缺失回退原文）、p3（译文等于原文）都不应插入 tn-source 段
+        self.assertEqual(ps[2].get("class"), None)
+        self.assertEqual(ps[3].get("class"), None)
+
+    def test_order_source_first_places_source_before_target(self):
+        ch = _chapter_with_template()
+        html = _render_chapter_html(ch, bilingual=True, order="source_first")
+        soup = BeautifulSoup(html, "html.parser")
+        ps = soup.find_all("p")
+        self.assertEqual(
+            [p.get_text() for p in ps], ["原文一", "译文一", "原文二", "原文三"]
+        )
+        self.assertEqual(
+            ps[0]["class"], ["tn-source", "ibooks-dark-theme-use-custom-text-color"]
+        )
+        self.assertEqual(ps[1].get("class"), None)
+
+    def test_mono_render_has_no_source_paragraphs(self):
+        ch = _chapter_with_template()
+        html = _render_chapter_html(ch)  # 默认单语，不应引入 tn-source
+        self.assertNotIn("tn-source", html)
+        self.assertNotIn("data-tn-id", html)
+
+
+def _config(state_dir: str, output: dict | None = None):
+    raw = {
+        "language": {"source": "ja", "target": "zh"},
+        "llm": {
+            "provider": "fake",
+            "tiers": {"strong": {"model": "p"}, "cheap": {"model": "f"}},
+        },
+        "pipeline": {
+            "review": True,
+            "polish": False,
+            "backtranslate_sample": 0.0,
+            "consistency_qa": False,
+        },
+        "paths": {"state_dir": state_dir},
+    }
+    if output is not None:
+        raw["output"] = output
+    return Config.from_dict(raw)
+
+
+def _run(input_path, state_dir, output=None):
+    cfg = _config(state_dir, output)
+    orch = Orchestrator(cfg, client=FakeClient(handler=routing_handler))
+    return orch.run(input_path), cfg
+
+
+class TestBuildEpubFromChaptersBilingual(unittest.TestCase):
+    def test_bilingual_epub_has_source_paragraphs_and_style(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            store, _ = _run(txt, os.path.join(d, "state"))
+            out = assemble(store, txt, out_format="epub", bilingual=True)
+            self.assertTrue(zipfile.is_zipfile(out))
+            with zipfile.ZipFile(out) as z:
+                xhtml_names = [
+                    n
+                    for n in z.namelist()
+                    if n.endswith(".xhtml") and n.startswith("EPUB/")
+                ]
+                self.assertTrue(xhtml_names)
+                bodies = {n: z.read(n).decode("utf-8") for n in xhtml_names}
+            all_html = "\n".join(bodies.values())
+            self.assertIn("tn-source", all_html)
+            self.assertIn("译0", all_html)  # 译文仍在（fake 翻译器返回 译N）
+            some_head_has_style = any(
+                "tn-bilingual-style" in html
+                and "@media (prefers-color-scheme: dark)" in html
+                and ".tn-source" in html
+                for html in bodies.values()
+            )
+            self.assertTrue(some_head_has_style)
+
+
+class TestAssembleTextBilingual(unittest.TestCase):
+    def test_bilingual_txt_contains_target_and_source_target_first(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            store, _ = _run(txt, os.path.join(d, "state"))
+            out = assemble(
+                store, txt, out_format="txt", bilingual=True, order="target_first"
+            )
+            with open(out, encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("译1", content)  # 译文（段落1，段落0是标题）
+            self.assertIn("綾小路は教室の窓際に座っていた", content)  # 原文
+            tgt_pos = content.index("译1")
+            src_pos = content.index("綾小路は教室の窓際に座っていた")
+            self.assertLess(tgt_pos, src_pos)  # target_first：译文先于原文
+
+    def test_bilingual_txt_source_first_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            store, _ = _run(txt, os.path.join(d, "state"))
+            out = assemble(
+                store, txt, out_format="txt", bilingual=True, order="source_first"
+            )
+            with open(out, encoding="utf-8") as f:
+                content = f.read()
+            tgt_pos = content.index("译1")
+            src_pos = content.index("綾小路は教室の窓際に座っていた")
+            self.assertLess(src_pos, tgt_pos)  # source_first：原文先于译文
+
+    def test_mono_txt_has_no_source_text(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            store, _ = _run(txt, os.path.join(d, "state"))
+            out = assemble(store, txt, out_format="txt")  # 默认单语
+            with open(out, encoding="utf-8") as f:
+                content = f.read()
+            self.assertNotIn("綾小路は教室の窓際に座っていた", content)
+
+
+class TestDefaultOutBilingual(unittest.TestCase):
+    def test_bilingual_suffix(self):
+        out = _default_out("/tmp/novel.txt", "epub", "", bilingual=True)
+        self.assertEqual(os.path.basename(out), "novel.zh-bi.epub")
+        self.assertEqual(os.path.dirname(out), "/tmp/output")
+
+    def test_mono_suffix_unchanged(self):
+        out = _default_out("/tmp/novel.txt", "epub", "")
+        self.assertEqual(os.path.basename(out), "novel.zh.epub")
+        self.assertEqual(os.path.dirname(out), "/tmp/output")
+
+
+class TestOutputConfigParsing(unittest.TestCase):
+    def test_defaults(self):
+        cfg = Config.from_dict({})
+        self.assertTrue(cfg.output.mono)
+        self.assertTrue(cfg.output.bilingual)
+        self.assertEqual(cfg.output.bilingual_order, "target_first")
+
+    def test_bilingual_off_keeps_mono_default(self):
+        cfg = Config.from_dict({"output": {"bilingual": False}})
+        self.assertFalse(cfg.output.bilingual)
+        self.assertIs(cfg.output.mono, True)
+
+
+class TestOrchestratorMultiOutput(unittest.TestCase):
+    def test_default_config_produces_mono_and_bilingual(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(
+                os.path.join(d, "state")
+            )  # 不传 output -> 默认 mono+bilingual 都开
+            orch = Orchestrator(cfg, client=FakeClient(handler=routing_handler))
+            result = orch.run_all(txt, out_format="epub")
+            outputs = result["outputs"]
+            self.assertEqual(len(outputs), 2)
+            basenames = sorted(os.path.basename(p) for p in outputs)
+            self.assertEqual(basenames, ["novel.zh-bi.epub", "novel.zh.epub"])
+            for p in outputs:
+                self.assertTrue(os.path.isfile(p))
+            self.assertEqual(result["output"], outputs[0])
+
+    def test_bilingual_off_produces_single_mono_output(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(os.path.join(d, "state"), output={"bilingual": False})
+            orch = Orchestrator(cfg, client=FakeClient(handler=routing_handler))
+            result = orch.run_all(txt, out_format="epub")
+            outputs = result["outputs"]
+            self.assertEqual(len(outputs), 1)
+            self.assertEqual(os.path.basename(outputs[0]), "novel.zh.epub")
+
+
+class TestAssembleEpubTemplateBilingual(unittest.TestCase):
+    def test_epub_template_rebuild_bilingual(self):
+        with tempfile.TemporaryDirectory() as d:
+            ep = os.path.join(d, "novel.epub")
+            write_sample_epub(ep)
+            store, _ = _run(ep, os.path.join(d, "state"))
+            out = assemble(store, ep, out_format="epub", bilingual=True)
+            self.assertEqual(os.path.basename(out), "novel.zh-bi.epub")
+            with zipfile.ZipFile(out) as z:
+                html = z.read("OEBPS/ch1.xhtml").decode("utf-8")
+            self.assertNotIn("data-tn-id", html)  # 占位标记已清除
+            self.assertIn("tn-source", html)  # 原文淡化块已插入
+            self.assertIn("tn-bilingual-style", html)  # 双语样式已注入
+            self.assertIn("綾小路は教室の窓際に座っていた", html)  # 原文仍保留
+
+
+class TestCliBilingualFlags(unittest.TestCase):
+    def test_translate_flags_override_output_config(self):
+        cfg = Config.from_dict(
+            {
+                "llm": {"provider": "fake", "tiers": {"strong": {"model": "p"}}},
+            }
+        )
+        captured = {}
+
+        class FakeOrchestrator:
+            def __init__(self, config):
+                captured["mono"] = config.output.mono
+                captured["bilingual"] = config.output.bilingual
+
+            def run_all(self, input_path, **kwargs):
+                return {
+                    "report": {
+                        "summary": {"chapters_done": 1, "chapters_total": 1, "terms": 0}
+                    },
+                    "qa_issues": [],
+                    "output": "novel.zh.epub",
+                    "outputs": ["novel.zh.epub", "novel.zh-bi.epub"],
+                }
+
+        with (
+            patch("trans_novel.cli._load_config", return_value=cfg),
+            patch("trans_novel.pipeline.orchestrator.Orchestrator", FakeOrchestrator),
+            patch("trans_novel.cli.os.path.isfile", return_value=True),
+        ):
+            result = CliRunner().invoke(
+                app, ["translate", "input.txt", "--no-mono", "--bilingual"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        flat = result.output.replace("\n", "")
+        self.assertFalse(captured["mono"])
+        self.assertTrue(captured["bilingual"])
+        self.assertIn("novel.zh.epub", flat)
+        self.assertIn("novel.zh-bi.epub", flat)
+
+    def test_tools_assemble_produces_mono_and_bilingual_outputs(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            state_dir = os.path.join(d, "state")
+            _, cfg = _run(txt, state_dir)
+            with patch("trans_novel.cli._load_config", return_value=cfg):
+                result = CliRunner().invoke(
+                    app, ["tools", "assemble", txt, "--mono", "--bilingual"]
+                )
+            self.assertEqual(result.exit_code, 0, result.output)
+            flat = result.output.replace("\n", "")
+            self.assertIn("novel.zh.epub", flat)
+            self.assertIn("novel.zh-bi.epub", flat)
+            output_dir = os.path.join(d, "output")
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "novel.zh.epub")))
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "novel.zh-bi.epub")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -185,10 +185,18 @@ def _render_chapter_html(
         src = _bilingual_source(src_by_anchor.get(anchor, ""), text)
         if not src:
             continue
-        src_el = soup.new_tag("p")
+        # p 的原文可作为相邻段落插入；li/blockquote 则必须留在原容器内，
+        # 避免生成 <ul><li>...</li><p>...</p></ul> 之类的非法列表结构，
+        # 同时保留引用块的语义和样式。
+        nested_source = el.name in {"li", "blockquote"}
+        src_el = soup.new_tag("div" if nested_source else "p")
         src_el["class"] = ["tn-source", "ibooks-dark-theme-use-custom-text-color"]
         src_el.append(src)
-        if order == "source_first":
+        if nested_source and order == "source_first":
+            el.insert(0, src_el)
+        elif nested_source:
+            el.append(src_el)
+        elif order == "source_first":
             el.insert_before(src_el)
         else:
             el.insert_after(src_el)

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -25,6 +25,25 @@ _VERTICAL_MARKERS = (
     re.compile(rb"\bclass\s*=\s*['\"][^'\"]*\bvrtl\b", re.I),
 )
 _HORIZONTAL_OVERRIDE_ID = "trans-novel-horizontal-override"
+_BILINGUAL_STYLE_ID = "tn-bilingual-style"
+_BILINGUAL_CSS = """\
+.tn-source {
+  font-size: 0.88em;
+  line-height: 1.55;
+  color: #6b6b6b;
+  background-color: #f4f3f0;
+  padding: 0.5em 0.8em;
+  border-radius: 5px;
+  margin: 0.2em 0 1em;
+}
+@media (prefers-color-scheme: dark) {
+  .tn-source {
+    color: #a8a8a8;
+    background-color: #2a2a2a;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.14);
+  }
+}
+"""
 
 
 def _sanitize_filename(name: str, fallback: str = "translated") -> str:
@@ -33,7 +52,13 @@ def _sanitize_filename(name: str, fallback: str = "translated") -> str:
     return name[:120] or fallback
 
 
-def _default_out(source_path: str, out_format: str, title: str | None = None) -> str:
+def _default_out(
+    source_path: str,
+    out_format: str,
+    title: str | None = None,
+    *,
+    bilingual: bool = False,
+) -> str:
     """Return the default export path under the input file's ``output`` folder."""
     ext = ".epub" if out_format == "epub" else ".txt"
     output_dir = os.path.join(os.path.dirname(os.path.abspath(source_path)), "output")
@@ -42,10 +67,17 @@ def _default_out(source_path: str, out_format: str, title: str | None = None) ->
         # 保留给显式调用方使用；默认 assemble 不传书名译名。
         return os.path.join(output_dir, _sanitize_filename(title) + ext)
     base, _ = os.path.splitext(source_path)
+    suffix = ".zh-bi" if bilingual else ".zh"
     return os.path.join(
         output_dir,
-        f"{os.path.basename(base)}.zh{ext}",
+        f"{os.path.basename(base)}{suffix}{ext}",
     )
+
+
+def bilingual_out_path(out_path: str) -> str:
+    """调用方显式指定了 out_path 时，派生双语版路径：stem 追加 -bi。"""
+    base, ext = os.path.splitext(out_path)
+    return f"{base}-bi{ext}"
 
 
 def _ch_title(c: dict) -> str:
@@ -65,46 +97,82 @@ def _epub_lang(lang: str | None) -> str:
     return lang or "zh-Hans"
 
 
-def _merged_paragraphs(chapter: Chapter) -> list[tuple[str, str]]:
-    """把章内 Segment 合并为段落，cont 续段并回上一段。返回 [(kind, text), ...]。"""
-    paras: list[list[str]] = []      # 每段累积的文本片段
+def _merged_paragraphs(chapter: Chapter) -> list[tuple[str, str, str]]:
+    """把章内 Segment 合并为段落，cont 续段并回上一段。返回 [(kind, target, source), ...]。"""
+    paras: list[list[str]] = []  # 每段累积的译文片段
+    srcs: list[list[str]] = []  # 每段累积的原文片段
     kinds: list[str] = []
     for s in chapter.segments:
         if not s.source.strip():
             continue
         if s.cont and paras:
             paras[-1].append(_seg_text(s))
+            srcs[-1].append(s.source)
         else:
             paras.append([_seg_text(s)])
+            srcs.append([s.source])
             kinds.append(s.kind)
-    return [(k, "".join(p)) for k, p in zip(kinds, paras)]
+    return [(k, "".join(p), "".join(sr)) for k, p, sr in zip(kinds, paras, srcs)]
+
+
+def _bilingual_source(source: str, target: str) -> str:
+    """双语原文去重：原文为空白，或与译文相同（翻译回退到原文）时不输出原文。"""
+    return source if (source.strip() and source != target) else ""
 
 
 # ── 纯文本 ──────────────────────────────────────────────────────────────────
-def _assemble_text(store: RunStore, out_path: str) -> str:
+def _assemble_text(
+    store: RunStore,
+    out_path: str,
+    *,
+    bilingual: bool = False,
+    order: str = "target_first",
+) -> str:
     m = store.load_manifest()
     chapter_blocks: list[str] = []
     for c in m["chapters"]:
         ch = store.load_chapter(c["index"])
-        paras = [text for _, text in _merged_paragraphs(ch)]
-        chapter_blocks.append("\n\n".join(paras))
+        blocks: list[str] = []
+        for kind, target, source in _merged_paragraphs(ch):
+            src = (
+                _bilingual_source(source, target)
+                if (bilingual and kind != KIND_HEADING)
+                else ""
+            )
+            if not src:
+                blocks.append(target)
+            elif order == "source_first":
+                blocks.extend((src, target))
+            else:
+                blocks.extend((target, src))
+        chapter_blocks.append("\n\n".join(blocks))
     with open(out_path, "w", encoding="utf-8") as f:
         f.write("\n\n".join(chapter_blocks) + "\n")
     return out_path
 
 
 # ── EPUB ────────────────────────────────────────────────────────────────────
-def _render_chapter_html(chapter: Chapter) -> str:
+def _render_chapter_html(
+    chapter: Chapter,
+    *,
+    bilingual: bool = False,
+    order: str = "target_first",
+) -> str:
     soup = BeautifulSoup(chapter.template or "", "html.parser")
     # 合并 cont 续段：续段文本并回其所属 anchor 元素
     by_anchor: dict[str, str] = {}
+    src_by_anchor: dict[str, str] = {}
+    kind_by_anchor: dict[str, str] = {}
     cur_anchor: str | None = None
     for s in chapter.segments:
         if s.cont and cur_anchor is not None:
             by_anchor[cur_anchor] += _seg_text(s)
+            src_by_anchor[cur_anchor] += s.source
         elif s.anchor:
             cur_anchor = s.anchor
             by_anchor[cur_anchor] = _seg_text(s)
+            src_by_anchor[cur_anchor] = s.source
+            kind_by_anchor[cur_anchor] = s.kind
     for anchor, text in by_anchor.items():
         el = soup.find(True, attrs={"data-tn-id": anchor})
         if el is None:
@@ -112,6 +180,18 @@ def _render_chapter_html(chapter: Chapter) -> str:
         el.clear()
         el.append(text)
         del el["data-tn-id"]
+        if not bilingual or kind_by_anchor.get(anchor) == KIND_HEADING:
+            continue
+        src = _bilingual_source(src_by_anchor.get(anchor, ""), text)
+        if not src:
+            continue
+        src_el = soup.new_tag("p")
+        src_el["class"] = ["tn-source", "ibooks-dark-theme-use-custom-text-color"]
+        src_el.append(src)
+        if order == "source_first":
+            el.insert_before(src_el)
+        else:
+            el.insert_after(src_el)
     return str(soup)
 
 
@@ -174,8 +254,14 @@ def _epub_looks_vertical(zf: zipfile.ZipFile) -> bool:
     return False
 
 
-def _rewrite_html_document(data: bytes | str, *, lang: str, force_horizontal: bool) -> bytes:
-    """给 XHTML/HTML 写入译后语言；必要时注入横排覆盖样式。"""
+def _rewrite_html_document(
+    data: bytes | str,
+    *,
+    lang: str,
+    force_horizontal: bool,
+    bilingual: bool = False,
+) -> bytes:
+    """给 XHTML/HTML 写入译后语言；必要时注入横排覆盖样式/双语原文样式。"""
     try:
         text = data.decode("utf-8") if isinstance(data, bytes) else data
         soup = BeautifulSoup(text, "html.parser")
@@ -209,6 +295,15 @@ def _rewrite_html_document(data: bytes | str, *, lang: str, force_horizontal: bo
                 "direction: ltr !important; "
                 "}"
             )
+            head.append(style)
+
+        if bilingual and soup.find(id=_BILINGUAL_STYLE_ID) is None:
+            head = soup.find("head")
+            if head is None:
+                head = soup.new_tag("head")
+                html.insert(0, head)
+            style = soup.new_tag("style", id=_BILINGUAL_STYLE_ID)
+            style.string = _BILINGUAL_CSS
             head.append(style)
         return str(soup).encode("utf-8")
     except Exception:
@@ -247,7 +342,14 @@ def _rewrite_toc(data: bytes, title_by_base: dict[str, str], *, is_ncx: bool) ->
         return data
 
 
-def _assemble_epub(store: RunStore, source_path: str, out_path: str) -> str:
+def _assemble_epub(
+    store: RunStore,
+    source_path: str,
+    out_path: str,
+    *,
+    bilingual: bool = False,
+    order: str = "target_first",
+) -> str:
     m = store.load_manifest()
     target_lang = _epub_lang(m.get("target_lang", "zh"))
     # href -> 渲染后的 XHTML
@@ -255,7 +357,9 @@ def _assemble_epub(store: RunStore, source_path: str, out_path: str) -> str:
     for c in m["chapters"]:
         ch = store.load_chapter(c["index"])
         if ch.href and ch.template:
-            rendered[ch.href] = _render_chapter_html(ch)
+            rendered[ch.href] = _render_chapter_html(
+                ch, bilingual=bilingual, order=order
+            )
 
     # 目录标题映射（文件名 → 译名）；书名保持原文，不改 OPF 主标题。
     title_by_base: dict[str, str] = {}
@@ -294,6 +398,7 @@ def _assemble_epub(store: RunStore, source_path: str, out_path: str) -> str:
                             rendered[name],
                             lang=target_lang,
                             force_horizontal=force_horizontal,
+                            bilingual=bilingual,
                         ),
                     )
                 elif name == "mimetype":
@@ -319,6 +424,7 @@ def _assemble_epub(store: RunStore, source_path: str, out_path: str) -> str:
                             data,
                             lang=target_lang,
                             force_horizontal=force_horizontal,
+                            bilingual=bilingual,
                         ),
                     )
                 else:
@@ -330,7 +436,36 @@ def _is_nav(data: bytes) -> bool:
     return b"epub:type" in data and b"toc" in data
 
 
-def _build_epub_from_chapters(store: RunStore, out_path: str) -> str:
+def _inject_bilingual_style(
+    out_path: str, chapter_filenames: set[str], lang: str
+) -> None:
+    """ebooklib 写盘时按模板重建每章 <head>，内联样式会被丢弃；这里对写好的 zip
+    做一次后处理，把双语样式补回各章节 head（复用 _rewrite_html_document）。"""
+    with zipfile.ZipFile(out_path, "r") as zin:
+        infos = zin.infolist()
+        entries = {info.filename: zin.read(info.filename) for info in infos}
+    tmp_path = out_path + ".tmp"
+    with zipfile.ZipFile(tmp_path, "w") as zout:
+        for info in infos:
+            data = entries[info.filename]
+            if os.path.basename(info.filename) in chapter_filenames:
+                data = _rewrite_html_document(
+                    data,
+                    lang=lang,
+                    force_horizontal=False,
+                    bilingual=True,
+                )
+            zout.writestr(info, data)
+    os.replace(tmp_path, out_path)
+
+
+def _build_epub_from_chapters(
+    store: RunStore,
+    out_path: str,
+    *,
+    bilingual: bool = False,
+    order: str = "target_first",
+) -> str:
     """从章节数据生成一个规范的 EPUB3（用于纯文本输入），使用 ebooklib。"""
     from html import escape
 
@@ -347,14 +482,32 @@ def _build_epub_from_chapters(store: RunStore, out_path: str) -> str:
 
     spine: list = ["nav"]
     toc: list = []
+    chapter_filenames: set[str] = set()
     for c in m["chapters"]:
         ch = store.load_chapter(c["index"])
         ch_title = _ch_title(c) or ch.title
         body_parts = []
-        for kind, text in _merged_paragraphs(ch):
+        for kind, target, source in _merged_paragraphs(ch):
             tag = "h1" if kind == KIND_HEADING else "p"
-            body_parts.append(f"<{tag}>{escape(text)}</{tag}>")
+            target_html = f"<{tag}>{escape(target)}</{tag}>"
+            src = (
+                _bilingual_source(source, target)
+                if (bilingual and kind != KIND_HEADING)
+                else ""
+            )
+            if not src:
+                body_parts.append(target_html)
+                continue
+            src_html = (
+                '<p class="tn-source ibooks-dark-theme-use-custom-text-color">'
+                f"{escape(src)}</p>"
+            )
+            if order == "source_first":
+                body_parts.extend((src_html, target_html))
+            else:
+                body_parts.extend((target_html, src_html))
         fname = f"ch{c['index']}.xhtml"
+        chapter_filenames.add(fname)
         item = epub.EpubHtml(title=ch_title, file_name=fname, lang=lang)
         item.content = (
             f'<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{lang}">'
@@ -370,6 +523,8 @@ def _build_epub_from_chapters(store: RunStore, out_path: str) -> str:
     book.add_item(epub.EpubNav())
     book.spine = spine
     epub.write_epub(out_path, book)
+    if bilingual:
+        _inject_bilingual_style(out_path, chapter_filenames, lang)
     return out_path
 
 
@@ -378,6 +533,9 @@ def assemble(
     source_path: str,
     out_path: str | None = None,
     out_format: str = "epub",
+    *,
+    bilingual: bool = False,
+    order: str = "target_first",
 ) -> str:
     """生成译文文件（默认 EPUB）。
 
@@ -385,13 +543,17 @@ def assemble(
       - 原文是 EPUB → 按原模板回填，保留排版/资源；
       - 原文是纯文本 → 生成一个规范的 EPUB（标题 h1 + 段落 p）。
     out_format="txt"：无论原文格式，按章重建为纯文本。
+    bilingual=True 时额外输出原文（淡背景块），order 控制译文/原文先后。
     """
     m = store.load_manifest()
     if out_format == "txt":
-        return _assemble_text(store, out_path or _default_out(source_path, "txt", ""))
+        out_path = out_path or _default_out(source_path, "txt", "", bilingual=bilingual)
+        return _assemble_text(store, out_path, bilingual=bilingual, order=order)
     # epub
-    out_path = out_path or _default_out(source_path, "epub", "")
+    out_path = out_path or _default_out(source_path, "epub", "", bilingual=bilingual)
     if m["fmt"] == "epub":
-        return _assemble_epub(store, source_path, out_path)
+        return _assemble_epub(
+            store, source_path, out_path, bilingual=bilingual, order=order
+        )
     # fb2 / text → 从章节数据生成规范 EPUB
-    return _build_epub_from_chapters(store, out_path)
+    return _build_epub_from_chapters(store, out_path, bilingual=bilingual, order=order)

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -91,6 +91,8 @@ def _translate_impl(
     out: Optional[str] = None,
     polish: Optional[bool] = None,
     qa: Optional[bool] = None,
+    mono: Optional[bool] = None,
+    bilingual: Optional[bool] = None,
 ) -> None:
     """translate/resume 共享实现，避免 CLI 参数转发漂移。"""
     from .pipeline.orchestrator import Orchestrator
@@ -99,6 +101,10 @@ def _translate_impl(
     config = _load_config()
     if polish is not None:
         config.pipeline.polish = polish
+    if mono is not None:
+        config.output.mono = mono
+    if bilingual is not None:
+        config.output.bilingual = bilingual
     orch = Orchestrator(config)
 
     with Progress(
@@ -133,7 +139,8 @@ def _translate_impl(
         f"[bold green]完成[/]：{s['chapters_done']}/{s['chapters_total']} 章，"
         f"术语 {s['terms']}，一致性问题 {len(result['qa_issues'])} 项。"
     )
-    console.print(f"译文：[bold]{result['output']}[/]")
+    for path in result.get("outputs") or [result["output"]]:
+        console.print(f"译文：[bold]{path}[/]")
 
 
 # ── translate / resume：连续全流程 ──────────────────────────────────────────
@@ -157,9 +164,28 @@ def translate(
         "--qa/--no-qa",
         help="覆盖配置文件中的一致性 QA 开关",
     ),
+    mono: Optional[bool] = typer.Option(
+        None,
+        "--mono/--no-mono",
+        help="覆盖配置文件中的单语版产出开关",
+    ),
+    bilingual: Optional[bool] = typer.Option(
+        None,
+        "--bilingual/--no-bilingual",
+        help="覆盖配置文件中的双语版产出开关",
+    ),
 ):
     """翻译（连续全流程；可断点续跑）。"""
-    _translate_impl(input, chapter=chapter, fmt=fmt, out=out, polish=polish, qa=qa)
+    _translate_impl(
+        input,
+        chapter=chapter,
+        fmt=fmt,
+        out=out,
+        polish=polish,
+        qa=qa,
+        mono=mono,
+        bilingual=bilingual,
+    )
 
 
 @app.command()
@@ -261,17 +287,49 @@ def assemble(
     input: str = typer.Argument(..., help="输入文件"),
     out: Optional[str] = typer.Option(None, "--out"),
     fmt: str = typer.Option("epub", "--format", help="epub | txt"),
+    mono: Optional[bool] = typer.Option(
+        None,
+        "--mono/--no-mono",
+        help="覆盖配置文件中的单语版产出开关",
+    ),
+    bilingual: Optional[bool] = typer.Option(
+        None,
+        "--bilingual/--no-bilingual",
+        help="覆盖配置文件中的双语版产出开关",
+    ),
 ):
     """回填生成译文文件（默认 EPUB）。"""
     from .assemble.writer import assemble as do_assemble
+    from .assemble.writer import bilingual_out_path
 
     config = _load_config()
     store = _runstore_for(config, input)
     if not store.exists():
         console.print("[yellow]尚无进度。先运行 translate。[/]")
         raise typer.Exit(1)
-    path = do_assemble(store, input, out_path=out, out_format=fmt)
-    console.print(f"已生成译文：[bold]{path}[/]")
+    do_mono = config.output.mono if mono is None else mono
+    do_bilingual = config.output.bilingual if bilingual is None else bilingual
+    if not do_mono and not do_bilingual:
+        do_mono = True  # 兜底：至少产一个单语产物
+    paths: list[str] = []
+    if do_mono:
+        paths.append(
+            do_assemble(store, input, out_path=out, out_format=fmt, bilingual=False)
+        )
+    if do_bilingual:
+        bi_out = bilingual_out_path(out) if out else None
+        paths.append(
+            do_assemble(
+                store,
+                input,
+                out_path=bi_out,
+                out_format=fmt,
+                bilingual=True,
+                order=config.output.bilingual_order,
+            )
+        )
+    for path in paths:
+        console.print(f"已生成译文：[bold]{path}[/]")
 
 
 @tools_app.command()

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -114,12 +114,21 @@ class PipelineConfig(BaseModel):
     glossary_scope: str = "chapter"  # chapter=只注入本章出现的词条+锁定人物（省 token）；full=全量表
 
 
+class OutputConfig(BaseModel):
+    mono: bool = True  # 产出单语版
+    bilingual: bool = True  # 产出双语版
+    bilingual_order: str = (
+        "target_first"  # target_first=译文在上原文在下(默认); source_first=原文在上
+    )
+
+
 class Config(BaseModel):
     source_lang: str = "auto"        # auto | ja | en | …（auto 时由模型检测）
     target_lang: str = "zh"
     llm: LLMConfig = Field(default_factory=LLMConfig)
     segment: SegmentConfig = Field(default_factory=SegmentConfig)
     pipeline: PipelineConfig = Field(default_factory=PipelineConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
     honorific_strategy: str = "keep_style"
     punctuation_normalize: bool = True  # 译文标点规范化为简体中文通用
     state_dir: str = "state"
@@ -161,6 +170,7 @@ class Config(BaseModel):
         )
         segment = SegmentConfig.model_validate(raw.get("segment", {}) or {})
         pipeline = PipelineConfig.model_validate(raw.get("pipeline", {}) or {})
+        output = OutputConfig.model_validate(raw.get("output", {}) or {})
         punct = raw.get("punctuation", {}) or {}
         return cls(
             source_lang=lang.get("source", "auto"),
@@ -168,6 +178,7 @@ class Config(BaseModel):
             llm=llm,
             segment=segment,
             pipeline=pipeline,
+            output=output,
             honorific_strategy=raw.get("honorific", {}).get("strategy", "keep_style"),
             punctuation_normalize=bool(punct.get("normalize", True)),
             state_dir=raw.get("paths", {}).get("state_dir", "state"),

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -684,7 +684,7 @@ class Orchestrator:
                   out_format: str = "epub", out_path: str | None = None) -> dict[str, Any]:
         """按需执行步骤子集（可单选可全选）。steps ⊆ ALL_STEPS。"""
         from ..agents.consistency import ConsistencyChecker
-        from ..assemble.writer import assemble
+        from ..assemble.writer import assemble, bilingual_out_path
         from ..assemble.report import build_report
 
         steps = set(steps)
@@ -718,19 +718,49 @@ class Orchestrator:
         finally:
             glossary.close()
 
-        out = None
+        outputs: list[str] = []
         if "assemble" in steps:
-            out = assemble(store, input_path, out_path=out_path, out_format=out_format)
-            store.log_event("assembled", output=out, out_format=out_format)
+            out_cfg = self.config.output
+            do_mono, do_bilingual = out_cfg.mono, out_cfg.bilingual
+            if not do_mono and not do_bilingual:
+                do_mono = True  # 兜底：mono/bilingual 都关时至少产一个单语产物
+            if do_mono:
+                outputs.append(
+                    assemble(
+                        store,
+                        input_path,
+                        out_path=out_path,
+                        out_format=out_format,
+                        bilingual=False,
+                    )
+                )
+            if do_bilingual:
+                bi_out_path = bilingual_out_path(out_path) if out_path else None
+                outputs.append(
+                    assemble(
+                        store,
+                        input_path,
+                        out_path=bi_out_path,
+                        out_format=out_format,
+                        bilingual=True,
+                        order=out_cfg.bilingual_order,
+                    )
+                )
+            store.log_event("assembled", outputs=outputs, out_format=out_format)
 
         store.log_event(
             "run_steps_finished",
             steps=run_steps_input,
-            output=out,
+            outputs=outputs,
             qa_issue_count=len(qa_issues),
         )
-        return {"store": store, "output": out, "report": report,
-                "qa_issues": qa_issues}
+        return {
+            "store": store,
+            "output": outputs[0] if outputs else None,
+            "outputs": outputs,
+            "report": report,
+            "qa_issues": qa_issues,
+        }
 
     def run_all(self, input_path: str, *, progress: Optional[ProgressFn] = None,
                 out_format: str = "epub", out_path: str | None = None,


### PR DESCRIPTION
Proofreading a translation is easier with the source alongside it, so besides the mono Chinese edition the assembler can now emit a bilingual edition that shows the dimmed source under each translated paragraph.

Controlled by output.mono / output.bilingual / output.bilingual_order in config.yaml and the --mono/--bilingual CLI flags; both EPUB and plain text are covered. Bilingual files use the .zh-bi suffix.