### PR TITLE
增加单次运行指标，为翻译流水线 A/B 测试建立可比基线

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,7 +91,9 @@ export MINERU_API_KEY=...
 uv run trans-novel translate book.pdf
 ```
 
-MinerU's converted HTML is saved at `state/<book>/source/converted.html`.
+MinerU's converted HTML is saved at
+`state/<book>/source/<source-sha256>/converted.html`. The content-addressed
+directory prevents an interrupted run from reusing another PDF's conversion.
 Later runs reuse this file, and you may correct it manually before resuming.
 
 #### PDF output
@@ -119,11 +121,12 @@ TTC font file. This option also works on Windows.
 
 ## Per-run metrics
 
-`state/<book>/usage.json` remains the cumulative token total for the book. Each
-top-level command also writes an independent
+`state/<book>/usage.json` remains the cumulative token total for the book.
+`translate`, `prepare`, `review`, `assemble`, and `report` each write an independent
 `state/<book>/run_metrics/<run-id>.json` record with:
 
-- input, configuration, package, and Git revision fingerprints;
+- the input SHA-256, configuration, package, and Git revision fingerprints;
+- invocation options such as a selected chapter, output format, and PDF engine;
 - requested stages, completion or failure status, and per-stage wall time;
 - only the LLM calls and tokens added by that invocation; and
 - ending chapter and segment completion counts.
@@ -132,6 +135,10 @@ Every resume creates a new record, so clean runs from different branches can be
 compared without mixing their costs. Records omit the full source path and book
 text, redact sensitive option values, and store only an exception type on
 failure.
+
+New manifests store `source_sha256` instead of an absolute source path. Wenyi
+rejects a same-title state directory when its recorded hash does not match the
+current input. Manifests created by older versions must be rebuilt.
 
 ## Common commands
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,22 @@ Images mixed with text are placed as separate blocks. It uses a discoverable
 CJK system font; if none is found, set `TRANS_NOVEL_PDF_FONT` to a TTF, OTF, or
 TTC font file. This option also works on Windows.
 
+## Per-run metrics
+
+`state/<book>/usage.json` remains the cumulative token total for the book. Each
+top-level command also writes an independent
+`state/<book>/run_metrics/<run-id>.json` record with:
+
+- input, configuration, package, and Git revision fingerprints;
+- requested stages, completion or failure status, and per-stage wall time;
+- only the LLM calls and tokens added by that invocation; and
+- ending chapter and segment completion counts.
+
+Every resume creates a new record, so clean runs from different branches can be
+compared without mixing their costs. Records omit the full source path and book
+text, redact sensitive option values, and store only an exception type on
+failure.
+
 ## Common commands
 
 ```bash

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -115,6 +115,20 @@ uv run trans-novel assemble book.html --format pdf --pdf-engine fpdf2
 `TRANS_NOVEL_PDF_FONT` 指定 TTF、OTF 或 TTC 字体文件。此方案也适用于
 Windows。
 
+## 单次运行指标
+
+`state/<书名>/usage.json` 继续保存这本书跨续跑累计的 token 总账。每个顶层命令
+还会独立生成一份 `state/<书名>/run_metrics/<run-id>.json`，记录：
+
+- 输入、配置、程序包和 Git 提交的指纹；
+- 本次请求的阶段、成功或失败状态，以及各阶段墙钟耗时；
+- 仅由本次命令新增的模型调用数与 token；
+- 命令结束时已完成的章节数和正文段数。
+
+每次续跑都会新建一条记录，因此不同分支的全新运行可以公平比较，不会把历史
+成本混在一起。账本不保存完整源文件路径或书籍正文；敏感配置值会被遮蔽，失败
+时也只记录异常类型。
+
 ## 常用命令
 
 ```bash

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -90,7 +90,9 @@ export MINERU_API_KEY=...
 uv run trans-novel translate book.pdf
 ```
 
-MinerU 转换生成的 HTML 会保存到 `state/<书名>/source/converted.html`。
+MinerU 转换生成的 HTML 会保存到
+`state/<书名>/source/<源文件 SHA-256>/converted.html`。按内容隔离缓存，可避免
+初始化中断后把另一份 PDF 的转换结果误用于当前文件。
 后续运行会直接复用该文件，也可人工修正后再续跑。
 
 #### PDF 导出
@@ -117,10 +119,12 @@ Windows。
 
 ## 单次运行指标
 
-`state/<书名>/usage.json` 继续保存这本书跨续跑累计的 token 总账。每个顶层命令
-还会独立生成一份 `state/<书名>/run_metrics/<run-id>.json`，记录：
+`state/<书名>/usage.json` 继续保存这本书跨续跑累计的 token 总账。`translate`、
+`prepare`、`review`、`assemble` 和 `report` 会各自生成一份
+`state/<书名>/run_metrics/<run-id>.json`，记录：
 
-- 输入、配置、程序包和 Git 提交的指纹；
+- 输入文件 SHA-256、配置、程序包和 Git 提交的指纹；
+- 指定章节、输出格式、PDF 引擎等本次调用参数；
 - 本次请求的阶段、成功或失败状态，以及各阶段墙钟耗时；
 - 仅由本次命令新增的模型调用数与 token；
 - 命令结束时已完成的章节数和正文段数。
@@ -128,6 +132,9 @@ Windows。
 每次续跑都会新建一条记录，因此不同分支的全新运行可以公平比较，不会把历史
 成本混在一起。账本不保存完整源文件路径或书籍正文；敏感配置值会被遮蔽，失败
 时也只记录异常类型。
+
+新 manifest 使用 `source_sha256`，不再保存源文件绝对路径。若同名状态目录记录的
+哈希与当前输入不一致，Wenyi 会拒绝续跑；旧版本生成的 manifest 需要重新建立。
 
 ## 常用命令
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -405,6 +405,86 @@ class TestCliConfig(unittest.TestCase):
         self.assertIn("输入文件不存在", result.output)
         self.assertNotIn("DEEPSEEK_API_KEY", result.output)
 
+    def test_assemble_uses_local_orchestrator_entry(self):
+        cfg = Config.from_dict({"llm": {"provider": "fake"}})
+        captured = {}
+
+        class FakeOrchestrator:
+            def __init__(self, config, client=None):
+                del client
+                captured["mono"] = config.output.mono
+                captured["bilingual"] = config.output.bilingual
+
+            def run_assemble(self, input_path, **kwargs):
+                captured["input"] = input_path
+                captured["kwargs"] = kwargs
+                return {"outputs": ["out.pdf"]}
+
+        with (
+            patch("trans_novel.cli._load_config", return_value=cfg),
+            patch("trans_novel.pipeline.orchestrator.Orchestrator", FakeOrchestrator),
+            patch("trans_novel.cli.os.path.isfile", return_value=True),
+        ):
+            result = CliRunner().invoke(
+                app,
+                [
+                    "assemble",
+                    "input.epub",
+                    "--format",
+                    "pdf",
+                    "--pdf-engine",
+                    "fpdf2",
+                    "--no-mono",
+                    "--bilingual",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(captured["mono"])
+        self.assertTrue(captured["bilingual"])
+        self.assertEqual(captured["input"], "input.epub")
+        self.assertEqual(captured["kwargs"]["out_format"], "pdf")
+        self.assertEqual(captured["kwargs"]["pdf_engine"], "fpdf2")
+        self.assertIn("out.pdf", result.output)
+
+    def test_report_uses_local_orchestrator_entry(self):
+        cfg = Config.from_dict({"llm": {"provider": "fake"}})
+        captured = {}
+
+        class ReportStore:
+            report_path = "state/book/report.json"
+
+        class FakeOrchestrator:
+            def __init__(self, config, client=None):
+                del client
+                captured["config"] = config
+
+            def run_report(self, input_path):
+                captured["input"] = input_path
+                return {
+                    "store": ReportStore(),
+                    "report": {
+                        "summary": {
+                            "chapters_done": 2,
+                            "chapters_total": 2,
+                            "terms": 3,
+                            "open_conflicts": 0,
+                            "backtranslation_issues": 0,
+                        }
+                    },
+                }
+
+        with (
+            patch("trans_novel.cli._load_config", return_value=cfg),
+            patch("trans_novel.pipeline.orchestrator.Orchestrator", FakeOrchestrator),
+            patch("trans_novel.cli.os.path.isfile", return_value=True),
+        ):
+            result = CliRunner().invoke(app, ["report", "input.epub"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured["input"], "input.epub")
+        self.assertIn("state/book/report.json", result.output)
+
     def test_translate_expected_errors_are_printed_without_traceback(self):
         cfg = Config.from_dict({"llm": {"provider": "fake", "tiers": {"strong": {"model": "p"}}}})
 
@@ -487,6 +567,28 @@ class TestCliConfig(unittest.TestCase):
             self.assertEqual(result.exit_code, 1, result.output)
             self.assertIn("尚无进度", result.output)
             self.assertFalse(os.path.exists(state_dir))
+
+    def test_state_commands_print_source_identity_errors(self):
+        commands = (
+            ["status", "book.epub"],
+            ["glossary", "list", "book.epub"],
+            ["glossary", "conflicts", "book.epub"],
+            ["glossary", "resolve", "book.epub", "source", "target"],
+        )
+        for args in commands:
+            with self.subTest(args=args):
+                with (
+                    patch("trans_novel.cli.os.path.isfile", return_value=True),
+                    patch(
+                        "trans_novel.cli._runstore_for",
+                        side_effect=ValueError("输入文件内容与现有状态不一致"),
+                    ),
+                ):
+                    result = CliRunner().invoke(app, args)
+
+                self.assertEqual(result.exit_code, 1, result.output)
+                self.assertIn("错误：输入文件内容与现有状态不一致", result.output)
+                self.assertNotIn("Traceback", result.output)
 
 
 class TestWindowsConsoleEncoding(unittest.TestCase):

--- a/tests/test_pdf_support.py
+++ b/tests/test_pdf_support.py
@@ -15,12 +15,14 @@ from bs4.element import Comment
 from trans_novel.assemble.writer import assemble
 from trans_novel.cli import _runstore_for
 from trans_novel.config import Config
+from trans_novel.glossary.store import GlossaryStore, GlossaryTerm
 from trans_novel.ingest.errors import MinerUError
 from trans_novel.ingest.models import Document
+from trans_novel.ingest.pdf_reader import pdf_cache_html_path
 from trans_novel.ingest.segmenter import load_document
 from trans_novel.llm.providers.fake import FakeClient
 from trans_novel.pipeline.orchestrator import Orchestrator
-from trans_novel.pipeline.runstore import RunStore
+from trans_novel.pipeline.runstore import RunStore, source_sha256
 
 _HTML = """\
 <!doctype html>
@@ -57,8 +59,8 @@ class TestPdfIngest(unittest.TestCase):
             with open(pdf_path, "wb") as file:
                 file.write(b"not accessed when cached HTML exists")
             cache_dir = os.path.join(directory, "state", "sample", "source")
-            os.makedirs(cache_dir)
-            cached_html = os.path.join(cache_dir, "converted.html")
+            cached_html = pdf_cache_html_path(cache_dir, source_sha256(pdf_path))
+            os.makedirs(os.path.dirname(cached_html))
             with open(cached_html, "w", encoding="utf-8") as file:
                 file.write(_HTML)
 
@@ -72,10 +74,8 @@ class TestPdfIngest(unittest.TestCase):
         self.assertEqual(document.title, "sample")
         self.assertEqual(document.fmt, "pdf")
         self.assertEqual(document.source_path, os.path.abspath(pdf_path))
-        self.assertEqual(
-            document.meta["converted_html_path"],
-            os.path.abspath(cached_html),
-        )
+        self.assertNotIn("pdf_path", document.meta)
+        self.assertNotIn("converted_html_path", document.meta)
         self.assertEqual(
             [chapter.title for chapter in document.chapters],
             ["Chapter One", "Chapter Two"],
@@ -105,6 +105,85 @@ class TestPdfIngest(unittest.TestCase):
 
         self.assertIsInstance(raised.exception.__cause__, RuntimeError)
 
+    def test_pdf_failed_conversion_cannot_leave_a_reusable_partial_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pdf_path = os.path.join(directory, "sample.pdf")
+            with open(pdf_path, "wb") as file:
+                file.write(b"invalid PDF; conversion is mocked")
+            cache_dir = os.path.join(directory, "state", "sample", "source")
+
+            def write_partial_then_fail(_input: str, output: str, **_kwargs) -> None:
+                os.makedirs(os.path.dirname(output), exist_ok=True)
+                with open(output, "w", encoding="utf-8") as file:
+                    file.write("<html><body><p>PARTIAL</p></body></html>")
+                raise RuntimeError("connection reset")
+
+            with (
+                patch(
+                    "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                    side_effect=write_partial_then_fail,
+                ),
+                self.assertRaises(MinerUError),
+            ):
+                load_document(pdf_path, "en", "zh", cache_dir=cache_dir)
+
+            def convert_fresh(_input: str, output: str, **_kwargs) -> None:
+                os.makedirs(os.path.dirname(output), exist_ok=True)
+                with open(output, "w", encoding="utf-8") as file:
+                    file.write(_HTML.replace("First paragraph.", "Fresh retry."))
+
+            with patch(
+                "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                side_effect=convert_fresh,
+            ) as conversion:
+                document = load_document(pdf_path, "en", "zh", cache_dir=cache_dir)
+
+            conversion.assert_called_once()
+            self.assertIn("Fresh retry.", document.chapters[0].segments[1].source)
+
+    def test_pdf_failed_conversion_metric_survives_successful_retry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pdf_path = os.path.join(directory, "sample.pdf")
+            with open(pdf_path, "wb") as file:
+                file.write(b"invalid PDF; conversion is mocked")
+            state_dir = os.path.join(directory, "state")
+            config = Config.from_dict(
+                {
+                    "language": {"source": "en", "target": "zh"},
+                    "llm": {"provider": "fake"},
+                    "pipeline": {"book_understanding": False},
+                    "paths": {"state_dir": state_dir},
+                }
+            )
+
+            with (
+                patch(
+                    "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                    side_effect=RuntimeError("temporary outage"),
+                ),
+                self.assertRaises(MinerUError),
+            ):
+                Orchestrator(config, client=FakeClient()).prepare_for_translation(pdf_path)
+
+            def convert_fresh(_input: str, output: str, **_kwargs) -> None:
+                os.makedirs(os.path.dirname(output), exist_ok=True)
+                with open(output, "w", encoding="utf-8") as file:
+                    file.write(_HTML)
+
+            with patch(
+                "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                side_effect=convert_fresh,
+            ):
+                store = Orchestrator(
+                    config,
+                    client=FakeClient(),
+                ).prepare_for_translation(pdf_path)
+
+            self.assertEqual(
+                [metric["status"] for metric in store.load_run_metrics()],
+                ["failed", "completed"],
+            )
+
     def test_orchestrator_uses_state_cache_and_resume_skips_pdf_parse(self):
         with tempfile.TemporaryDirectory() as directory:
             pdf_path = os.path.join(directory, "sample.pdf")
@@ -112,8 +191,8 @@ class TestPdfIngest(unittest.TestCase):
                 file.write(b"not accessed when cached HTML exists")
             state_dir = os.path.join(directory, "state")
             cache_dir = os.path.join(state_dir, "sample", "source")
-            os.makedirs(cache_dir)
-            cached_html = os.path.join(cache_dir, "converted.html")
+            cached_html = pdf_cache_html_path(cache_dir, source_sha256(pdf_path))
+            os.makedirs(os.path.dirname(cached_html))
             with open(cached_html, "w", encoding="utf-8") as file:
                 file.write(_HTML)
             config = Config.from_dict(
@@ -131,10 +210,110 @@ class TestPdfIngest(unittest.TestCase):
             store = orchestrator.prepare(pdf_path)
             os.remove(cached_html)
             resumed = orchestrator.prepare(pdf_path)
+            serialized_manifest = str(store.load_manifest())
 
         self.assertEqual(store.run_dir, os.path.join(state_dir, "sample"))
         self.assertEqual(resumed.run_dir, store.run_dir)
         self.assertFalse(os.path.exists(cached_html))
+        self.assertNotIn(os.path.abspath(pdf_path), serialized_manifest)
+        self.assertNotIn(os.path.abspath(cached_html), serialized_manifest)
+
+    def test_pdf_cache_isolated_by_source_hash_after_interrupted_initialization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pdf_path = os.path.join(directory, "sample.pdf")
+            with open(pdf_path, "wb") as file:
+                file.write(b"old PDF")
+            state_dir = os.path.join(directory, "state")
+            cache_root = os.path.join(state_dir, "sample", "source")
+            stale_hash = source_sha256(pdf_path)
+            stale_html = pdf_cache_html_path(cache_root, stale_hash)
+            os.makedirs(os.path.dirname(stale_html))
+            with open(stale_html, "w", encoding="utf-8") as file:
+                file.write(_HTML.replace("First paragraph.", "Stale body."))
+            config = Config.from_dict(
+                {
+                    "language": {"source": "en", "target": "zh"},
+                    "llm": {
+                        "provider": "fake",
+                        "tiers": {"strong": {"model": "fake"}},
+                    },
+                    "paths": {"state_dir": state_dir},
+                }
+            )
+            with (
+                patch.object(RunStore, "save_manifest", side_effect=OSError("disk full")),
+                self.assertRaisesRegex(OSError, "disk full"),
+            ):
+                Orchestrator(config, client=FakeClient()).prepare(pdf_path)
+
+            partial_store = RunStore(os.path.join(state_dir, "sample"))
+            stale_glossary = GlossaryStore(partial_store.glossary_path)
+            stale_glossary.upsert_term(GlossaryTerm(source="OldBook", target="旧书"))
+            stale_glossary.close()
+
+            with open(pdf_path, "wb") as file:
+                file.write(b"new PDF")
+            fresh_hash = source_sha256(pdf_path)
+
+            def convert(_input: str, output: str, **_kwargs) -> None:
+                os.makedirs(os.path.dirname(output), exist_ok=True)
+                with open(output, "w", encoding="utf-8") as file:
+                    file.write(_HTML.replace("First paragraph.", "Fresh body."))
+
+            with patch(
+                "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                side_effect=convert,
+            ) as conversion:
+                store = Orchestrator(config, client=FakeClient()).prepare(pdf_path)
+
+            conversion.assert_called_once()
+            self.assertEqual(store.load_manifest()["source_sha256"], fresh_hash)
+            self.assertIn("Fresh body.", store.load_chapter(0).segments[1].source)
+            glossary = GlossaryStore(store.glossary_path)
+            try:
+                self.assertIsNone(glossary.get_term("OldBook"))
+            finally:
+                glossary.close()
+
+    def test_pdf_change_during_conversion_is_rejected_and_cache_is_discarded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pdf_path = os.path.join(directory, "sample.pdf")
+            with open(pdf_path, "wb") as file:
+                file.write(b"PDF before conversion")
+            original_hash = source_sha256(pdf_path)
+            state_dir = os.path.join(directory, "state")
+
+            def convert(_input: str, output: str, **_kwargs) -> None:
+                with open(pdf_path, "wb") as file:
+                    file.write(b"PDF replaced during conversion")
+                os.makedirs(os.path.dirname(output), exist_ok=True)
+                with open(output, "w", encoding="utf-8") as file:
+                    file.write(_HTML)
+
+            config = Config.from_dict(
+                {
+                    "language": {"source": "en", "target": "zh"},
+                    "llm": {"provider": "fake"},
+                    "paths": {"state_dir": state_dir},
+                }
+            )
+            with (
+                patch(
+                    "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                    side_effect=convert,
+                ),
+                self.assertRaisesRegex(ValueError, "转换或解析期间发生变化"),
+            ):
+                Orchestrator(config, client=FakeClient()).prepare(pdf_path)
+
+            stale_cache = os.path.dirname(
+                pdf_cache_html_path(
+                    os.path.join(state_dir, "sample", "source"),
+                    original_hash,
+                )
+            )
+            self.assertFalse(os.path.exists(stale_cache))
+            self.assertFalse(os.path.isfile(os.path.join(state_dir, "sample", "manifest.json")))
 
     def test_cli_tools_locate_pdf_state_without_parsing_source(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -167,13 +346,13 @@ class TestPdfIngest(unittest.TestCase):
             with open(pdf_path, "wb") as file:
                 file.write(b"not accessed when cached HTML exists")
             cache_dir = os.path.join(directory, "state", "sample", "source")
-            image_dir = os.path.join(cache_dir, "images")
+            cached_html = pdf_cache_html_path(cache_dir, source_sha256(pdf_path))
+            image_dir = os.path.join(os.path.dirname(cached_html), "images")
             os.makedirs(image_dir)
             with open(os.path.join(image_dir, "chart.svg"), "w", encoding="utf-8") as file:
                 file.write(
                     '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
                 )
-            cached_html = os.path.join(cache_dir, "converted.html")
             with open(cached_html, "w", encoding="utf-8") as file:
                 file.write(
                     """<html><body><h1>Chapter</h1>
@@ -186,7 +365,7 @@ class TestPdfIngest(unittest.TestCase):
                 "zh",
                 cache_dir=cache_dir,
             )
-            store = RunStore(os.path.join(directory, "run"))
+            store = RunStore(os.path.join(directory, "state", "sample"))
             _initialize_test_store(store, document)
             _set_test_targets(store)
             output_path = os.path.join(directory, "translated.epub")

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import tempfile
 import threading
@@ -93,6 +94,39 @@ class _ClientStub:
 
     def __init__(self, responses: list[Any]) -> None:
         self.chat = _ChatStub(responses)
+
+
+class _MeteredFakeClient(FakeClient):
+    """每次离线调用都写入固定 token，供单次运行账本断言。"""
+
+    def complete(
+        self,
+        messages,
+        *,
+        tier: str = "strong",
+        json_mode: bool = False,
+        max_tokens: int | None = None,
+        stage: str | None = None,
+    ) -> str:
+        result = super().complete(
+            messages,
+            tier=tier,
+            json_mode=json_mode,
+            max_tokens=max_tokens,
+            stage=stage,
+        )
+        self.usage.record(
+            tier,
+            UsageSample(
+                prompt_tokens=7,
+                completion_tokens=3,
+                total_tokens=10,
+                cache_hit_tokens=2,
+                cache_miss_tokens=5,
+            ),
+            stage,
+        )
+        return result
 
 
 def _minimal_deepseek_cfg() -> LLMConfig:
@@ -657,6 +691,155 @@ class TestUsageIncrementalPersistence(unittest.TestCase):
             self.assertEqual(usage["totals"]["total_tokens"], 170)
             self.assertEqual(usage["totals"]["calls"], 2)
             self.assertEqual(result["store"].load_usage(), usage)
+
+
+class TestPerRunMetrics(unittest.TestCase):
+    @staticmethod
+    def _config(directory: str) -> Config:
+        return Config.from_dict(
+            {
+                "language": {"source": "ja", "target": "zh"},
+                "llm": {
+                    "provider": "fake",
+                    "tiers": {
+                        "strong": {
+                            "model": "fake-strong",
+                            "options": {
+                                "api_token": "must-not-be-stored",
+                                "max_tokens": 1024,
+                                "temperature": 0.2,
+                            },
+                        }
+                    },
+                },
+                "pipeline": {
+                    "book_understanding": False,
+                    "review": False,
+                    "polish": False,
+                },
+                "paths": {"state_dir": os.path.join(directory, "state")},
+            }
+        )
+
+    def test_nested_pipeline_entry_creates_one_complete_metric(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            client = _MeteredFakeClient(handler=routing_handler)
+            orchestrator = Orchestrator(
+                self._config(directory),
+                client=client,
+            )
+
+            store = orchestrator.run_steps(source, {"translate"})["store"]
+
+            metrics = store.load_run_metrics()
+            self.assertEqual(len(metrics), 1)
+            metric = metrics[0]
+            self.assertEqual(metric["operation"], "pipeline")
+            self.assertEqual(metric["requested_steps"], ["translate"])
+            self.assertEqual(metric["status"], "completed")
+            self.assertEqual(
+                metric["usage"]["totals"]["calls"],
+                len(client.calls),
+            )
+            self.assertEqual(
+                metric["usage"]["totals"]["total_tokens"],
+                len(client.calls) * 10,
+            )
+            self.assertEqual(len(metric["input"]["sha256"]), 64)
+            self.assertEqual(len(metric["config"]["fingerprint"]), 64)
+            self.assertEqual(
+                metric["config"]["summary"]["llm"]["tiers"]["strong"]["options"]["api_token"],
+                "<redacted>",
+            )
+            self.assertEqual(
+                metric["config"]["summary"]["llm"]["tiers"]["strong"]["options"]["max_tokens"],
+                1024,
+            )
+            self.assertNotIn("must-not-be-stored", json.dumps(metric))
+            self.assertIn("prepare", metric["stage_seconds"])
+            self.assertIn("understanding", metric["stage_seconds"])
+            self.assertIn("translate", metric["stage_seconds"])
+            self.assertGreater(metric["state"]["segments_total"], 0)
+            self.assertEqual(
+                metric["state"]["segments_translated"],
+                metric["state"]["segments_total"],
+            )
+
+    def test_resume_gets_a_new_zero_call_metric(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            client = _MeteredFakeClient(handler=routing_handler)
+            orchestrator = Orchestrator(
+                self._config(directory),
+                client=client,
+            )
+            store = orchestrator.run_steps(source, {"translate"})["store"]
+
+            orchestrator.run_steps(source, {"report"})
+
+            metrics = store.load_run_metrics()
+            self.assertEqual(len(metrics), 2)
+            self.assertEqual(metrics[1]["requested_steps"], ["report"])
+            self.assertEqual(metrics[1]["usage"]["totals"]["calls"], 0)
+            self.assertIn("report", metrics[1]["stage_seconds"])
+
+    def test_failure_records_only_exception_type(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            config = self._config(directory)
+            initial = Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            )
+            store = initial.run_steps(source, {"translate"})["store"]
+            failing = Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            )
+
+            with patch.object(
+                failing,
+                "_run_review_session",
+                side_effect=RuntimeError("private failure detail"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "private failure"):
+                    failing.run_review(source)
+
+            metric = store.load_run_metrics()[-1]
+            self.assertEqual(metric["status"], "failed")
+            self.assertEqual(metric["error"], {"type": "RuntimeError"})
+            self.assertNotIn("private failure detail", json.dumps(metric))
+
+    def test_runstore_rejects_unsafe_run_id(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = RunStore(os.path.join(directory, "state", "book"))
+            with self.assertRaisesRegex(ValueError, "run_id"):
+                store.save_run_metric({"run_id": "../outside"})
+
+    def test_metric_write_failure_does_not_fail_translation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            orchestrator = Orchestrator(
+                self._config(directory),
+                client=_MeteredFakeClient(handler=routing_handler),
+            )
+
+            with patch.object(
+                RunStore,
+                "save_run_metric",
+                side_effect=OSError("disk full"),
+            ):
+                with self.assertWarnsRegex(RuntimeWarning, "无法保存"):
+                    result = orchestrator.run_steps(source, {"translate"})
+
+            store = result["store"]
+            self.assertEqual(store.pending_chapters(), [])
+            self.assertEqual(store.load_run_metrics(), [])
 
 
 class TestRunStoreLock(unittest.TestCase):

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -35,8 +35,9 @@ from trans_novel.llm.usage import (
     merge_usage_summaries,
     usage_delta,
 )
+from trans_novel.pipeline.metrics import RunMetricsRecorder, config_identity
 from trans_novel.pipeline.orchestrator import Orchestrator
-from trans_novel.pipeline.runstore import RunStore
+from trans_novel.pipeline.runstore import RunStore, source_sha256
 
 
 def _make_usage(
@@ -701,6 +702,8 @@ class TestPerRunMetrics(unittest.TestCase):
                 "language": {"source": "ja", "target": "zh"},
                 "llm": {
                     "provider": "fake",
+                    "base_url": "https://example.invalid/v1",
+                    "reasoning_style": "openai",
                     "tiers": {
                         "strong": {
                             "model": "fake-strong",
@@ -748,7 +751,18 @@ class TestPerRunMetrics(unittest.TestCase):
                 len(client.calls) * 10,
             )
             self.assertEqual(len(metric["input"]["sha256"]), 64)
+            manifest = store.load_manifest()
+            self.assertEqual(manifest["source_sha256"], metric["input"]["sha256"])
+            self.assertNotIn("source_path", manifest)
             self.assertEqual(len(metric["config"]["fingerprint"]), 64)
+            self.assertEqual(
+                metric["config"]["summary"]["llm"]["base_url"],
+                "https://example.invalid",
+            )
+            self.assertEqual(
+                metric["config"]["summary"]["llm"]["reasoning_style"],
+                "openai",
+            )
             self.assertEqual(
                 metric["config"]["summary"]["llm"]["tiers"]["strong"]["options"]["api_token"],
                 "<redacted>",
@@ -766,6 +780,82 @@ class TestPerRunMetrics(unittest.TestCase):
                 metric["state"]["segments_translated"],
                 metric["state"]["segments_total"],
             )
+            self.assertNotIn("chapters_reviewed", metric["state"])
+
+    def test_config_fingerprint_tracks_base_url_and_reasoning_style(self):
+        base = self._config("state")
+        changed_url = base.model_copy(deep=True)
+        changed_url.llm.base_url = "https://other.invalid/v1"
+        changed_reasoning = base.model_copy(deep=True)
+        changed_reasoning.llm.reasoning_style = "deepseek"
+        changed_path = base.model_copy(deep=True)
+        changed_path.llm.base_url = "https://example.invalid/another-endpoint"
+        changed_query = base.model_copy(deep=True)
+        changed_query.llm.base_url = "https://example.invalid/v1?api-version=2026-08-01"
+
+        base_identity = config_identity(base)
+        url_identity = config_identity(changed_url)
+        reasoning_identity = config_identity(changed_reasoning)
+        path_identity = config_identity(changed_path)
+        query_identity = config_identity(changed_query)
+
+        self.assertNotEqual(base_identity["fingerprint"], url_identity["fingerprint"])
+        self.assertNotEqual(
+            base_identity["fingerprint"],
+            reasoning_identity["fingerprint"],
+        )
+        self.assertNotEqual(base_identity["fingerprint"], path_identity["fingerprint"])
+        self.assertNotEqual(base_identity["fingerprint"], query_identity["fingerprint"])
+
+    def test_config_identity_redacts_credentials_embedded_in_base_url(self):
+        config = self._config("state")
+        config.llm.base_url = "https://user:password@example.invalid/v1?api_key=secret"
+
+        identity = config_identity(config)
+        clean_identity = config_identity(self._config("state"))
+        serialized = json.dumps(identity)
+
+        self.assertEqual(
+            identity["summary"]["llm"]["base_url"],
+            "https://example.invalid",
+        )
+        self.assertNotIn("password", serialized)
+        self.assertNotIn("api_key", serialized)
+        self.assertNotIn("secret", serialized)
+        self.assertEqual(identity["fingerprint"], clean_identity["fingerprint"])
+
+    def test_invocation_parameters_are_redacted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            client = FakeClient(handler=routing_handler)
+            store = RunStore(os.path.join(directory, "state", "book"))
+            store.save_manifest({"chapters": []})
+            recorder = RunMetricsRecorder.start(
+                operation="assemble",
+                requested_steps=["assemble"],
+                input_path=source,
+                config=self._config(directory),
+                client=client,
+                invocation={
+                    "out_format": "pdf",
+                    "pdf_engine": "fpdf2",
+                    "parameters": {"api_token": "invocation-secret"},
+                },
+            )
+            recorder.attach_store(store)
+
+            recorder.finish(client, status="completed")
+
+            metric = store.load_run_metrics()[0]
+            self.assertEqual(metric["invocation"]["out_format"], "pdf")
+            self.assertEqual(metric["invocation"]["pdf_engine"], "fpdf2")
+            self.assertEqual(
+                metric["invocation"]["parameters"]["api_token"],
+                "<redacted>",
+            )
+            serialized = json.dumps(metric)
+            self.assertNotIn("invocation-secret", serialized)
 
     def test_resume_gets_a_new_zero_call_metric(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -785,6 +875,170 @@ class TestPerRunMetrics(unittest.TestCase):
             self.assertEqual(metrics[1]["requested_steps"], ["report"])
             self.assertEqual(metrics[1]["usage"]["totals"]["calls"], 0)
             self.assertIn("report", metrics[1]["stage_seconds"])
+
+    def test_chapter_run_records_selected_chapter(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            orchestrator = Orchestrator(
+                self._config(directory),
+                client=_MeteredFakeClient(handler=routing_handler),
+            )
+
+            store = orchestrator.run(source, only_chapter=0)
+
+            metric = store.load_run_metrics()[0]
+            self.assertEqual(metric["operation"], "translate")
+            self.assertEqual(metric["invocation"], {"only_chapter": 0})
+
+    def test_standalone_report_and_assemble_get_independent_metrics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            output = os.path.join(directory, "translated.txt")
+            write_sample_txt(source)
+            orchestrator = Orchestrator(
+                self._config(directory),
+                client=_MeteredFakeClient(handler=routing_handler),
+            )
+            store = orchestrator.run_steps(source, {"translate"})["store"]
+
+            orchestrator.run_report(source)
+            assembled = orchestrator.run_assemble(
+                source,
+                out_format="txt",
+                out_path=output,
+                pdf_engine="fpdf2",
+            )
+
+            self.assertEqual(assembled["outputs"], [output])
+            by_operation = {metric["operation"]: metric for metric in store.load_run_metrics()}
+            self.assertEqual(by_operation["report"]["requested_steps"], ["report"])
+            self.assertIn("report", by_operation["report"]["stage_seconds"])
+            self.assertEqual(
+                by_operation["assemble"]["invocation"],
+                {"out_format": "txt", "pdf_engine": "fpdf2"},
+            )
+            self.assertIn("assemble", by_operation["assemble"]["stage_seconds"])
+
+    def test_assemble_hashes_large_input_once_when_file_signature_is_stable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            output = os.path.join(directory, "translated.txt")
+            write_sample_txt(source)
+            config = self._config(directory)
+            Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            ).run_steps(source, {"translate"})
+            resumed = Orchestrator(config, client=FakeClient())
+
+            with (
+                patch(
+                    "trans_novel.pipeline.metrics.source_sha256",
+                    wraps=source_sha256,
+                ) as initial_hash,
+                patch(
+                    "trans_novel.pipeline.orchestrator.source_sha256",
+                    wraps=source_sha256,
+                ) as boundary_hash,
+            ):
+                resumed.run_assemble(
+                    source,
+                    out_format="txt",
+                    out_path=output,
+                )
+
+            self.assertEqual(initial_hash.call_count, 1)
+            self.assertEqual(boundary_hash.call_count, 0)
+
+    def test_changed_source_is_rejected_before_reusing_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            config = self._config(directory)
+            store = Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            ).run_steps(source, {"translate"})["store"]
+            with open(source, "a", encoding="utf-8") as file:
+                file.write("\n追加された本文。\n")
+
+            with self.assertRaisesRegex(ValueError, "内容与现有翻译状态不一致"):
+                Orchestrator(config, client=FakeClient()).run_report(source)
+
+            self.assertNotEqual(store.load_manifest()["source_sha256"], source_sha256(source))
+
+    def test_source_change_between_metrics_snapshot_and_state_check_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            config = self._config(directory)
+            Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            ).run_steps(source, {"translate"})
+            resumed = Orchestrator(config, client=FakeClient())
+            locate = resumed._locate_existing_store
+            original_stat = os.stat(source)
+
+            def mutate_then_locate(*args, **kwargs):
+                with open(source, "rb") as file:
+                    data = file.read()
+                changed = data.replace("綾".encode(), "絢".encode(), 1)
+                self.assertEqual(len(changed), len(data))
+                with open(source, "wb") as file:
+                    file.write(changed)
+                os.utime(
+                    source,
+                    ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+                )
+                return locate(*args, **kwargs)
+
+            with (
+                patch.object(
+                    resumed,
+                    "_locate_existing_store",
+                    side_effect=mutate_then_locate,
+                ),
+                self.assertRaisesRegex(ValueError, "本次命令执行期间发生变化"),
+            ):
+                resumed.run_report(source)
+
+    def test_existing_state_restores_both_manifest_languages(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            initial_config = self._config(directory)
+            Orchestrator(
+                initial_config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            ).run_steps(source, {"translate"})
+            resumed_config = self._config(directory)
+            resumed_config.source_lang = "auto"
+            resumed_config.target_lang = "ja"
+            resumed = Orchestrator(resumed_config, client=FakeClient())
+
+            resumed.run_report(source)
+
+            self.assertEqual(resumed.config.source_lang, "ja")
+            self.assertEqual(resumed.config.target_lang, "zh")
+            self.assertEqual(resumed.reviewer.src, "ja")
+            self.assertEqual(resumed.reviewer.tgt, "zh")
+
+    def test_manifest_without_source_hash_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            store = RunStore(os.path.join(directory, "state", "book"))
+            store.save_manifest(
+                {
+                    "source_path": source,
+                    "chapters": [],
+                }
+            )
+
+            with self.assertRaisesRegex(ValueError, "缺少有效的 source_sha256"):
+                store.ensure_source_identity(source)
 
     def test_failure_records_only_exception_type(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -813,6 +1067,37 @@ class TestPerRunMetrics(unittest.TestCase):
             self.assertEqual(metric["status"], "failed")
             self.assertEqual(metric["error"], {"type": "RuntimeError"})
             self.assertNotIn("private failure detail", json.dumps(metric))
+
+    def test_captured_ending_state_does_not_drift_after_lock_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            write_sample_txt(source)
+            config = self._config(directory)
+            store = Orchestrator(
+                config,
+                client=_MeteredFakeClient(handler=routing_handler),
+            ).run_steps(source, {"translate"})["store"]
+            client = FakeClient()
+            recorder = RunMetricsRecorder.start(
+                operation="report",
+                requested_steps=["report"],
+                input_path=source,
+                config=config,
+                client=client,
+            )
+            with store.lock():
+                recorder.capture_state(store)
+
+            chapter = store.load_chapter(0)
+            chapter.segments[0].target = None
+            store.save_chapter(chapter)
+            recorder.finish(client, status="completed")
+
+            metric = store.load_run_metrics()[-1]
+            self.assertEqual(
+                metric["state"]["segments_translated"],
+                metric["state"]["segments_total"],
+            )
 
     def test_runstore_rejects_unsafe_run_id(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -264,13 +264,19 @@ def _materialize_html_resources(
     return rewritten
 
 
-def _template_resource_source(manifest: dict, source_path: str) -> str:
+def _template_resource_source(
+    store: RunStore,
+    manifest: dict,
+    source_path: str,
+) -> str:
     """Return the HTML file whose directory resolves template media references."""
-    raw_meta = manifest.get("meta")
-    meta = raw_meta if isinstance(raw_meta, dict) else {}
-    converted_html_path = meta.get("converted_html_path")
-    if manifest.get("fmt") == "pdf" and isinstance(converted_html_path, str):
-        return converted_html_path
+    if manifest.get("fmt") == "pdf":
+        from ..ingest.pdf_reader import pdf_cache_html_path
+
+        source_hash = manifest.get("source_sha256")
+        if not isinstance(source_hash, str):
+            raise ValueError("PDF manifest 缺少有效的 source_sha256")
+        return pdf_cache_html_path(store.source_dir, source_hash)
     return source_path
 
 
@@ -1579,7 +1585,7 @@ def _assemble_html(
 </html>"""
     full_html = _materialize_html_resources(
         full_html,
-        source_path=_template_resource_source(m, source_path),
+        source_path=_template_resource_source(store, m, source_path),
         out_path=out_path,
     )
 
@@ -2166,7 +2172,7 @@ def _build_epub_from_html_templates(
     meta = raw_meta if isinstance(raw_meta, dict) else {}
     head_html = meta.get("head_html", "")
     head_html = head_html if isinstance(head_html, str) else ""
-    resource_source = _template_resource_source(manifest, source_path)
+    resource_source = _template_resource_source(store, manifest, source_path)
 
     book = epub.EpubBook()
     book.set_identifier(f"trans-novel-{title}")

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -221,10 +221,24 @@ def _runstore_for(config: Config, input_path: str) -> RunStore:
     if os.path.splitext(input_path)[1].lower() == ".pdf":
         title = os.path.splitext(os.path.basename(input_path))[0]
         run_dir = os.path.join(config.state_dir, slugify(title))
-        return RunStore(run_dir, create=False)
-    doc = load_document(input_path, config.source_lang, config.target_lang)
-    run_dir = os.path.join(config.state_dir, slugify(doc.title))
-    return RunStore(run_dir, create=False)
+        store = RunStore(run_dir, create=False)
+    else:
+        doc = load_document(input_path, config.source_lang, config.target_lang)
+        run_dir = os.path.join(config.state_dir, slugify(doc.title))
+        store = RunStore(run_dir, create=False)
+    if store.exists():
+        with store.lock():
+            store.ensure_source_identity(input_path)
+    return store
+
+
+def _runstore_for_cli(config: Config, input_path: str) -> RunStore:
+    """为状态类 CLI 定位状态，并把身份错误转换为简洁提示。"""
+    try:
+        return _runstore_for(config, input_path)
+    except (IngestError, OSError, ValueError) as error:
+        console.print(f"[red]错误：{error}[/]")
+        raise typer.Exit(1) from None
 
 
 def _apply_store_languages(config: Config, store: _ManifestStore) -> None:
@@ -556,7 +570,7 @@ def status(
     from .glossary.store import GlossaryStore
 
     config = _load_config()
-    store = _runstore_for(config, input)
+    store = _runstore_for_cli(config, input)
     if not store.exists():
         console.print("[yellow]尚无进度。先运行 prepare 或 translate。[/]")
         raise typer.Exit(1)
@@ -585,7 +599,7 @@ def glossary_list(
     from .glossary.store import GlossaryStore
 
     config = _load_config()
-    store = _runstore_for(config, input)
+    store = _runstore_for_cli(config, input)
     if not store.exists():
         console.print("[yellow]尚无进度。先运行 prepare 或 translate。[/]")
         raise typer.Exit(1)
@@ -612,7 +626,7 @@ def glossary_conflicts(
     from .glossary.store import GlossaryStore
 
     config = _load_config()
-    store = _runstore_for(config, input)
+    store = _runstore_for_cli(config, input)
     if not store.exists():
         console.print("[yellow]尚无进度。先运行 translate 或 prepare。[/]")
         raise typer.Exit(1)
@@ -643,7 +657,7 @@ def glossary_resolve(
     from .glossary.store import GlossaryStore
 
     config = _load_config()
-    store = _runstore_for(config, input)
+    store = _runstore_for_cli(config, input)
     if not store.exists():
         console.print("[yellow]尚无进度。先运行 translate 或 prepare。[/]")
         raise typer.Exit(1)
@@ -687,48 +701,28 @@ def assemble(
     ),
 ):
     """从已有状态重新生成译文文件，不调用模型或重新翻译。"""
-    from .assemble.writer import assemble as do_assemble
-    from .assemble.writer import bilingual_out_path
+    from .llm.providers.fake import FakeClient
+    from .pipeline.orchestrator import Orchestrator
 
     config = _load_config()
     fmt = _validate_output_format(fmt)
     pdf_engine = _validate_pdf_engine(pdf_engine)
-    store = _runstore_for(config, input)
-    if not store.exists():
-        console.print("[yellow]尚无进度。先运行 prepare 或 translate。[/]")
-        raise typer.Exit(1)
-    do_mono = config.output.mono if mono is None else mono
-    do_bilingual = config.output.bilingual if bilingual is None else bilingual
-    if not do_mono and not do_bilingual:
-        do_mono = True  # 兜底：至少产一个单语产物
-    paths: list[str] = []
-    if do_mono:
-        paths.append(
-            do_assemble(
-                store,
-                input,
-                out_path=out,
-                out_format=fmt,
-                bilingual=False,
-                about_page=config.output.about_page,
-                pdf_engine=pdf_engine,
-            )
+    _require_input_file(input)
+    if mono is not None:
+        config.output.mono = mono
+    if bilingual is not None:
+        config.output.bilingual = bilingual
+    try:
+        result = Orchestrator(config, client=FakeClient()).run_assemble(
+            input,
+            out_format=fmt,
+            out_path=out,
+            pdf_engine=pdf_engine,
         )
-    if do_bilingual:
-        bi_out = bilingual_out_path(out) if out else None
-        paths.append(
-            do_assemble(
-                store,
-                input,
-                out_path=bi_out,
-                out_format=fmt,
-                bilingual=True,
-                order=config.output.bilingual_order,
-                preserve_source_style=(config.output.bilingual_preserve_source_style),
-                about_page=config.output.about_page,
-                pdf_engine=pdf_engine,
-            )
-        )
+    except (IngestError, OSError, ValueError) as error:
+        console.print(f"[red]错误：{error}[/]")
+        raise typer.Exit(1) from None
+    paths = result["outputs"]
     for path in paths:
         console.print(f"已生成译文：[bold]{path}[/]")
 
@@ -738,18 +732,18 @@ def report(
     input: str = typer.Argument(..., help="已建立翻译状态的源文件"),
 ) -> None:
     """根据当前章节和术语状态重新生成 report.json，不调用模型。"""
-    from .assemble.report import build_report
-    from .glossary.store import GlossaryStore
+    from .llm.providers.fake import FakeClient
+    from .pipeline.orchestrator import Orchestrator
 
     config = _load_config()
-    store = _runstore_for(config, input)
-    if not store.exists():
-        console.print("[yellow]尚无进度。先运行 prepare 或 translate。[/]")
-        raise typer.Exit(1)
-    g = GlossaryStore(store.glossary_path)
-    rep = build_report(store, g)
-    g.close()
-    store.save_report(rep)
+    _require_input_file(input)
+    try:
+        result = Orchestrator(config, client=FakeClient()).run_report(input)
+    except (IngestError, OSError, ValueError) as error:
+        console.print(f"[red]错误：{error}[/]")
+        raise typer.Exit(1) from None
+    store = result["store"]
+    rep = result["report"]
     s = rep["summary"]
     console.print(f"翻译报告已写入 {store.report_path}")
     console.print(

--- a/trans_novel/ingest/pdf_reader.py
+++ b/trans_novel/ingest/pdf_reader.py
@@ -12,12 +12,31 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import re
+import shutil
 from pathlib import Path
 
 from .errors import MinerUError
 from .html_reader import read_html
 from .models import Document
+
+
+def _source_sha256(path: str) -> str:
+    """流式计算 PDF 内容哈希，供直接调用读取器时绑定缓存。"""
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def pdf_cache_html_path(cache_dir: str, source_hash: str) -> str:
+    """返回由源文件哈希隔离的 MinerU HTML 缓存路径。"""
+    if not re.fullmatch(r"[0-9a-f]{64}", source_hash):
+        raise ValueError("源文件 SHA-256 格式无效")
+    return os.path.join(cache_dir, source_hash, "converted.html")
 
 
 def _check_deps() -> None:
@@ -32,8 +51,8 @@ def _check_deps() -> None:
         raise ImportError(
             f"PDF 转换需要额外依赖，请运行：\n"
             f"  uv pip install {' '.join(missing)}\n"
-            f"或先手动将 PDF 转为 HTML，保存到本书状态目录的 "
-            f"source/converted.html，再重跑。"
+            f"也可先安装依赖完成一次转换，再检查状态目录 source/<SHA-256>/"
+            f"converted.html。"
         )
 
 
@@ -43,12 +62,13 @@ def read_pdf(
     target_lang: str,
     *,
     cache_dir: str,
+    source_hash: str | None = None,
     api_token: str | None = None,
 ) -> Document:
     """将 PDF 转换为 HTML 后解析为 Document。
 
     中间 HTML 产物保存在本书运行状态目录的
-    ``source/converted.html``，
+    ``source/<source_sha256>/converted.html``，
     便于人工检查 MinerU 解析质量。若已存在则直接复用，不重复调用 API。
 
     Parameters
@@ -61,6 +81,8 @@ def read_pdf(
         目标语言代码。
     cache_dir : str
         本书运行状态下的输入预处理缓存目录。
+    source_hash : str | None
+        调用方已计算的源文件 SHA-256；省略时由读取器计算。
     api_token : str | None
         MinerU API token，默认读环境变量 ``MINERU_API_KEY``。
 
@@ -69,31 +91,44 @@ def read_pdf(
     Document
         fmt="pdf"，source_path 指向原始 PDF。
     """
-    os.makedirs(cache_dir, exist_ok=True)
-    html_path = os.path.join(cache_dir, "converted.html")
+    digest = source_hash or _source_sha256(path)
+    html_path = pdf_cache_html_path(cache_dir, digest)
+    os.makedirs(os.path.dirname(html_path), exist_ok=True)
 
+    converted = False
     # 若中间 HTML 不存在，调用 MinerU 转换
     if not os.path.isfile(html_path):
         _check_deps()
         from .pdf_to_html import convert_pdf_to_html
 
+        temporary_html_path = f"{html_path}.tmp"
         try:
-            convert_pdf_to_html(path, html_path, api_token=api_token)
+            os.remove(temporary_html_path)
+        except FileNotFoundError:
+            pass
+        try:
+            convert_pdf_to_html(path, temporary_html_path, api_token=api_token)
+            os.replace(temporary_html_path, html_path)
+            converted = True
         except MinerUError:
+            shutil.rmtree(os.path.dirname(html_path), ignore_errors=True)
             raise
         except Exception as error:
+            shutil.rmtree(os.path.dirname(html_path), ignore_errors=True)
             # HTTP、PDF 解析、ZIP 解包和写盘失败统一为输入层异常；
             # 原异常作为 cause 保留，便于调试时追踪。
             raise MinerUError(f"PDF 转换失败：{error}") from error
 
     # 用 html_reader 解析中间 HTML
     doc = read_html(html_path, source_lang, target_lang)
+    if _source_sha256(path) != digest:
+        if converted:
+            shutil.rmtree(os.path.dirname(html_path), ignore_errors=True)
+        raise ValueError("PDF 在转换或解析期间发生变化；已放弃本次缓存，请重试。")
 
     # 覆盖为 PDF 原始信息
     doc.title = Path(path).stem
     doc.fmt = "pdf"
     doc.source_path = os.path.abspath(path)
-    doc.meta["pdf_path"] = doc.source_path
-    doc.meta["converted_html_path"] = os.path.abspath(html_path)
 
     return doc

--- a/trans_novel/ingest/segmenter.py
+++ b/trans_novel/ingest/segmenter.py
@@ -114,6 +114,7 @@ def load_document(
     split_segments: int = 0,
     *,
     cache_dir: str | None = None,
+    source_hash: str | None = None,
 ) -> Document:
     """按文件扩展名读取文档，并按需拆分超过上限的翻译段。"""
     ext = os.path.splitext(path)[1].lower()
@@ -133,6 +134,7 @@ def load_document(
             source_lang,
             target_lang,
             cache_dir=cache_dir,
+            source_hash=source_hash,
         )
     else:
         raise ValueError(

--- a/trans_novel/pipeline/metrics.py
+++ b/trans_novel/pipeline/metrics.py
@@ -1,0 +1,289 @@
+"""单次流水线运行的可复现实验账本。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator
+
+from ..config import Config
+from ..llm.base import LLMClient
+from ..llm.usage import usage_delta
+
+if TYPE_CHECKING:
+    from .runstore import RunStore
+
+
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "password",
+    "secret",
+    "access_token",
+    "api_token",
+    "auth_token",
+    "bearer_token",
+)
+
+
+def _package_version() -> str:
+    """读取已安装包版本；源码树未安装时稳定降级。"""
+    try:
+        return version("trans-novel")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _now_iso() -> str:
+    """返回带本地时区、可排序的秒级时间。"""
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def _safe_value(value: Any, *, key: str = "") -> Any:
+    """把配置值转换为可序列化数据，并隐藏可能的凭据。"""
+    normalized_key = key.lower().replace("-", "_")
+    if normalized_key == "token" or any(part in normalized_key for part in _SENSITIVE_KEY_PARTS):
+        return "<redacted>"
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(item_key): _safe_value(item_value, key=str(item_key))
+            for item_key, item_value in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe_value(item) for item in value]
+    return f"<{type(value).__name__}>"
+
+
+def _fingerprint(data: Any) -> str:
+    """计算规范 JSON 的 SHA-256，用于比较输入和配置是否相同。"""
+    encoded = json.dumps(
+        data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def config_identity(config: Config) -> dict[str, Any]:
+    """提取影响翻译结果的非敏感配置，并给出稳定指纹。"""
+    summary = {
+        "language": {
+            "source": config.source_lang,
+            "target": config.target_lang,
+        },
+        "llm": {
+            "provider": config.llm.provider,
+            "timeout": config.llm.timeout,
+            "max_retries": config.llm.max_retries,
+            "tiers": {
+                name: {
+                    "model": tier.model,
+                    "options": _safe_value(tier.options),
+                }
+                for name, tier in sorted(config.llm.tiers.items())
+            },
+        },
+        "segment": _safe_value(config.segment.model_dump(mode="python")),
+        "pipeline": _safe_value(config.pipeline.model_dump(mode="python")),
+        "output": _safe_value(config.output.model_dump(mode="python")),
+        "honorific_strategy": config.honorific_strategy,
+        "punctuation_normalize": config.punctuation_normalize,
+    }
+    return {"fingerprint": _fingerprint(summary), "summary": summary}
+
+
+def input_identity(input_path: str) -> dict[str, Any]:
+    """记录输入文件的名称、大小和内容指纹，不保存完整路径或正文。"""
+    path = Path(input_path)
+    identity: dict[str, Any] = {
+        "name": path.name,
+        "suffix": path.suffix.lower(),
+        "exists": path.is_file(),
+    }
+    if not identity["exists"]:
+        return identity
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+        identity["size_bytes"] = path.stat().st_size
+        identity["sha256"] = digest.hexdigest()
+    except OSError:
+        identity["readable"] = False
+    return identity
+
+
+def _git_output(repo_root: Path, *args: str) -> str | None:
+    """读取 Git 身份信息；非 Git 安装或超时时静默降级。"""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            check=False,
+            encoding="utf-8",
+            errors="replace",
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = completed.stdout.strip()
+    return value if completed.returncode == 0 and value else None
+
+
+def code_identity() -> dict[str, Any]:
+    """记录包版本和 Git 提交，令不同分支的实验可追溯。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    revision = _git_output(repo_root, "rev-parse", "HEAD")
+    branch = _git_output(repo_root, "branch", "--show-current")
+    status = _git_output(repo_root, "status", "--porcelain")
+    return {
+        "package_version": _package_version(),
+        "git_revision": revision,
+        "git_branch": branch,
+        "git_dirty": bool(status) if revision else None,
+    }
+
+
+def _state_summary(store: RunStore) -> dict[str, int]:
+    """汇总结束时的章节和正文段完成度，不复制书籍内容。"""
+    manifest = store.load_manifest()
+    chapters = manifest.get("chapters", [])
+    summary = {
+        "chapters_total": len(chapters),
+        "chapters_translated": sum(item.get("status") == "done" for item in chapters),
+        "chapters_reviewed": sum(item.get("review_status") == "done" for item in chapters),
+        "segments_total": 0,
+        "segments_translated": 0,
+    }
+    for item in chapters:
+        chapter = store.load_chapter(item["index"])
+        text_segments = chapter.text_segments
+        summary["segments_total"] += len(text_segments)
+        summary["segments_translated"] += sum(
+            bool(segment.target and segment.target.strip()) for segment in text_segments
+        )
+    return summary
+
+
+@dataclass
+class RunMetricsRecorder:
+    """收集一次顶层操作的耗时、用量和可复现身份。"""
+
+    operation: str
+    requested_steps: list[str]
+    input: dict[str, Any]
+    config: dict[str, Any]
+    code: dict[str, Any]
+    usage_before: dict[str, Any]
+    run_id: str = field(
+        default_factory=lambda: (
+            f"run-{datetime.now().astimezone().strftime('%Y%m%dT%H%M%S%f%z')}-"
+            f"{uuid.uuid4().hex[:8]}"
+        )
+    )
+    started_at: str = field(default_factory=_now_iso)
+    _started: float = field(default_factory=time.perf_counter)
+    _store: RunStore | None = None
+    _stage_seconds: dict[str, float] = field(default_factory=dict)
+    _stage_started: dict[str, float] = field(default_factory=dict)
+    _stage_depth: dict[str, int] = field(default_factory=dict)
+    _finished: bool = False
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        operation: str,
+        requested_steps: list[str],
+        input_path: str,
+        config: Config,
+        client: LLMClient,
+    ) -> RunMetricsRecorder:
+        """在任何模型调用之前抓取本次运行的基线。"""
+        return cls(
+            operation=operation,
+            requested_steps=list(requested_steps),
+            input=input_identity(input_path),
+            config=config_identity(config),
+            code=code_identity(),
+            usage_before=client.usage_summary(),
+        )
+
+    def attach_store(self, store: RunStore) -> None:
+        """绑定状态目录；只接受本次操作实际使用的第一本书。"""
+        if self._store is None:
+            self._store = store
+            return
+        if self._store.run_dir != store.run_dir:
+            raise ValueError("一次运行账本不能跨越多个书籍状态目录")
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        """累加一个阶段的墙钟时间；同名嵌套只计算一次。"""
+        depth = self._stage_depth.get(name, 0)
+        self._stage_depth[name] = depth + 1
+        if depth == 0:
+            self._stage_started[name] = time.perf_counter()
+        try:
+            yield
+        finally:
+            remaining = self._stage_depth[name] - 1
+            self._stage_depth[name] = remaining
+            if remaining == 0:
+                elapsed = time.perf_counter() - self._stage_started.pop(name)
+                self._stage_seconds[name] = self._stage_seconds.get(name, 0.0) + elapsed
+
+    def finish(
+        self,
+        client: LLMClient,
+        *,
+        status: str,
+        error: BaseException | None = None,
+    ) -> str | None:
+        """完成并持久化账本；未能建立状态目录时不额外创建孤立记录。"""
+        if self._finished:
+            return None
+        self._finished = True
+        if self._store is None:
+            return None
+
+        record: dict[str, Any] = {
+            "schema_version": 1,
+            "run_id": self.run_id,
+            "operation": self.operation,
+            "requested_steps": self.requested_steps,
+            "status": status,
+            "started_at": self.started_at,
+            "finished_at": _now_iso(),
+            "duration_seconds": round(time.perf_counter() - self._started, 6),
+            "stage_seconds": {
+                name: round(seconds, 6) for name, seconds in sorted(self._stage_seconds.items())
+            },
+            "input": self.input,
+            "config": self.config,
+            "code": self.code,
+            "usage": usage_delta(client.usage_summary(), self.usage_before),
+        }
+        try:
+            record["state"] = _state_summary(self._store)
+        except (OSError, KeyError, TypeError, ValueError):
+            record["state"] = {"available": False}
+        if error is not None:
+            record["error"] = {"type": type(error).__name__}
+        return self._store.save_run_metric(record)

--- a/trans_novel/pipeline/metrics.py
+++ b/trans_novel/pipeline/metrics.py
@@ -13,10 +13,12 @@ from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ..config import Config
 from ..llm.base import LLMClient
 from ..llm.usage import usage_delta
+from .runstore import source_sha256
 
 if TYPE_CHECKING:
     from .runstore import RunStore
@@ -51,8 +53,7 @@ def _now_iso() -> str:
 
 def _safe_value(value: Any, *, key: str = "") -> Any:
     """把配置值转换为可序列化数据，并隐藏可能的凭据。"""
-    normalized_key = key.lower().replace("-", "_")
-    if normalized_key == "token" or any(part in normalized_key for part in _SENSITIVE_KEY_PARTS):
+    if _is_sensitive_key(key):
         return "<redacted>"
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
@@ -66,6 +67,12 @@ def _safe_value(value: Any, *, key: str = "") -> Any:
     return f"<{type(value).__name__}>"
 
 
+def _is_sensitive_key(key: str) -> bool:
+    """判断配置键是否可能承载凭据。"""
+    normalized = key.lower().replace("-", "_")
+    return normalized == "token" or any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
 def _fingerprint(data: Any) -> str:
     """计算规范 JSON 的 SHA-256，用于比较输入和配置是否相同。"""
     encoded = json.dumps(
@@ -77,8 +84,40 @@ def _fingerprint(data: Any) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _safe_base_url(
+    value: str | None,
+    *,
+    include_path: bool = False,
+) -> str | None:
+    """保留端点身份所需部分，同时去掉 URL 中可能携带的凭据和查询参数。"""
+    if not value:
+        return value
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname or ""
+        if ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        if parsed.port is not None:
+            hostname = f"{hostname}:{parsed.port}"
+        path = parsed.path if include_path else ""
+        query = ""
+        if include_path:
+            safe_query = sorted(
+                (key, item_value)
+                for key, item_value in parse_qsl(parsed.query, keep_blank_values=True)
+                if not _is_sensitive_key(key)
+            )
+            query = urlencode(safe_query)
+        return urlunsplit((parsed.scheme, hostname, path, query, ""))
+    except ValueError:
+        # 非法端口等畸形 URL 也不能原样写入账本。
+        return "<invalid-url>"
+
+
 def config_identity(config: Config) -> dict[str, Any]:
     """提取影响翻译结果的非敏感配置，并给出稳定指纹。"""
+    base_url = config.llm.base_url
+    endpoint_identity = _safe_base_url(base_url, include_path=True)
     summary = {
         "language": {
             "source": config.source_lang,
@@ -86,6 +125,11 @@ def config_identity(config: Config) -> dict[str, Any]:
         },
         "llm": {
             "provider": config.llm.provider,
+            "base_url": _safe_base_url(base_url),
+            "base_url_fingerprint": (
+                _fingerprint(endpoint_identity) if endpoint_identity else None
+            ),
+            "reasoning_style": config.llm.reasoning_style,
             "timeout": config.llm.timeout,
             "max_retries": config.llm.max_retries,
             "tiers": {
@@ -107,6 +151,23 @@ def config_identity(config: Config) -> dict[str, Any]:
 
 def input_identity(input_path: str) -> dict[str, Any]:
     """记录输入文件的名称、大小和内容指纹，不保存完整路径或正文。"""
+    identity, _signature = _capture_input_identity(input_path)
+    return identity
+
+
+def _source_signature(path: Path) -> tuple[int, int, int, int, int] | None:
+    """返回用于发现普通文件替换/改写的廉价稳定签名。"""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns
+
+
+def _capture_input_identity(
+    input_path: str,
+) -> tuple[dict[str, Any], tuple[int, int, int, int, int] | None]:
+    """一次性捕获输入身份和签名；哈希期间变化时不返回可复用签名。"""
     path = Path(input_path)
     identity: dict[str, Any] = {
         "name": path.name,
@@ -114,18 +175,18 @@ def input_identity(input_path: str) -> dict[str, Any]:
         "exists": path.is_file(),
     }
     if not identity["exists"]:
-        return identity
+        return identity, None
 
-    digest = hashlib.sha256()
+    before = _source_signature(path)
     try:
-        with path.open("rb") as source:
-            while chunk := source.read(1024 * 1024):
-                digest.update(chunk)
-        identity["size_bytes"] = path.stat().st_size
-        identity["sha256"] = digest.hexdigest()
+        if before is not None:
+            identity["size_bytes"] = before[2]
+        identity["sha256"] = source_sha256(str(path))
     except OSError:
         identity["readable"] = False
-    return identity
+        return identity, None
+    after = _source_signature(path)
+    return identity, after if before == after else None
 
 
 def _git_output(repo_root: Path, *args: str) -> str | None:
@@ -167,7 +228,6 @@ def _state_summary(store: RunStore) -> dict[str, int]:
     summary = {
         "chapters_total": len(chapters),
         "chapters_translated": sum(item.get("status") == "done" for item in chapters),
-        "chapters_reviewed": sum(item.get("review_status") == "done" for item in chapters),
         "segments_total": 0,
         "segments_translated": 0,
     }
@@ -191,6 +251,7 @@ class RunMetricsRecorder:
     config: dict[str, Any]
     code: dict[str, Any]
     usage_before: dict[str, Any]
+    invocation: dict[str, Any] = field(default_factory=dict)
     run_id: str = field(
         default_factory=lambda: (
             f"run-{datetime.now().astimezone().strftime('%Y%m%dT%H%M%S%f%z')}-"
@@ -204,6 +265,11 @@ class RunMetricsRecorder:
     _stage_started: dict[str, float] = field(default_factory=dict)
     _stage_depth: dict[str, int] = field(default_factory=dict)
     _finished: bool = False
+    _input_signature: tuple[int, int, int, int, int] | None = field(
+        default=None,
+        repr=False,
+    )
+    _state_snapshot: dict[str, Any] | None = field(default=None, repr=False)
 
     @classmethod
     def start(
@@ -214,16 +280,42 @@ class RunMetricsRecorder:
         input_path: str,
         config: Config,
         client: LLMClient,
+        invocation: dict[str, Any] | None = None,
     ) -> RunMetricsRecorder:
-        """在任何模型调用之前抓取本次运行的基线。"""
+        """在任何模型调用之前抓取本次运行的基线和非配置参数。"""
+        started_at = _now_iso()
+        started = time.perf_counter()
+        input_info, input_signature = _capture_input_identity(input_path)
         return cls(
             operation=operation,
             requested_steps=list(requested_steps),
-            input=input_identity(input_path),
+            input=input_info,
             config=config_identity(config),
             code=code_identity(),
             usage_before=client.usage_summary(),
+            invocation=_safe_value(invocation or {}),
+            started_at=started_at,
+            _started=started,
+            _input_signature=input_signature,
         )
+
+    def verify_input_sha256(self, input_path: str) -> str | None:
+        """廉价确认源文件未变；签名改变时重新哈希并与启动快照比较。"""
+        expected = self.input.get("sha256")
+        if not isinstance(expected, str):
+            return None
+        path = Path(input_path)
+        current_signature = _source_signature(path)
+        if self._input_signature is not None and current_signature == self._input_signature:
+            return expected
+
+        refreshed, signature = _capture_input_identity(input_path)
+        actual = refreshed.get("sha256")
+        if not isinstance(actual, str) or actual != expected:
+            raise ValueError("源文件在本次命令执行期间发生变化；请确认文件稳定后重试。")
+        self._input_signature = signature
+        self.input.update(refreshed)
+        return actual
 
     def attach_store(self, store: RunStore) -> None:
         """绑定状态目录；只接受本次操作实际使用的第一本书。"""
@@ -232,6 +324,14 @@ class RunMetricsRecorder:
             return
         if self._store.run_dir != store.run_dir:
             raise ValueError("一次运行账本不能跨越多个书籍状态目录")
+
+    def capture_state(self, store: RunStore) -> None:
+        """在业务书锁仍持有时冻结本次运行的结束状态。"""
+        self.attach_store(store)
+        try:
+            self._state_snapshot = _state_summary(store)
+        except (OSError, KeyError, TypeError, ValueError):
+            self._state_snapshot = {"available": False}
 
     @contextmanager
     def stage(self, name: str) -> Iterator[None]:
@@ -268,10 +368,9 @@ class RunMetricsRecorder:
             "run_id": self.run_id,
             "operation": self.operation,
             "requested_steps": self.requested_steps,
+            "invocation": self.invocation,
             "status": status,
             "started_at": self.started_at,
-            "finished_at": _now_iso(),
-            "duration_seconds": round(time.perf_counter() - self._started, 6),
             "stage_seconds": {
                 name: round(seconds, 6) for name, seconds in sorted(self._stage_seconds.items())
             },
@@ -280,10 +379,15 @@ class RunMetricsRecorder:
             "code": self.code,
             "usage": usage_delta(client.usage_summary(), self.usage_before),
         }
-        try:
-            record["state"] = _state_summary(self._store)
-        except (OSError, KeyError, TypeError, ValueError):
-            record["state"] = {"available": False}
+        if self._state_snapshot is not None:
+            record["state"] = self._state_snapshot
+        else:
+            try:
+                record["state"] = _state_summary(self._store)
+            except (OSError, KeyError, TypeError, ValueError):
+                record["state"] = {"available": False}
         if error is not None:
             record["error"] = {"type": type(error).__name__}
+        record["finished_at"] = _now_iso()
+        record["duration_seconds"] = round(time.perf_counter() - self._started, 6)
         return self._store.save_run_metric(record)

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -19,11 +19,14 @@ import hashlib
 import json
 import os
 import random
+import warnings
 from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from functools import wraps
 from threading import Lock
-from typing import Any
+from typing import Any, Iterator
 
 from ..agents.analyzer import Analyzer
 from ..agents.annotation_aligner import (
@@ -57,11 +60,66 @@ from ..llm.factory import build_client
 from ..llm.usage import merge_usage_summaries, usage_delta
 from ..postprocess.punct import normalize_zh_segments
 from .context import RollingContext
+from .metrics import RunMetricsRecorder
 from .review_evidence import BookEvidenceIndex
 from .review_run import ReviewOutcome, ReviewRunStore
 from .runstore import STATUS_DONE, RunStore, slugify
 
 ProgressFn = Callable[[int, int, str], None]
+
+
+def _record_run_metrics(
+    operation: str,
+    requested_steps: list[str],
+) -> Callable:
+    """为固定入口添加单次运行账本，同时允许入口之间安全嵌套。"""
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapped(
+            self: Orchestrator,
+            input_path: str,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            with self._run_metrics_session(
+                input_path,
+                operation=operation,
+                requested_steps=requested_steps,
+            ):
+                return func(self, input_path, *args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+def _record_pipeline_metrics(func: Callable) -> Callable:
+    """为动态步骤集合建立单条顶层流水线账本。"""
+
+    @wraps(func)
+    def wrapped(
+        self: Orchestrator,
+        input_path: str,
+        steps,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        normalized_steps = set(steps)
+        with self._run_metrics_session(
+            input_path,
+            operation="pipeline",
+            requested_steps=sorted(normalized_steps),
+        ):
+            return func(
+                self,
+                input_path,
+                normalized_steps,
+                *args,
+                **kwargs,
+            )
+
+    return wrapped
 
 
 # 语言名/代码 → ISO 639-1 两字母代码（模型检测结果归一化）
@@ -368,6 +426,8 @@ class Orchestrator:
         self.polisher = Polisher(self.client, config)
         self.extractor = GlossaryExtractor(self.client, config)
         self.annotation_aligner = AnnotationAligner(self.client, config)
+        self._active_run_metrics: RunMetricsRecorder | None = None
+        self._run_metrics_suppressed = False
 
     def _bind_llm_events(self, store: RunStore) -> None:
         """把 provider 重试事件实时写入当前书籍的追加式事件日志。"""
@@ -399,6 +459,96 @@ class Orchestrator:
             cumulative=cumulative,
         )
         return cumulative
+
+    @contextmanager
+    def _run_metrics_session(
+        self,
+        input_path: str,
+        *,
+        operation: str,
+        requested_steps: list[str],
+    ) -> Iterator[RunMetricsRecorder | None]:
+        """为一次顶层操作建立账本；嵌套入口复用同一记录。"""
+        active = self._active_run_metrics
+        if active is not None:
+            yield active
+            return
+        if self._run_metrics_suppressed:
+            yield None
+            return
+
+        try:
+            recorder = RunMetricsRecorder.start(
+                operation=operation,
+                requested_steps=requested_steps,
+                input_path=input_path,
+                config=self.config,
+                client=self.client,
+            )
+        except Exception as metrics_error:
+            warnings.warn(
+                f"无法启动单次运行指标：{type(metrics_error).__name__}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._run_metrics_suppressed = True
+            try:
+                yield None
+            finally:
+                self._run_metrics_suppressed = False
+            return
+
+        self._active_run_metrics = recorder
+        status = "failed"
+        error: BaseException | None = None
+        try:
+            yield recorder
+            status = "completed"
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            try:
+                recorder.finish(self.client, status=status, error=error)
+            except Exception as metrics_error:
+                warnings.warn(
+                    f"无法保存单次运行指标：{type(metrics_error).__name__}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            self._active_run_metrics = None
+
+    @contextmanager
+    def _metric_stage(self, name: str) -> Iterator[None]:
+        """在已有运行账本中统计阶段耗时；无账本时保持原行为。"""
+        if self._active_run_metrics is None:
+            yield
+            return
+        with self._active_run_metrics.stage(name):
+            yield
+
+    def _measure_stage_call(
+        self,
+        name: str,
+        func: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """统计一次函数调用所属阶段，并原样返回结果或抛出异常。"""
+        with self._metric_stage(name):
+            return func(*args, **kwargs)
+
+    def _attach_metrics_store(self, store: RunStore) -> None:
+        """让顶层运行账本随当前书籍状态一起落盘。"""
+        if self._active_run_metrics is not None:
+            try:
+                self._active_run_metrics.attach_store(store)
+            except Exception as metrics_error:
+                warnings.warn(
+                    f"无法绑定单次运行指标：{type(metrics_error).__name__}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
     # ── 语言解析 ────────────────────────────────────────────────────────────
     def _apply_language(self, lang: str) -> None:
@@ -456,6 +606,7 @@ class Orchestrator:
         if not store.exists():
             raise ValueError("尚无翻译进度。请先运行 translate。")
         self._bind_llm_events(store)
+        self._attach_metrics_store(store)
         return store
 
     def prepare(self, input_path: str, *, progress: ProgressFn | None = None) -> RunStore:
@@ -470,6 +621,7 @@ class Orchestrator:
             run_dir = os.path.join(self.config.state_dir, slugify(pdf_title))
             store = RunStore(run_dir)
             self._bind_llm_events(store)
+            self._attach_metrics_store(store)
             with store.lock():
                 if store.exists():
                     store.log_event(
@@ -501,6 +653,7 @@ class Orchestrator:
         run_dir = os.path.join(self.config.state_dir, slugify(doc.title))
         store = RunStore(run_dir)
         self._bind_llm_events(store)
+        self._attach_metrics_store(store)
         with store.lock():
             return self._prepare_locked(doc, store, input_path, progress)
 
@@ -625,6 +778,7 @@ class Orchestrator:
             parts.append(f"【{tag}】\n{chunk}")
         return "\n\n".join(parts)
 
+    @_record_run_metrics("translate", ["translate"])
     def run(
         self,
         input_path: str,
@@ -633,10 +787,20 @@ class Orchestrator:
         progress: ProgressFn | None = None,
     ) -> RunStore:
         """准备运行状态并在书级锁内翻译待处理章节。"""
-        store = self.prepare(input_path, progress=progress)
+        store = self._measure_stage_call(
+            "prepare",
+            self.prepare,
+            input_path,
+            progress=progress,
+        )
         with store.lock():
-            return self._run_locked(store, only_chapter=only_chapter, progress=progress)
+            return self._run_locked(
+                store,
+                only_chapter=only_chapter,
+                progress=progress,
+            )
 
+    @_record_run_metrics("prepare", ["prepare", "understanding"])
     def prepare_for_translation(
         self,
         input_path: str,
@@ -648,12 +812,22 @@ class Orchestrator:
         包括文档解析、语言识别、风格/初始术语分析，以及配置开启时的
         逐章预扫和全书概览。所有阶段均可续跑，再次调用会复用已落盘结果。
         """
-        store = self.prepare(input_path, progress=progress)
+        store = self._measure_stage_call(
+            "prepare",
+            self.prepare,
+            input_path,
+            progress=progress,
+        )
         with store.lock():
             manifest = store.load_manifest()
             self._apply_language(manifest.get("source_lang") or self.config.source_lang)
             try:
-                self._build_understanding(store, progress=progress)
+                self._measure_stage_call(
+                    "understanding",
+                    self._build_understanding,
+                    store,
+                    progress=progress,
+                )
                 store.log_event(
                     "translation_prepared",
                     input_path=input_path,
@@ -685,7 +859,8 @@ class Orchestrator:
         )
         style = self.analyzer.style_brief(store.load_analysis() or {})
         # 翻译前预扫源文，建立全书理解（幂等、可续跑）；全书概览注入每章翻译
-        book_synopsis = self._build_understanding(store, progress=progress)
+        with self._metric_stage("understanding"):
+            book_synopsis = self._build_understanding(store, progress=progress)
 
         if only_chapter is not None:
             targets = [only_chapter]
@@ -703,25 +878,26 @@ class Orchestrator:
             total_segments=total,
         )
         try:
-            for ci in targets:
-                done = self._translate_chapter(
-                    ci,
-                    store,
-                    glossary,
-                    context,
-                    style,
-                    book_synopsis,
-                    translation_history=translation_history,
-                    source_corpus=source_corpus,
-                    progress=progress,
-                    done=done,
-                    total=total,
-                )
-                store.save_context(context.to_dict())
-                self._flush_usage(store, scope="chapter")
-            # 全书译完后翻译各章标题和目录项（书名保持原文，借术语表保持专名一致）
-            if not store.pending_chapters():
-                self._translate_titles(store, glossary, progress=progress)
+            with self._metric_stage("translate"):
+                for ci in targets:
+                    done = self._translate_chapter(
+                        ci,
+                        store,
+                        glossary,
+                        context,
+                        style,
+                        book_synopsis,
+                        translation_history=translation_history,
+                        source_corpus=source_corpus,
+                        progress=progress,
+                        done=done,
+                        total=total,
+                    )
+                    store.save_context(context.to_dict())
+                    self._flush_usage(store, scope="chapter")
+                # 全书译完后翻译各章标题和目录项（书名保持原文，借术语表保持专名一致）
+                if not store.pending_chapters():
+                    self._translate_titles(store, glossary, progress=progress)
         finally:
             glossary.close()
             self._flush_usage(store, scope="translate")
@@ -2845,6 +3021,7 @@ class Orchestrator:
     # ── 可选步骤 / 连续全流程 ────────────────────────────────────────────────
     ALL_STEPS = ("translate", "review", "report", "assemble")
 
+    @_record_run_metrics("review", ["review"])
     def run_review(
         self,
         input_path: str,
@@ -2852,12 +3029,19 @@ class Orchestrator:
         progress: ProgressFn | None = None,
     ) -> dict[str, Any]:
         """全量执行只读 Review，并保存正式结果、事件与用量。"""
-        store = self._locate_existing_store(input_path, progress=progress)
+        store = self._measure_stage_call(
+            "prepare",
+            self._locate_existing_store,
+            input_path,
+            progress=progress,
+        )
         with store.lock():
             manifest = store.load_manifest()
             self._apply_language(manifest.get("source_lang") or self.config.source_lang)
             terms = GlossaryStore.load_terms_readonly(store.glossary_path)
-            outcome = self._run_review_session(
+            outcome = self._measure_stage_call(
+                "review",
+                self._run_review_session,
                 store,
                 terms,
                 progress=progress,
@@ -2870,6 +3054,7 @@ class Orchestrator:
             "review_dir": outcome.run_dir,
         }
 
+    @_record_pipeline_metrics
     def run_steps(
         self,
         input_path: str,
@@ -2899,7 +3084,12 @@ class Orchestrator:
         if "translate" in steps:
             store = self.run(input_path, progress=progress)
         else:
-            store = self.prepare(input_path, progress=progress)
+            store = self._measure_stage_call(
+                "prepare",
+                self.prepare,
+                input_path,
+                progress=progress,
+            )
             m = store.load_manifest()
             self._apply_language(m.get("source_lang") or self.config.source_lang)
         with store.lock():
@@ -2942,7 +3132,9 @@ class Orchestrator:
             if "review" in steps:
                 # 先保存此前阶段的增量，使会话 usage.json 只包含 Review 调用。
                 self._flush_usage(store, scope="pipeline")
-                outcome = self._run_review_session(
+                outcome = self._measure_stage_call(
+                    "review",
+                    self._run_review_session,
                     store,
                     (
                         glossary.all_terms()
@@ -2962,7 +3154,12 @@ class Orchestrator:
                     raise RuntimeError("报告生成需要术语库")
                 if progress:
                     progress(0, 0, "生成报告…")
-                report = build_report(store, glossary)
+                report = self._measure_stage_call(
+                    "report",
+                    build_report,
+                    store,
+                    glossary,
+                )
                 store.save_report(report)
                 store.log_event("report_saved", path=store.report_path)
         finally:
@@ -2980,7 +3177,9 @@ class Orchestrator:
                 do_mono = True  # 兜底：mono/bilingual 都关时至少产一个单语产物
             if do_mono:
                 outputs.append(
-                    assemble(
+                    self._measure_stage_call(
+                        "assemble",
+                        assemble,
                         store,
                         input_path,
                         out_path=out_path,
@@ -2993,7 +3192,9 @@ class Orchestrator:
             if do_bilingual:
                 bi_out_path = bilingual_out_path(out_path) if out_path else None
                 outputs.append(
-                    assemble(
+                    self._measure_stage_call(
+                        "assemble",
+                        assemble,
                         store,
                         input_path,
                         out_path=bi_out_path,

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -25,6 +25,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import wraps
+from inspect import signature
 from threading import Lock
 from typing import Any, Iterator
 
@@ -63,7 +64,7 @@ from .context import RollingContext
 from .metrics import RunMetricsRecorder
 from .review_evidence import BookEvidenceIndex
 from .review_run import ReviewOutcome, ReviewRunStore
-from .runstore import STATUS_DONE, RunStore, slugify
+from .runstore import STATUS_DONE, RunStore, slugify, source_sha256
 
 ProgressFn = Callable[[int, int, str], None]
 
@@ -71,10 +72,14 @@ ProgressFn = Callable[[int, int, str], None]
 def _record_run_metrics(
     operation: str,
     requested_steps: list[str],
+    *,
+    invocation_fields: tuple[str, ...] = (),
 ) -> Callable:
     """为固定入口添加单次运行账本，同时允许入口之间安全嵌套。"""
 
     def decorator(func: Callable) -> Callable:
+        call_signature = signature(func)
+
         @wraps(func)
         def wrapped(
             self: Orchestrator,
@@ -82,10 +87,14 @@ def _record_run_metrics(
             *args: Any,
             **kwargs: Any,
         ) -> Any:
+            bound = call_signature.bind(self, input_path, *args, **kwargs)
+            bound.apply_defaults()
+            invocation = {name: bound.arguments.get(name) for name in invocation_fields}
             with self._run_metrics_session(
                 input_path,
                 operation=operation,
                 requested_steps=requested_steps,
+                invocation=invocation,
             ):
                 return func(self, input_path, *args, **kwargs)
 
@@ -97,6 +106,8 @@ def _record_run_metrics(
 def _record_pipeline_metrics(func: Callable) -> Callable:
     """为动态步骤集合建立单条顶层流水线账本。"""
 
+    call_signature = signature(func)
+
     @wraps(func)
     def wrapped(
         self: Orchestrator,
@@ -106,10 +117,22 @@ def _record_pipeline_metrics(func: Callable) -> Callable:
         **kwargs: Any,
     ) -> Any:
         normalized_steps = set(steps)
+        bound = call_signature.bind(
+            self,
+            input_path,
+            normalized_steps,
+            *args,
+            **kwargs,
+        )
+        bound.apply_defaults()
         with self._run_metrics_session(
             input_path,
             operation="pipeline",
             requested_steps=sorted(normalized_steps),
+            invocation={
+                "out_format": bound.arguments["out_format"],
+                "pdf_engine": bound.arguments["pdf_engine"],
+            },
         ):
             return func(
                 self,
@@ -467,6 +490,7 @@ class Orchestrator:
         *,
         operation: str,
         requested_steps: list[str],
+        invocation: dict[str, Any] | None = None,
     ) -> Iterator[RunMetricsRecorder | None]:
         """为一次顶层操作建立账本；嵌套入口复用同一记录。"""
         active = self._active_run_metrics
@@ -484,6 +508,7 @@ class Orchestrator:
                 input_path=input_path,
                 config=self.config,
                 client=self.client,
+                invocation=invocation,
             )
         except Exception as metrics_error:
             warnings.warn(
@@ -550,6 +575,45 @@ class Orchestrator:
                     stacklevel=2,
                 )
 
+    def _capture_metrics_state(self, store: RunStore) -> None:
+        """在书锁内冻结结束状态，防止等待进程污染本次账本。"""
+        if self._active_run_metrics is None:
+            return
+        try:
+            self._active_run_metrics.capture_state(store)
+        except Exception as metrics_error:
+            warnings.warn(
+                f"无法捕获单次运行结束状态：{type(metrics_error).__name__}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    def _source_sha256(self, input_path: str) -> str:
+        """在状态消费边界重新计算源文件哈希，不能信任锁外指标快照。"""
+        if self._active_run_metrics is not None:
+            verified = self._active_run_metrics.verify_input_sha256(input_path)
+            if verified is not None:
+                return verified
+        digest = source_sha256(input_path)
+        if self._active_run_metrics is not None:
+            self._active_run_metrics.input["sha256"] = digest
+        return digest
+
+    def _initial_source_sha256(self, input_path: str) -> str:
+        """取得解析前内容快照；有指标时复用其启动快照以少读一次文件。"""
+        if self._active_run_metrics is not None:
+            initial = self._active_run_metrics.input.get("sha256")
+            if isinstance(initial, str):
+                return initial
+        return source_sha256(input_path)
+
+    def _ensure_store_source(self, store: RunStore, input_path: str) -> str:
+        """校验候选状态确实属于当前输入文件。"""
+        return store.ensure_source_identity(
+            input_path,
+            actual_sha256=self._source_sha256(input_path),
+        )
+
     # ── 语言解析 ────────────────────────────────────────────────────────────
     def _apply_language(self, lang: str) -> None:
         """把解析出的源语言应用到 config 与各 agent（auto 检测后调用）。"""
@@ -573,6 +637,17 @@ class Orchestrator:
             self.annotation_aligner,
         ):
             ag.src = resolved
+            ag.tgt = self.config.target_lang
+
+    def _apply_manifest_languages(self, manifest: dict[str, Any]) -> None:
+        """从既有状态恢复源语言和目标语言，再同步给全部 agent。"""
+        target = manifest.get("target_lang")
+        if isinstance(target, str) and target:
+            self.config.target_lang = target
+        source = manifest.get("source_lang")
+        self._apply_language(
+            source if isinstance(source, str) and source else self.config.source_lang
+        )
 
     # ── 准备 / 续跑入口 ──────────────────────────────────────────────────
     def _locate_existing_store(
@@ -605,6 +680,8 @@ class Orchestrator:
         )
         if not store.exists():
             raise ValueError("尚无翻译进度。请先运行 translate。")
+        with store.lock():
+            self._ensure_store_source(store, input_path)
         self._bind_llm_events(store)
         self._attach_metrics_store(store)
         return store
@@ -624,6 +701,7 @@ class Orchestrator:
             self._attach_metrics_store(store)
             with store.lock():
                 if store.exists():
+                    self._ensure_store_source(store, input_path)
                     store.log_event(
                         "run_resumed",
                         input_path=input_path,
@@ -632,17 +710,30 @@ class Orchestrator:
                     return store
                 if progress:
                     progress(0, 0, "解析文档…")
+                source_hash = self._initial_source_sha256(input_path)
+                # 转换失败也要留下同源初始化标记，确保重试保留失败运行账本。
+                store.begin_initialization(source_hash)
                 doc = load_document(
                     input_path,
                     self.config.source_lang,
                     self.config.target_lang,
                     split_segments=self.config.segment.max_chars_per_segment,
                     cache_dir=store.source_dir,
+                    source_hash=source_hash,
                 )
-                return self._prepare_locked(doc, store, input_path, progress)
+                if self._source_sha256(input_path) != source_hash:
+                    raise ValueError("PDF 在解析期间发生变化；请确认文件稳定后重试。")
+                return self._prepare_locked(
+                    doc,
+                    store,
+                    input_path,
+                    progress,
+                    source_hash=source_hash,
+                )
 
         if progress:
             progress(0, 0, "解析文档…")
+        source_hash = self._initial_source_sha256(input_path)
         # 超长段按句拆分（max_chars_per_segment），续段标 cont 供回填并回
         doc = load_document(
             input_path,
@@ -650,12 +741,20 @@ class Orchestrator:
             self.config.target_lang,
             split_segments=self.config.segment.max_chars_per_segment,
         )
+        if self._source_sha256(input_path) != source_hash:
+            raise ValueError("源文件在解析期间发生变化；请确认文件稳定后重试。")
         run_dir = os.path.join(self.config.state_dir, slugify(doc.title))
         store = RunStore(run_dir)
         self._bind_llm_events(store)
         self._attach_metrics_store(store)
         with store.lock():
-            return self._prepare_locked(doc, store, input_path, progress)
+            return self._prepare_locked(
+                doc,
+                store,
+                input_path,
+                progress,
+                source_hash=source_hash,
+            )
 
     def _prepare_locked(
         self,
@@ -663,11 +762,17 @@ class Orchestrator:
         store: RunStore,
         input_path: str,
         progress: ProgressFn | None,
+        *,
+        source_hash: str | None = None,
     ) -> RunStore:
         """恢复已有状态；新运行分阶段写入，并以 manifest 原子提交完成标志。"""
         if store.exists():
+            self._ensure_store_source(store, input_path)
             store.log_event("run_resumed", input_path=input_path, run_dir=store.run_dir)
             return store  # 已有进度 → 直接续跑，不重置（语言在 run() 里按 manifest 应用）
+
+        initialization_hash = source_hash or self._source_sha256(input_path)
+        store.begin_initialization(initialization_hash)
 
         # 新建：auto 时只使用模型检测主要语言；失败则要求用户显式指定。
         if self.config.source_lang in ("auto", "", None):
@@ -684,7 +789,10 @@ class Orchestrator:
             store.log_event("language_detected", source_lang=doc.source_lang)
         self._apply_language(doc.source_lang)
 
-        manifest = store.stage_document(doc)
+        manifest = store.stage_document(
+            doc,
+            source_hash=initialization_hash,
+        )
         glossary = GlossaryStore(store.glossary_path)
         try:
             if progress:
@@ -704,6 +812,7 @@ class Orchestrator:
             # manifest 是初始化完成标志，必须最后原子落盘。
             manifest["initialized"] = True
             store.save_manifest(manifest)
+            store.finish_initialization()
             store.log_event(
                 "run_initialized",
                 input_path=input_path,
@@ -778,7 +887,11 @@ class Orchestrator:
             parts.append(f"【{tag}】\n{chunk}")
         return "\n\n".join(parts)
 
-    @_record_run_metrics("translate", ["translate"])
+    @_record_run_metrics(
+        "translate",
+        ["translate"],
+        invocation_fields=("only_chapter",),
+    )
     def run(
         self,
         input_path: str,
@@ -794,11 +907,13 @@ class Orchestrator:
             progress=progress,
         )
         with store.lock():
-            return self._run_locked(
+            result = self._run_locked(
                 store,
                 only_chapter=only_chapter,
                 progress=progress,
             )
+            self._capture_metrics_state(store)
+            return result
 
     @_record_run_metrics("prepare", ["prepare", "understanding"])
     def prepare_for_translation(
@@ -820,7 +935,7 @@ class Orchestrator:
         )
         with store.lock():
             manifest = store.load_manifest()
-            self._apply_language(manifest.get("source_lang") or self.config.source_lang)
+            self._apply_manifest_languages(manifest)
             try:
                 self._measure_stage_call(
                     "understanding",
@@ -835,6 +950,7 @@ class Orchestrator:
                 )
             finally:
                 self._flush_usage(store, scope="prepare")
+            self._capture_metrics_state(store)
         return store
 
     def _run_locked(
@@ -846,7 +962,7 @@ class Orchestrator:
     ) -> RunStore:
         """恢复语言和上下文，依次翻译章节并持续保存用量与进度。"""
         manifest = store.load_manifest()
-        self._apply_language(manifest.get("source_lang") or self.config.source_lang)
+        self._apply_manifest_languages(manifest)
         chapter_indices = {chapter.get("index") for chapter in manifest.get("chapters", [])}
         if only_chapter is not None and only_chapter not in chapter_indices:
             available = sorted(index for index in chapter_indices if isinstance(index, int))
@@ -2144,7 +2260,7 @@ class Orchestrator:
         debug.start(
             reviewed_content_digest=reviewed_content_digest,
             metadata={
-                "source_path": manifest.get("source_path"),
+                "source_sha256": manifest.get("source_sha256"),
                 "title": manifest.get("title"),
                 "source_lang": self.config.source_lang,
                 "target_lang": self.config.target_lang,
@@ -3037,7 +3153,7 @@ class Orchestrator:
         )
         with store.lock():
             manifest = store.load_manifest()
-            self._apply_language(manifest.get("source_lang") or self.config.source_lang)
+            self._apply_manifest_languages(manifest)
             terms = GlossaryStore.load_terms_readonly(store.glossary_path)
             outcome = self._measure_stage_call(
                 "review",
@@ -3046,6 +3162,7 @@ class Orchestrator:
                 terms,
                 progress=progress,
             )
+            self._capture_metrics_state(store)
         return {
             "store": store,
             "review_issues": outcome.issues,
@@ -3053,6 +3170,77 @@ class Orchestrator:
             "review_result": outcome.result,
             "review_dir": outcome.run_dir,
         }
+
+    def _run_existing_steps(
+        self,
+        input_path: str,
+        steps: set[str],
+        *,
+        progress: ProgressFn | None,
+        out_format: str = "epub",
+        out_path: str | None = None,
+        pdf_engine: str = "weasyprint",
+    ) -> dict[str, Any]:
+        """仅从既有状态执行本地收尾阶段，不创建新的翻译任务。"""
+        store = self._measure_stage_call(
+            "prepare",
+            self._locate_existing_store,
+            input_path,
+            progress=progress,
+        )
+        with store.lock():
+            manifest = store.load_manifest()
+            self._apply_manifest_languages(manifest)
+            result = self._finish_steps_locked(
+                store,
+                input_path=input_path,
+                steps=steps,
+                run_steps_input=sorted(steps),
+                progress=progress,
+                out_format=out_format,
+                out_path=out_path,
+                pdf_engine=pdf_engine,
+            )
+            self._capture_metrics_state(store)
+            return result
+
+    @_record_run_metrics("report", ["report"])
+    def run_report(
+        self,
+        input_path: str,
+        *,
+        progress: ProgressFn | None = None,
+    ) -> dict[str, Any]:
+        """从既有状态重新生成报告，并记录独立运行指标。"""
+        return self._run_existing_steps(
+            input_path,
+            {"report"},
+            progress=progress,
+        )
+
+    @_record_run_metrics(
+        "assemble",
+        ["assemble"],
+        invocation_fields=("out_format", "pdf_engine"),
+    )
+    def run_assemble(
+        self,
+        input_path: str,
+        *,
+        out_format: str = "epub",
+        out_path: str | None = None,
+        pdf_engine: str = "weasyprint",
+        progress: ProgressFn | None = None,
+    ) -> dict[str, Any]:
+        """从既有状态重新导出成品，并记录格式与 PDF 引擎。"""
+        return self._run_existing_steps(
+            input_path,
+            {"assemble"},
+            progress=progress,
+            out_format=out_format,
+            out_path=out_path,
+            pdf_engine=pdf_engine,
+        )
 
     @_record_pipeline_metrics
     def run_steps(
@@ -3091,9 +3279,9 @@ class Orchestrator:
                 progress=progress,
             )
             m = store.load_manifest()
-            self._apply_language(m.get("source_lang") or self.config.source_lang)
+            self._apply_manifest_languages(m)
         with store.lock():
-            return self._finish_steps_locked(
+            result = self._finish_steps_locked(
                 store,
                 input_path=input_path,
                 steps=steps,
@@ -3103,6 +3291,8 @@ class Orchestrator:
                 out_path=out_path,
                 pdf_engine=pdf_engine,
             )
+            self._capture_metrics_state(store)
+            return result
 
     def _finish_steps_locked(
         self,
@@ -3160,6 +3350,7 @@ class Orchestrator:
                     store,
                     glossary,
                 )
+                assert report is not None
                 store.save_report(report)
                 store.log_event("report_saved", path=store.report_path)
         finally:
@@ -3169,6 +3360,8 @@ class Orchestrator:
 
         outputs: list[str] = []
         if "assemble" in steps:
+            # 导出会重新读取源书模板；在读取前后都验证，避免运行期间替换文件。
+            self._ensure_store_source(store, input_path)
             if progress:
                 progress(0, 0, "回填译文…")
             out_cfg = self.config.output
@@ -3206,6 +3399,7 @@ class Orchestrator:
                         pdf_engine=pdf_engine,
                     )
                 )
+            self._ensure_store_source(store, input_path)
             store.log_event("assembled", outputs=outputs, out_format=out_format)
 
         store.log_event(

--- a/trans_novel/pipeline/runstore.py
+++ b/trans_novel/pipeline/runstore.py
@@ -16,9 +16,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
+import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -34,6 +36,15 @@ def slugify(name: str) -> str:
     """把书名转换为适合作为状态目录名的稳定短名。"""
     s = re.sub(r"[^\w一-鿿぀-ヿ-]+", "_", name).strip("_")
     return s or "book"
+
+
+def source_sha256(path: str) -> str:
+    """流式计算源文件 SHA-256，避免把整本书一次性读入内存。"""
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 class RunStore:
@@ -83,6 +94,11 @@ class RunStore:
     def manifest_path(self) -> str:
         """返回书籍清单文件路径。"""
         return os.path.join(self.run_dir, "manifest.json")
+
+    @property
+    def initialization_path(self) -> str:
+        """返回未完成初始化使用的临时源身份文件。"""
+        return os.path.join(self.run_dir, ".initializing.json")
 
     @property
     def context_path(self) -> str:
@@ -153,17 +169,83 @@ class RunStore:
         """判断运行状态是否已完成初始化并写入 manifest。"""
         return os.path.isfile(self.manifest_path)
 
+    def begin_initialization(self, source_hash: str) -> None:
+        """清理未完成初始化的派生状态，并记录本次源内容身份。
+
+        PDF 转换缓存按哈希隔离且代价较高，因此保留 ``source/``；同一源文件
+        的失败运行指标和事件也保留。章节、术语、分析等可变派生物一律重建，
+        防止上次在 manifest 提交前失败时留下的数据污染新任务。
+        """
+        if not re.fullmatch(r"[0-9a-f]{64}", source_hash):
+            raise ValueError("源文件 SHA-256 格式无效")
+
+        previous_hash: str | None = None
+        if os.path.isfile(self.initialization_path):
+            try:
+                marker = self._read_json(self.initialization_path)
+            except (OSError, json.JSONDecodeError, TypeError):
+                marker = None
+            if isinstance(marker, dict) and isinstance(marker.get("source_sha256"), str):
+                previous_hash = marker["source_sha256"]
+
+        shutil.rmtree(self.chapters_dir, ignore_errors=True)
+        os.makedirs(self.chapters_dir, exist_ok=True)
+        for path in (
+            self.analysis_path,
+            self.context_path,
+            self.glossary_path,
+            f"{self.glossary_path}-wal",
+            f"{self.glossary_path}-shm",
+            f"{self.glossary_path}-journal",
+            self.report_path,
+            self.usage_path,
+            f"{self.manifest_path}.tmp",
+        ):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+        if previous_hash != source_hash:
+            shutil.rmtree(self.reviews_dir, ignore_errors=True)
+            shutil.rmtree(self.run_metrics_dir, ignore_errors=True)
+            try:
+                os.remove(self.event_log_path)
+            except FileNotFoundError:
+                pass
+
+        self._batch_glossary_event_cache = None
+        self._write_json(
+            self.initialization_path,
+            {"source_sha256": source_hash},
+        )
+
+    def finish_initialization(self) -> None:
+        """在 manifest 已成功提交后清除临时初始化身份。"""
+        try:
+            os.remove(self.initialization_path)
+        except FileNotFoundError:
+            pass
+
     # ── manifest ──────────────────────────────────────────────────────────
-    def stage_document(self, doc: Document) -> dict:
+    def stage_document(
+        self,
+        doc: Document,
+        *,
+        source_hash: str | None = None,
+    ) -> dict:
         """写入初始章节文件并返回 manifest 内容，但不提前写 manifest。
 
         manifest 是一次运行初始化完成的标志，由调用方在分析、术语库
         和上下文都已落盘后最后保存。
         """
+        digest = source_hash or source_sha256(doc.source_path)
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError("源文件 SHA-256 格式无效")
         manifest = {
             "title": doc.title,
             "fmt": doc.fmt,
-            "source_path": doc.source_path,
+            "source_sha256": digest,
             "source_lang": doc.source_lang,
             "target_lang": doc.target_lang,
             "meta": doc.meta,
@@ -181,6 +263,30 @@ class RunStore:
         for c in doc.chapters:
             self.save_chapter(c)
         return manifest
+
+    def ensure_source_identity(
+        self,
+        input_path: str,
+        *,
+        actual_sha256: str | None = None,
+    ) -> str:
+        """校验输入内容属于当前状态；缺少内容身份的旧状态直接拒绝。"""
+        actual = actual_sha256 or source_sha256(input_path)
+        if not re.fullmatch(r"[0-9a-f]{64}", actual):
+            raise ValueError("源文件 SHA-256 格式无效")
+
+        manifest = self.load_manifest()
+        expected = manifest.get("source_sha256")
+        if not isinstance(expected, str) or not re.fullmatch(r"[0-9a-f]{64}", expected):
+            raise ValueError(
+                "现有翻译状态缺少有效的 source_sha256；请删除该状态目录并重新建立翻译状态。"
+            )
+        if expected != actual:
+            raise ValueError(
+                "输入文件内容与现有翻译状态不一致（状态目录同名）；请使用原始源文件，"
+                "或移走该状态目录后重新建立。"
+            )
+        return actual
 
     def save_manifest(self, manifest: dict) -> None:
         """原子保存书籍清单和章节状态。"""

--- a/trans_novel/pipeline/runstore.py
+++ b/trans_novel/pipeline/runstore.py
@@ -7,6 +7,7 @@
   context.json      滚动上下文（梗概 + 前文尾段）
   analysis.json     全局分析结果
   usage.json        本书跨 translate/resume 累计的 LLM token 用量
+  run_metrics/      每次顶层运行独立的耗时、用量和版本账本
   glossary.db       术语库 + 译法冲突记录
   report.json       翻译报告
   events.jsonl      追加式行为 / 改写 / 翻译结果日志
@@ -107,6 +108,11 @@ class RunStore:
     def usage_path(self) -> str:
         """返回本书累计 token 用量文件路径。"""
         return os.path.join(self.run_dir, "usage.json")
+
+    @property
+    def run_metrics_dir(self) -> str:
+        """返回每次运行独立指标账本的目录。"""
+        return os.path.join(self.run_dir, "run_metrics")
 
     @property
     def event_log_path(self) -> str:
@@ -253,6 +259,27 @@ class RunStore:
             if isinstance(result, dict):
                 return result
         return None
+
+    def save_run_metric(self, record: dict[str, Any]) -> str:
+        """按 run_id 原子保存一次运行指标并返回文件路径。"""
+        run_id = record.get("run_id")
+        if not isinstance(run_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}", run_id
+        ):
+            raise ValueError("run_id 只能包含字母、数字、点、下划线、加号和连字符")
+        path = os.path.join(self.run_metrics_dir, f"{run_id}.json")
+        self._write_json(path, record)
+        return path
+
+    def load_run_metrics(self) -> list[dict[str, Any]]:
+        """按文件名顺序读取全部单次运行账本。"""
+        if not os.path.isdir(self.run_metrics_dir):
+            return []
+        return [
+            self._read_json(os.path.join(self.run_metrics_dir, name))
+            for name in sorted(os.listdir(self.run_metrics_dir))
+            if name.endswith(".json")
+        ]
 
     # ── 批次恢复检查点 ────────────────────────────────────────────────────
     @staticmethod


### PR DESCRIPTION
## 背景

现有的 `usage.json` 是一本书跨多次翻译与续跑的累计总账。它无法回答“某个分支的一次完整运行具体用了多少调用、token 和时间”，因此也无法对原作者最新版与后续质量重构做可信的 A/B 比较。

本 PR 是质量流水线重构的第 1 步：**只建立测量基线，不改变翻译、润色、审校或自动修复策略。**

## 主要改动

- 每个顶层的准备、翻译、审校或完整流水线命令，都会生成独立的 `state/<书名>/run_metrics/<run-id>.json`。
- 单次账本记录输入文件指纹、非敏感配置指纹、程序包与 Git 版本、请求阶段、各阶段墙钟耗时、本次新增的模型调用/token，以及结束时的章节和正文段完成度。
- 嵌套入口只生成一条记录；每次续跑都会新建记录，不再把本次成本与历史累计成本混在一起。
- 不保存书籍正文或完整源文件路径；常见密钥字段会被遮蔽，失败时只记录异常类型。
- 指标写入失败只发出警告，不会让已经正常工作的翻译流水线失败。

## 兼容性与影响

- 原有 `usage.json` 的累计语义保持不变，现有调用方无需迁移。
- 新账本只写入本地 `state/` 运行目录；该目录已被 Git 忽略，不会提交书籍、中间产物或密钥。
- 本 PR 不新增模型调用，也不改变译文、报告或 EPUB 的生成逻辑。
- 后续 PR 可以据此比较“质量提升了多少、耗时和 token 增加或减少多少”，而不是依赖一次混合总账。

## 验证

- `.venv/Scripts/python.exe -m pytest tests/test_usage.py -q`：**24 passed**
- `.venv/Scripts/python.exe -m pytest -q -k "not test_bilingual_suffix and not test_mono_suffix_unchanged"`：**257 passed, 2 deselected, 25 subtests passed**
- 未过滤全量测试：**257 passed, 2 failed, 25 subtests passed**。两个失败均为原作者最新版已有的 Windows 路径断言：测试写死了 POSIX 的 `/tmp/output`，Windows 会返回对应的本地路径；本 PR 未修改该输出路径逻辑。
