### PR TITLE
fix: guard translation evidence quality

### DIFF
--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -60,6 +60,30 @@ class TestGlossary(unittest.TestCase):
             {"OpenAI", "ＡＢＣ"},
         )
 
+    def test_short_japanese_names_do_not_match_inside_common_words(self):
+        self.store.upsert_term(GlossaryTerm(source="あんな", target="安奈"))
+        self.store.upsert_term(GlossaryTerm(source="メイ", target="MEI"))
+        self.store.upsert_term(GlossaryTerm(source="しょう", target="小翔"))
+
+        self.assertEqual(
+            self.store.terms_in_text("あんなに明るいメイン曲ならしょうがない。"),
+            [],
+        )
+        hits = self.store.terms_in_text("「あんな」とメイたちがしょうを呼んだ。")
+        self.assertEqual({term.source for term in hits}, {"あんな", "メイ", "しょう"})
+
+    def test_single_kanji_name_requires_a_plausible_boundary(self):
+        self.store.upsert_term(GlossaryTerm(source="明", target="明"))
+        self.store.upsert_term(GlossaryTerm(source="光", target="光"))
+        self.store.upsert_term(GlossaryTerm(source="母", target="母亲"))
+
+        self.assertEqual(
+            self.store.terms_in_text("明るい夜明けに左耳が光っていて、お母さんが来た。"),
+            [],
+        )
+        hits = self.store.terms_in_text("「明さん、光は母と来る？」")
+        self.assertEqual({term.source for term in hits}, {"明", "光", "母"})
+
     def test_appellation_does_not_match_bare_name_alias(self):
         self.store.upsert_term(
             GlossaryTerm(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -586,13 +586,14 @@ class TestEpubIngest(unittest.TestCase):
 
     def test_ruby_reading_is_not_included_in_translatable_source(self):
         html = """<html><body>
-<p><ruby>漢字<rt>かんじ</rt></ruby>です</p>
+<p><ruby>漢字<rp>（</rp><rt>かんじ</rt><rp>）</rp></ruby>です</p>
 </body></html>"""
 
         _title, segments, template = annotate_epub_resource(html, 0, "chapter.xhtml")
 
         self.assertEqual([segment.source for segment in segments], ["漢字です"])
         self.assertIn("<rt>かんじ</rt>", template)
+        self.assertIn("<rp>（</rp>", template)
 
     def test_table_and_definition_list_cells_are_extracted(self):
         html = """<html><body>

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -681,6 +681,48 @@ class TestStyleAnalysis(unittest.TestCase):
             self.assertNotIn("【中部样章】", sample)
             self.assertNotIn("【结尾样章】", sample)
 
+    def test_sample_text_skips_long_epub_front_matter(self):
+        """作品信息/目录再长也不应占用开头样章。"""
+        from trans_novel.ingest.models import Chapter, Document, Segment
+
+        front = Chapter(
+            index=0,
+            segments=[
+                Segment(index=0, source="作品情報"),
+                Segment(index=1, source="あらすじ" + "あ" * 1200),
+                *[
+                    Segment(index=i + 2, source=f"00{i:02d} 第{i}話 タイトル (2026-01-01)")
+                    for i in range(20)
+                ],
+            ],
+        )
+        chapters = [front]
+        for chapter_index in range(1, 4):
+            chapters.append(
+                Chapter(
+                    index=chapter_index,
+                    segments=[
+                        Segment(
+                            index=i,
+                            source=f"正文{chapter_index}-{i}。人物が会話を続けている。" + "あ" * 30,
+                        )
+                        for i in range(8)
+                    ],
+                )
+            )
+        doc = Document(
+            title="test",
+            source_lang="ja",
+            target_lang="zh",
+            fmt="epub",
+            chapters=chapters,
+        )
+
+        sample = Orchestrator._sample_text(doc)
+
+        self.assertNotIn("作品情報", sample)
+        self.assertIn("正文1-0", sample)
+
     def test_style_brief_new_fields(self):
         """style_brief 渲染新风格维度；旧 analysis（缺新字段）不报错不输出。"""
         from trans_novel.agents.analyzer import Analyzer

--- a/tests/test_review_polish.py
+++ b/tests/test_review_polish.py
@@ -77,6 +77,7 @@ class TestPolisher(unittest.TestCase):
         p = Polisher(client, _cfg())
         out = p.polish(["甲", "乙"])
         self.assertEqual(out, ["甲", "乙"])  # 段数不符 → 保守保留原译
+        self.assertEqual(p.last_failed_indexes, [0, 1])
 
 
 class TestBackTranslator(unittest.TestCase):

--- a/tests/test_review_polish.py
+++ b/tests/test_review_polish.py
@@ -79,6 +79,17 @@ class TestPolisher(unittest.TestCase):
         self.assertEqual(out, ["甲", "乙"])  # 段数不符 → 保守保留原译
         self.assertEqual(p.last_failed_indexes, [0, 1])
 
+    def test_empty_polish_clears_previous_failure_state(self):
+        client = FakeClient(handler=lambda m, t, j: json.dumps(
+            {"polished": ["只有一段"]}, ensure_ascii=False))
+        p = Polisher(client, _cfg())
+        p.polish(["甲", "乙"])
+
+        out = p.polish([])
+
+        self.assertEqual(out, [])
+        self.assertEqual(p.last_failed_indexes, [])
+
 
 class TestBackTranslator(unittest.TestCase):
     def test_check(self):

--- a/trans_novel/agents/polisher.py
+++ b/trans_novel/agents/polisher.py
@@ -12,11 +12,16 @@ from .base import Agent
 
 
 class Polisher(Agent):
+    def __init__(self, client, config) -> None:
+        super().__init__(client, config)
+        self.last_failed_indexes: list[int] = []
+
     def polish(self, targets: list[str], *, glossary_terms: list[GlossaryTerm] | None = None,
                style: str = "") -> list[str]:
         """润色等长译文列表；调用失败或数量不符时原样返回输入。"""
         if not targets:
             return []
+        self.last_failed_indexes = []
         n = len(targets)
         system = prompts.render("polisher_system", src=self.src, tgt=self.tgt, n=n)
         user = prompts.render(
@@ -28,4 +33,5 @@ class Polisher(Agent):
         items = self._ask_json(system, user, tier="strong", key="polished", default=None)
         if isinstance(items, list) and len(items) == n:
             return [str(x) for x in items]
+        self.last_failed_indexes = list(range(n))
         return list(targets)  # 失败/段数不符 → 保守保留原译

--- a/trans_novel/agents/polisher.py
+++ b/trans_novel/agents/polisher.py
@@ -19,9 +19,9 @@ class Polisher(Agent):
     def polish(self, targets: list[str], *, glossary_terms: list[GlossaryTerm] | None = None,
                style: str = "") -> list[str]:
         """润色等长译文列表；调用失败或数量不符时原样返回输入。"""
+        self.last_failed_indexes = []
         if not targets:
             return []
-        self.last_failed_indexes = []
         n = len(targets)
         system = prompts.render("polisher_system", src=self.src, tgt=self.tgt, n=n)
         user = prompts.render(

--- a/trans_novel/glossary/store.py
+++ b/trans_novel/glossary/store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import sqlite3
 import time
 import unicodedata
@@ -29,6 +30,74 @@ TYPE_SPEECH = "口癖"
 TYPE_FIXED_EXPR = "固定表达"
 
 _SOURCE_ONLY_TYPES = {TYPE_APPELLATION, TYPE_HONORIFIC, TYPE_SPEECH, TYPE_FIXED_EXPR}
+
+_HIRAGANA_TERM_RE = re.compile(r"^[\u3040-\u309f]+$")
+_KATAKANA_TERM_RE = re.compile(r"^[\u30a0-\u30ffー]+$")
+_SINGLE_CJK_TERM_RE = re.compile(r"^[\u3400-\u9fff]$")
+_SINGLE_CJK_ALLOWED_SUFFIXES = (
+    "さん", "ちゃん", "くん", "君", "氏", "先輩", "先生", "様",
+)
+_SINGLE_CJK_PARTICLES = set("はがをにへともでの、。！？!?「」『』（）()…\n\r\t ")
+_SHORT_KANA_ALLOWED_PARTICLES = set("はをへともで")
+_SHORT_KANA_ALLOWED_PREFIX_PARTICLES = set("はがをにへともで")
+
+
+def _term_occurs(text: str, key: str) -> bool:
+    """Return whether a glossary key occurs as a plausible Japanese token.
+
+    Short kana and one-kanji names otherwise produce common substring false
+    positives, such as ``あんな`` in ``あんなに`` or ``明`` in ``明るい``.
+    Longer and mixed keys keep substring matching because Japanese compounds
+    and attached particles do not have universal whitespace boundaries.
+    """
+    if not key:
+        return False
+    start = 0
+    while True:
+        index = text.find(key, start)
+        if index < 0:
+            return False
+        before = text[index - 1] if index > 0 else ""
+        after_index = index + len(key)
+        after = text[after_index] if after_index < len(text) else ""
+
+        if _HIRAGANA_TERM_RE.fullmatch(key) and len(key) <= 4:
+            before_same = bool(before and "\u3040" <= before <= "\u309f")
+            after_same = bool(after and "\u3040" <= after <= "\u309f")
+            before_is_allowed = (
+                not before_same or before in _SHORT_KANA_ALLOWED_PREFIX_PARTICLES
+            )
+            valid = before_is_allowed and (
+                not after_same or after in _SHORT_KANA_ALLOWED_PARTICLES
+            )
+        elif _KATAKANA_TERM_RE.fullmatch(key) and len(key) <= 4:
+            before_same = bool(before and ("\u30a0" <= before <= "\u30ff" or before == "ー"))
+            after_same = bool(after and ("\u30a0" <= after <= "\u30ff" or after == "ー"))
+            valid = not before_same and not after_same
+        elif _SINGLE_CJK_TERM_RE.fullmatch(key):
+            before_is_japanese = bool(
+                before
+                and (
+                    "\u3040" <= before <= "\u30ff"
+                    or "\u3400" <= before <= "\u9fff"
+                )
+            )
+            suffix = text[after_index:]
+            before_is_allowed = (
+                not before_is_japanese or before in _SINGLE_CJK_PARTICLES
+            )
+            after_is_allowed = (
+                not after
+                or after in _SINGLE_CJK_PARTICLES
+                or any(suffix.startswith(item) for item in _SINGLE_CJK_ALLOWED_SUFFIXES)
+            )
+            valid = before_is_allowed and after_is_allowed
+        else:
+            valid = True
+
+        if valid:
+            return True
+        start = index + 1
 
 @dataclass
 class GlossaryTerm:
@@ -233,7 +302,10 @@ class GlossaryStore:
                 if term.type in _SOURCE_ONLY_TYPES
                 else [term.source] + term.aliases
             )
-            if any(k and _match_text(k) in normalized_text for k in keys):
+            if any(
+                k and _term_occurs(normalized_text, _match_text(k))
+                for k in keys
+            ):
                 out.append(term)
         return out
 

--- a/trans_novel/ingest/epub_reader.py
+++ b/trans_novel/ingest/epub_reader.py
@@ -100,8 +100,10 @@ def _segment_content(block: Tag, anchor: str) -> tuple[str, dict[str, object]]:
         nonlocal raw_length
         for child in parent.children:
             if isinstance(child, Tag):
-                if child.name == "rt":
-                    # 振假名是注音而非正文；保留在模板中，不送给模型翻译。
+                if child.name in {"rt", "rp"}:
+                    # 振假名与不支持 ruby 时显示的备用括号都不是正文；
+                    # 保留在模板中，但不要把 ``漢字（かんじ）`` 拆成
+                    # 可翻译源文里的 ``漢字（）``。
                     continue
                 if id(child) in root_ids:
                     node_offsets.append((child, raw_length))

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 import random
+import re
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -101,6 +102,7 @@ def _resume_batches(segments, max_chars: int) -> list[list]:
 class _BatchResult:
     targets: list[str]
     bt_samples: list[tuple[str, str]] = field(default_factory=list)
+    refinement_failed_indexes: list[int] = field(default_factory=list)
 
 
 class Orchestrator:
@@ -338,8 +340,22 @@ class Orchestrator:
     def _sample_text(doc, *, labeled: bool = True) -> str:
         """取风格分析样章。labeled=True 时多点采样（开头/中部/结尾各一段，带中文标注），
         让分析覆盖全书风格全貌；labeled=False 返回单段纯源文（语言检测用，不能混入中文标签）。"""
-        texts = ["\n".join(s.source for s in ch.text_segments) for ch in doc.chapters]
-        texts = [t for t in texts if len(t) > 200]
+        candidates: list[tuple[str, int]] = []
+        for chapter in doc.chapters:
+            sources = [segment.source for segment in chapter.text_segments]
+            text = "\n".join(sources)
+            if len(text) <= 200:
+                continue
+            # A long EPUB metadata/TOC page contains few narrative sentences.
+            # Prefer chapters with several prose/dialogue segments so character
+            # analysis is based on real story evidence.
+            narrative_segments = sum(
+                bool(re.search(r"[。！？!?」』]", source)) and len(source) >= 20
+                for source in sources
+            )
+            candidates.append((text, narrative_segments))
+        narrative_texts = [text for text, score in candidates if score >= 4]
+        texts = narrative_texts if narrative_texts else [text for text, _ in candidates]
         if not texts:  # 兜底：全书都是短章
             joined = "\n".join(
                 s.source for ch in doc.chapters[:2] for s in ch.text_segments)
@@ -856,7 +872,12 @@ class Orchestrator:
                 chapter=ci,
                 start_index=batch_start,
                 count=len(b),
-                polished=self.config.pipeline.polish,
+                polish_requested=self.config.pipeline.polish,
+                polished=(
+                    self.config.pipeline.polish
+                    and not res.refinement_failed_indexes
+                ),
+                polish_failed_indexes=res.refinement_failed_indexes,
                 punctuation_normalized=self._punctuation_enabled(),
                 backtranslate_sample_count=len(res.bt_samples),
                 segments=[
@@ -1285,10 +1306,12 @@ class Orchestrator:
             sources, glossary_terms=terms, style=style, context=ctx_text,
             book_synopsis=book_synopsis, chapter_digest=chapter_digest)
 
+        refinement_failed_indexes: list[int] = []
         if self.config.pipeline.polish:
             polished = self.polisher.polish(targets, glossary_terms=terms, style=style)
             if len(polished) == len(targets):
                 targets = polished
+            refinement_failed_indexes = list(self.polisher.last_failed_indexes)
 
         bt_samples: list[tuple[str, str]] = []
         rate = self.config.pipeline.backtranslate_sample
@@ -1297,7 +1320,11 @@ class Orchestrator:
                 if random.random() < rate:
                     bt_samples.append((s, t or ""))
 
-        return _BatchResult(targets=targets, bt_samples=bt_samples)
+        return _BatchResult(
+            targets=targets,
+            bt_samples=bt_samples,
+            refinement_failed_indexes=refinement_failed_indexes,
+        )
 
     # ── 可选步骤 / 连续全流程 ────────────────────────────────────────────────
     ALL_STEPS = ("translate", "review", "qa", "report", "assemble")


### PR DESCRIPTION
## Summary

- prefer narrative chapters over long EPUB metadata/TOC resources when building the analyzer sample;
- prevent short kana and single-kanji glossary entries from matching inside unrelated Japanese words;
- exclude EPUB ruby fallback-parenthesis (`rp`) text from translatable source while preserving the original ruby markup;
- record whether refinement was requested, fully applied, or fell back for specific segment indexes.

This is the narrow guardrail portion of #87. Canonical entity identity, evidence-backed facts, contextual glossary classes and artifact invalidation remain follow-up architecture work described in that issue.

## Why

The previous substring matcher can inject character entries for unrelated words (`あんな`/`あんなに`, `メイ`/`メイン`, `明`/`明るい`, `母`/`お母さん`). Separately, a large EPUB front-matter resource can consume the opening analyzer sample and hide early narrative evidence. EPUB ruby markup such as `<ruby>伸枝<rp>（</rp><rt>のぶえ</rt><rp>）</rp></ruby>` also became `伸枝（）` because only `rt` was excluded. Finally, a failed polisher call conservatively returns the draft but the event log used to report `polished=true` whenever the feature was enabled.

Together these behaviours make a bad inferred fact look stronger and more durable than it is.

## Tests

- `uv run python -m unittest tests.test_glossary tests.test_review_polish tests.test_orchestrator.TestStyleAnalysis` — 19 passed.
- `uv run python -m unittest tests.test_ingest.TestEpubIngest.test_ruby_reading_is_not_included_in_translatable_source` — passed.
- Full suite: 235 passed; two existing platform-specific failures remain in `TestDefaultOutBilingual`, where the tests expect POSIX `/tmp/output` but Windows correctly returns `C:\tmp\output`.
- `git diff --check` passed.
