### PR TITLE
feat(cli): 允许纯本地命令在未配置 API 凭据时运行

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,15 +246,12 @@ class TestCliConfig(unittest.TestCase):
         self.assertIn("conflicts", result.output)
         self.assertIn("resolve", result.output)
 
-    def test_api_preflight_covers_every_command_except_assemble(self):
+    def test_api_preflight_covers_model_commands(self):
         for command in (
             "translate",
             "prepare",
             "review",
-            "status",
             "qa",
-            "report",
-            "glossary",
         ):
             with self.subTest(command=command):
                 with patch(
@@ -266,13 +263,32 @@ class TestCliConfig(unittest.TestCase):
                 self.assertIn("missing key", result.output)
                 validate.assert_called_once_with()
 
-        with patch(
-            "trans_novel.cli._validate_api_configuration",
-            side_effect=AssertionError("assemble must not validate credentials"),
-        ) as validate:
-            result = CliRunner().invoke(app, ["assemble"])
-        self.assertEqual(result.exit_code, 2, result.output)
-        validate.assert_not_called()
+    def test_api_preflight_skips_local_commands(self):
+        for args in (
+            ["status", "missing.txt"],
+            ["report", "missing.txt"],
+            ["glossary", "list", "missing.txt"],
+            ["glossary", "conflicts", "missing.txt"],
+            [
+                "glossary",
+                "resolve",
+                "missing.txt",
+                "source",
+                "target",
+            ],
+            ["assemble", "missing.txt"],
+        ):
+            with self.subTest(args=args):
+                with patch(
+                    "trans_novel.cli._validate_api_configuration",
+                    side_effect=AssertionError(
+                        f"{args} must not validate credentials"
+                    ),
+                ) as validate:
+                    result = CliRunner().invoke(app, args)
+                self.assertEqual(result.exit_code, 1, result.output)
+                self.assertIn("输入文件不存在", result.output)
+                validate.assert_not_called()
 
     def test_api_preflight_skips_help_at_every_level(self):
         for args in (["--help"], ["translate", "--help"], ["glossary", "--help"]):

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -52,7 +52,12 @@ def _configure_windows_console(
 _configure_windows_console()
 
 _CONFIG: dict[str, Any] = {"path": "config.yaml", "skip_api_check": False}
-_API_CHECK_EXEMPT_COMMANDS = {"assemble"}
+_API_CHECK_EXEMPT_COMMANDS = {
+    "assemble",
+    "glossary",
+    "report",
+    "status",
+}
 
 
 def _config_path_from_args(args: Sequence[str]) -> str:


### PR DESCRIPTION
## 修改内容

- 允许 `status`、`report`、`assemble` 以及所有 `glossary` 子命令跳过 LLM API 凭据预检。
- 保留 `translate`、`prepare`、`review` 和 `qa` 的凭据预检。
- 为所有本地命令路径补充 CLI 回归测试，包括：
  - `glossary list`
  - `glossary conflicts`
  - `glossary resolve`

## 问题背景

Wenyi 的翻译流程需要连接 LLM API，但部分命令只读取或修改已经保存在本地的状态，并不会调用模型。

目前这些纯本地命令仍会执行 API 凭据预检，导致用户在离线、API Key 过期或模型服务不可用时，无法查看翻译进度、重新生成报告和输出文件，或维护已有术语库。

## 设计说明

提交 `d2a1db5` 将除 `assemble` 外的所有顶层命令纳入 API 凭据预检。本 PR 有意调整这一策略，仅对实际调用模型的命令执行预检。

这不会让翻译流程脱离 API，只是允许用户在无法连接模型时继续管理已有的本地翻译状态和产物。

请维护者确认项目希望采用哪种语义：

1. 所有工作流命令启动前都要求翻译配置完整；
2. 只有当前操作实际需要调用模型时才要求 API 凭据。

本 PR 实现的是第二种语义。

如果项目更倾向于维持“除 `assemble` 外，所有工作流命令均需预先验证 API 凭据”的统一策略,我完全理解，维护者可直接关闭本 PR。

## 用户影响

纯本地命令现在无需 API 凭据即可运行。需要调用模型的命令仍保留原有预检行为。

本次修改不涉及翻译流程、Provider、配置模型或术语数据库逻辑，也没有新增依赖。

## 验证结果

- CLI 定向测试：20 passed，15 subtests passed
- 全量测试：255 passed，28 subtests passed
- `git diff --check` 通过