### PR TITLE
Fix Windows test portability

### DIFF
--- a/tests/test_bilingual.py
+++ b/tests/test_bilingual.py
@@ -295,14 +295,18 @@ class TestAssembleTextBilingual(unittest.TestCase):
 
 class TestDefaultOutBilingual(unittest.TestCase):
     def test_bilingual_suffix(self):
-        out = _default_out("/tmp/novel.txt", "epub", "", bilingual=True)
-        self.assertEqual(os.path.basename(out), "novel.zh-bi.epub")
-        self.assertEqual(os.path.dirname(out), "/tmp/output")
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            out = _default_out(source, "epub", "", bilingual=True)
+            self.assertEqual(os.path.basename(out), "novel.zh-bi.epub")
+            self.assertEqual(os.path.dirname(out), os.path.join(directory, "output"))
 
     def test_mono_suffix_unchanged(self):
-        out = _default_out("/tmp/novel.txt", "epub", "")
-        self.assertEqual(os.path.basename(out), "novel.zh.epub")
-        self.assertEqual(os.path.dirname(out), "/tmp/output")
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "novel.txt")
+            out = _default_out(source, "epub", "")
+            self.assertEqual(os.path.basename(out), "novel.zh.epub")
+            self.assertEqual(os.path.dirname(out), os.path.join(directory, "output"))
 
 
 class TestOutputConfigParsing(unittest.TestCase):

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
 
 from trans_novel.glossary.store import (
     TYPE_APPELLATION,
@@ -186,7 +187,7 @@ class TestGlossary(unittest.TestCase):
 
     def test_opening_store_removes_legacy_translation_memory_table(self):
         self.store.close()
-        with sqlite3.connect(self.store.db_path) as conn:
+        with closing(sqlite3.connect(self.store.db_path)) as conn:
             conn.execute(
                 """CREATE TABLE translation_memory (
                     source_hash TEXT PRIMARY KEY,
@@ -195,6 +196,7 @@ class TestGlossary(unittest.TestCase):
                 )"""
             )
             conn.execute("INSERT INTO translation_memory VALUES ('hash', 'source', 'target')")
+            conn.commit()
 
         self.store = GlossaryStore(self.store.db_path)
         row = self.store.conn.execute(


### PR DESCRIPTION
## Summary

- make default-output path tests use the platform-native temporary directory instead of hard-coded `/tmp` paths
- explicitly close the temporary legacy SQLite connection used by the glossary migration test
- keep the change tests-only; production path and glossary behavior are unchanged

## Why

The full suite had three deterministic failures on Windows:

1. two assertions expected the Unix-only string `/tmp/output`, even though `_default_out()` correctly normalizes paths for the host OS
2. `sqlite3.Connection`'s context manager commits or rolls back a transaction but does not close the connection, so Windows kept `g.db` locked during temporary-directory cleanup

Using `TemporaryDirectory()` plus `os.path.join()` makes the path assertions portable. Wrapping the setup connection in `contextlib.closing()` releases the database handle before teardown.

## Validation

- `ruff check tests/test_bilingual.py tests/test_glossary.py` — passed
- `ruff format --check tests/test_bilingual.py tests/test_glossary.py` — passed
- full `pytest -q` on Windows — `279 passed, 28 subtests passed`

No production files, book data, state files, or secrets are included.
