### PR TITLE
Add per-run debug review usage metrics

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -52,12 +52,15 @@ uv run trans-novel review book.epub
 The explicit command runs even when `pipeline.review` is disabled. Every invocation
 reviews the complete translated book from the beginning. It never fixes text and
 does not update chapter JSON, the manifest, `report.json`, the formal event log, or
-`usage.json`. Prompts, raw responses, parsed actions, requested evidence, events,
-and final suggestions are written only to:
+the formal `usage.json`. Prompts, raw responses, parsed actions, requested evidence,
+events, final suggestions, and the run-local usage delta are written only to:
 
 ```text
 state/<book>/debug/review-YYYYMMDD-HHMMSS-ffffff/
 ```
+
+The debug directory contains its own `usage.json` with totals plus `by_tier` and
+`by_stage` breakdowns. It is written for both successful and failed review runs.
 
 These debug traces contain source and translated passages. Treat them with the
 same privacy and copyright care as the rest of the state directory.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -138,9 +138,11 @@ unchanged initial Reviewer runs over contiguous chunks concurrently; candidates
 can then enter a bounded evidence loop, and contradictory cross-chunk consistency
 suggestions can receive a final recommendation. Review never fixes the body and
 does not update the manifest, chapter JSON, `report.json`, the formal event log, or
-`usage.json`. Each run writes prompts, raw responses, parsed actions, requested
-evidence, events, and suggestions to
+the formal `usage.json`. Each run writes prompts, raw responses, parsed actions,
+requested evidence, events, suggestions, and its model-usage delta to
 `state/<book>/debug/review-<timestamp>/`.
+The debug directory's `usage.json` includes totals plus `by_tier` and `by_stage`
+breakdowns and is retained on both success and failure.
 
 `qa` and `report` collect problems without modifying translated text. `assemble`
 rebuilds output from existing state without calling the model again.

--- a/docs/zh/pipeline.md
+++ b/docs/zh/pipeline.md
@@ -50,12 +50,15 @@ uv run trans-novel review book.epub
 
 即使关闭 `pipeline.review`，显式调用上述命令仍会执行审校。每次运行都会从头
 审查完整译文，不修复正文，也不会更新章节 JSON、manifest、`report.json`、
-正式 `events.jsonl` 或 `usage.json`。提示词、原始响应、解析后的动作、取证结果、
-事件和最终建议只写入：
+正式 `events.jsonl` 或正式 `usage.json`。提示词、原始响应、解析后的动作、
+取证结果、事件、最终建议和本次运行的用量增量只写入：
 
 ```text
 state/<书名>/debug/review-YYYYMMDD-HHMMSS-ffffff/
 ```
+
+该调试目录内有独立的 `usage.json`，包含总量及 `by_tier`、`by_stage` 明细；
+无论审校成功还是失败都会保留。
 
 调试记录包含原文和译文片段，应与其他状态文件一样注意隐私与版权。
 

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -132,8 +132,10 @@ uv run trans-novel assemble book.epub
 `review` 会使用最终术语库检查完整译文。原有 Reviewer 提示词先并发检查连续
 文本块；候选问题随后可进入有界取证循环，互相矛盾的跨块一致性建议还可获得
 终局建议。Review 不修复正文，也不更新 manifest、章节 JSON、`report.json`、
-正式事件日志或 `usage.json`。每次运行的提示词、原始响应、解析动作、取证结果、
-事件和建议会写入 `state/<书名>/debug/review-<时间戳>/`。
+正式事件日志或正式 `usage.json`。每次运行的提示词、原始响应、解析动作、
+取证结果、事件、建议和模型用量增量会写入
+`state/<书名>/debug/review-<时间戳>/`。调试目录内独立的 `usage.json` 包含
+总量及 `by_tier`、`by_stage` 明细，无论成功还是失败都会保留。
 
 `qa` 和 `report` 默认只汇总问题，不会修改正文；`assemble` 可在不重新调用模型
 的情况下重新导出已有译文。

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -504,6 +504,14 @@ class TestReviewReporting(unittest.TestCase):
             }
             self.assertEqual(formal_after, formal_before)
             self.assertTrue(os.path.isfile(os.path.join(result["debug_dir"], "result.json")))
+            with open(
+                os.path.join(result["debug_dir"], "usage.json"),
+                encoding="utf-8",
+            ) as file:
+                debug_usage = json.load(file)
+            self.assertGreater(debug_usage["totals"]["calls"], 0)
+            self.assertIn("Reviewer", debug_usage["by_stage"])
+            self.assertNotIn("Translator", debug_usage["by_stage"])
             self.assertGreater(
                 client.usage_summary()["by_stage"]["Reviewer"]["calls"],
                 0,
@@ -762,6 +770,14 @@ class TestReviewReporting(unittest.TestCase):
                 receipt = json.load(file)
             self.assertEqual(receipt["status"], "failed")
             self.assertEqual(receipt["error_type"], "RuntimeError")
+            with open(
+                os.path.join(debug_root, runs[-1], "usage.json"),
+                encoding="utf-8",
+            ) as file:
+                debug_usage = json.load(file)
+            self.assertEqual(debug_usage["totals"]["calls"], 1)
+            self.assertEqual(debug_usage["totals"]["total_tokens"], 8)
+            self.assertEqual(debug_usage["by_stage"]["Reviewer"]["calls"], 1)
             self.assertEqual(Path(store.usage_path).read_bytes(), usage_before)
             self.assertEqual(Path(store.event_log_path).read_bytes(), events_before)
             self.assertEqual(client.usage_summary()["by_stage"]["Reviewer"]["calls"], 1)

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -1158,6 +1158,17 @@ class Orchestrator:
                 "review_conflict_arbitration": (self.config.pipeline.review_conflict_arbitration),
             },
         )
+        usage_before = self.client.usage_summary()
+
+        def save_debug_usage() -> dict[str, Any]:
+            """保存本次实验 Review 的用量增量，不写入正式 usage.json。"""
+            usage = usage_delta(self.client.usage_summary(), usage_before)
+            debug.write_json("usage.json", usage)
+            debug.log_event(
+                "review_debug_usage_recorded",
+                **usage["totals"],
+            )
+            return usage
 
         done = 0
         raw_issues: list[dict[str, Any]] = []
@@ -1302,6 +1313,7 @@ class Orchestrator:
                 },
             )
             debug.write_json("summary.json", summary)
+            save_debug_usage()
             debug.finish(status="finished", **summary)
             return final_issues
         except Exception as error:
@@ -1309,6 +1321,7 @@ class Orchestrator:
             debug.write_json("initial_issues.json", initial_issues)
             debug.write_json("dismissed_issues.json", dismissed)
             debug.write_json("partial_issues.json", raw_issues)
+            save_debug_usage()
             debug.finish(
                 status="failed",
                 issue_count=len(raw_issues),


### PR DESCRIPTION
## Summary

- snapshot cumulative model usage immediately before an experimental full-book Review starts
- write that run's delta to `debug/review-<timestamp>/usage.json` on both success and failure
- preserve the existing boundary: experimental Review still does not update the book-level formal `usage.json` or formal event log
- document the artifact in English and Chinese, with regression coverage for successful and failed runs

## Why

PR #110 intentionally excludes experimental Review calls from formal book usage. That keeps production accounting clean, but it also leaves each debug run without a cost receipt, which makes A/B comparisons difficult. A run-local artifact preserves both boundaries.

## Output shape

The debug `usage.json` uses the existing provider-independent summary schema:

- `totals`
- `by_tier`
- `by_stage`

This keeps Reviewer, ReviewAgent, and ReviewArbiter attribution available without introducing a second accounting format.

## Validation

- `ruff check trans_novel/pipeline/orchestrator.py tests/test_orchestrator.py` — passed
- `ruff format --check trans_novel/pipeline/orchestrator.py tests/test_orchestrator.py` — passed
- targeted orchestrator regression tests — 3 passed, including 2 subtests
- full `pytest -q` — 308 passed; 3 unrelated Windows-only failures were reproduced unchanged on the unmodified latest `dev` checkout (`/tmp/output` path expectations and a locked SQLite temp file)

## Scope

This is a small stacked PR targeting `feat/review-agent-loop` from PR #110. It does not contain translation content, state files, generated books, or secrets.
