### PR TITLE
fix: reject identical source and target languages

### DIFF
--- a/tests/test_newfeatures.py
+++ b/tests/test_newfeatures.py
@@ -56,6 +56,36 @@ class TestModelLanguageDetection(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "language.source"):
                 Orchestrator(cfg, client=FakeClient(handler=handler)).prepare(txt)
 
+    def test_explicit_same_source_and_target_stops_before_model_calls(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = Config.from_dict({
+                "language": {"source": "ja", "target": "ja-JP"},
+                "llm": {"provider": "fake"},
+                "paths": {"state_dir": os.path.join(d, "state")},
+            })
+            client = FakeClient(handler=routing_handler)
+
+            with self.assertRaisesRegex(ValueError, "源语言与目标语言相同（ja）"):
+                Orchestrator(cfg, client=client).prepare(txt)
+
+            self.assertEqual(client.calls, [])
+
+    def test_auto_detected_source_matching_target_stops_before_analysis(self):
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = self._cfg(os.path.join(d, "state"))
+
+            def handler(messages, tier, json_mode):
+                if "语言识别器" in messages[0]["content"]:
+                    return json.dumps({"language": "chinese"}, ensure_ascii=False)
+                raise AssertionError("相同语言不应继续进入分析或翻译")
+
+            with self.assertRaisesRegex(ValueError, "源语言与目标语言相同（zh）"):
+                Orchestrator(cfg, client=FakeClient(handler=handler)).prepare(txt)
+
 
 class TestPunct(unittest.TestCase):
     def test_japanese_quotes(self):

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -151,6 +151,13 @@ class Orchestrator:
     def _apply_language(self, lang: str) -> None:
         """把解析出的源语言应用到 config 与各 agent（auto 检测后调用）。"""
         resolved = lang or self.config.source_lang
+        source = _normalize_lang(resolved)
+        target = _normalize_lang(self.config.target_lang)
+        if source and target and source == target:
+            raise ValueError(
+                f"源语言与目标语言相同（{source}），无需翻译；"
+                "请修改 config.yaml 中的 language.source 或 language.target。"
+            )
         self.config.source_lang = resolved
         for ag in (self.analyzer, self.synopsizer, self.translator, self.reviewer,
                    self.backtrans, self.polisher, self.extractor):


### PR DESCRIPTION
Stop before analysis or translation when an explicit or auto-detected source language matches the configured target language.
