### PR TITLE
ci：为 Pull Request 运行离线测试

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: astral-sh/setup-uv@v9.0.0
+
       - name: Install
-        run: python -m pip install . pytest
+        run: uv sync --locked --group dev --python ${{ matrix.python-version }}
 
       - name: Test
-        run: python -m pytest -q
+        run: uv run --no-sync pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: python -m pip install . pytest
+
+      - name: Test
+        run: python -m pytest -q


### PR DESCRIPTION
## 变更说明

为目标分支是 `dev` 的 Pull Request 增加离线测试工作流。

该工作流：

- 在 Pull Request 指向 `dev` 时运行
- 支持通过 `workflow_dispatch` 手动触发
- 在 Ubuntu 上测试 Python 3.10 和 3.12
- 仅授予仓库内容只读权限
- 安装项目和 pytest，不增加新的运行时依赖

## 具体修改

- 新增 `.github/workflows/tests.yml`
- 沿用现有构建工作流使用的 `actions/checkout@v4`
- 沿用现有构建工作流使用的 `actions/setup-python@v5`
- 未修改打包、发布、翻译流程、CLI 行为或 LLM Provider

## 验证结果

已在 Python 3.12 环境运行本地全量测试：

```text
254 passed, 25 subtests passed in 6.47s