### PR TITLE
Respect conflicted glossary terms during review

### DIFF
--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -123,10 +123,41 @@ class TestBookEvidenceIndex(unittest.TestCase):
         self.assertEqual(result["term"]["source"], "Ann")
         self.assertEqual(result["term"]["target"], "安")
         self.assertEqual(result["term"]["aliases"], ["Annie"])
+        self.assertEqual(result["term"]["status"], "ok")
+        self.assertTrue(result["term"]["authoritative"])
         self.assertEqual(
             BookEvidenceIndex.evidence_refs(result),
             {result["term"]["ref"]},
         )
+
+    def test_conflicted_person_term_preserves_case_and_is_not_authoritative(self):
+        term = GlossaryTerm(
+            source="Giant",
+            target="巨指",
+            type="人物",
+            status="conflict",
+        )
+        index = BookEvidenceIndex(
+            [
+                _chapter(
+                    0,
+                    [
+                        ("The giant fingers held the ship.", "巨指固定住飞船。"),
+                        ("The Giant leaned closer.", "巨人靠近了。"),
+                    ],
+                )
+            ],
+            [term],
+            {},
+        )
+
+        result = index.term_occurrences({"term": "Giant", "selectors": [1], "context_radius": 0})
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["total_matches"], 1)
+        self.assertEqual(result["selected"][0]["source"], "The Giant leaned closer.")
+        self.assertEqual(result["glossary_term"]["status"], "conflict")
+        self.assertFalse(result["glossary_term"]["authoritative"])
 
     def test_exact_source_wins_over_another_terms_same_alias(self):
         other = GlossaryTerm(source="Anne", target="安妮", aliases=["Ann"], type="人物")

--- a/tests/test_review_polish.py
+++ b/tests/test_review_polish.py
@@ -11,6 +11,7 @@ import unittest
 from trans_novel.agents.polisher import Polisher
 from trans_novel.agents.reviewer import BackTranslator, Reviewer, ReviewOutputError
 from trans_novel.config import Config
+from trans_novel.glossary.store import GlossaryTerm
 from trans_novel.ingest.models import Segment
 from trans_novel.llm.providers.fake import FakeClient
 from trans_novel.pipeline.orchestrator import Orchestrator
@@ -61,6 +62,29 @@ class TestReviewer(unittest.TestCase):
         out = r.review(["あ", "い"], ["甲", "乙"])
         self.assertEqual(len(out), 2)
         self.assertEqual(client.calls[-1]["tier"], "cheap")  # 审校走廉价档
+
+    def test_reviewer_excludes_conflicted_glossary_terms(self):
+        def handler(messages, tier, json_mode):
+            prompt = messages[-1]["content"]
+            self.assertIn("Stable → 稳定", prompt)
+            self.assertNotIn("Giant → 巨指", prompt)
+            return _review_response([], 1)
+
+        reviewer = Reviewer(FakeClient(handler=handler), _cfg())
+
+        reviewer.review(
+            ["The Giant arrived."],
+            ["巨人来了。"],
+            [
+                GlossaryTerm(source="Stable", target="稳定", status="ok"),
+                GlossaryTerm(
+                    source="Giant",
+                    target="巨指",
+                    type="人物",
+                    status="conflict",
+                ),
+            ],
+        )
 
     def test_reviewer_drops_fields_outside_the_initial_issue_contract(self):
         """廉价初审不能绕过强档 Agent 注入跨块一致性 claim。"""

--- a/trans_novel/agents/prompts.py
+++ b/trans_novel/agents/prompts.py
@@ -99,7 +99,8 @@ $pairs
 REVIEW_EVIDENCE_TOOLS = """\
 可用只读工具及 arguments：
 1. glossary_term：按原文术语或 alias 读取一个术语库条目。
-   {"term":"原文术语或别名"}；不得请求或枚举全量术语表。
+   {"term":"原文术语或别名"}；不得请求或枚举全量术语表。返回条目的
+   status 非 ok 或 authoritative=false 时表示译法仍有冲突，不得作为强制译法。
 2. term_occurrences：按术语在全书中命中的段落次序取证。
    {"term":"原文术语或别名","selectors":[1,3,"first","middle","last"],"context_radius":0}；
    selectors 最多 8 项，context_radius 为 0..2。不得请求全量正文。

--- a/trans_novel/agents/reviewer.py
+++ b/trans_novel/agents/reviewer.py
@@ -64,7 +64,9 @@ class Reviewer(Agent):
             "reviewer_user",
             src=self.src,
             tgt=self.tgt,
-            glossary=prompts.render_glossary(glossary_terms or []),
+            glossary=prompts.render_glossary(
+                [term for term in (glossary_terms or []) if getattr(term, "status", "ok") == "ok"]
+            ),
             n=len(sources),
             pairs=prompts.numbered_pairs(sources, targets),
         )

--- a/trans_novel/glossary/store.py
+++ b/trans_novel/glossary/store.py
@@ -100,10 +100,15 @@ def _match_text(text: str) -> str:
 _WORD_BOUNDARY_SCRIPTS = ("LATIN", "GREEK", "CYRILLIC")
 
 
-def _source_pattern(key: str) -> re.Pattern[str] | None:
+def _source_pattern(
+    key: str,
+    *,
+    case_sensitive: bool = False,
+) -> re.Pattern[str] | None:
     """为空格分词文字构造边界正则；连续书写文字返回 None 使用子串匹配。"""
     if key.isascii():
-        return re.compile(rf"(?<![a-z0-9_]){re.escape(key)}(?![a-z0-9_])")
+        boundary = "A-Za-z0-9_" if case_sensitive else "a-z0-9_"
+        return re.compile(rf"(?<![{boundary}]){re.escape(key)}(?![{boundary}])")
 
     letters = [char for char in key if char.isalpha()]
     if not letters or not all(
@@ -117,17 +122,25 @@ def _source_pattern(key: str) -> re.Pattern[str] | None:
     return re.compile(f"{left_boundary}{re.escape(key)}{right_boundary}")
 
 
-def source_matches_text(source: str, text: str) -> bool:
+def source_matches_text(
+    source: str,
+    text: str,
+    *,
+    case_sensitive: bool = False,
+) -> bool:
     """判断术语原文是否出现，并避免空格分词文字命中更长单词。
 
     CJK 等连续书写文字沿用规范化子串匹配；ASCII、拉丁、希腊和西里尔文字
     检查单词边界，避免 ``Ann`` 命中 ``Anna``、``гад`` 命中 ``гадкий``。
+    冲突人物等需要区分专名/普通词义时可保留大小写，避免 ``Giant`` 命中
+    ``giant fingers``。
     """
-    key = _match_text(source).strip()
+    normalize = unicodedata.normalize
+    key = normalize("NFKC", source).strip() if case_sensitive else _match_text(source).strip()
     if not key:
         return False
-    normalized_text = _match_text(text)
-    if pattern := _source_pattern(key):
+    normalized_text = normalize("NFKC", text) if case_sensitive else _match_text(text)
+    if pattern := _source_pattern(key, case_sensitive=case_sensitive):
         return pattern.search(normalized_text) is not None
     return key in normalized_text
 

--- a/trans_novel/pipeline/review_evidence.py
+++ b/trans_novel/pipeline/review_evidence.py
@@ -181,10 +181,18 @@ class BookEvidenceIndex:
             return canonical, cached, []
 
         keys = term_match_sources(term) if term is not None else [canonical]
+        preserve_case = term is not None and term.status != "ok"
         found = tuple(
             segment
             for segment in self.segments
-            if any(source_matches_text(key, segment.source) for key in keys)
+            if any(
+                source_matches_text(
+                    key,
+                    segment.source,
+                    case_sensitive=preserve_case,
+                )
+                for key in keys
+            )
         )
         with self._cache_lock:
             existing = self._occurrence_cache.setdefault(cache_key, found)
@@ -274,6 +282,8 @@ class BookEvidenceIndex:
             "aliases": [_clip(alias, 256) for alias in term.aliases[:16]],
             "first_chapter": term.first_chapter,
             "note": _clip(term.note, 2000),
+            "status": _clip(term.status, 64),
+            "authoritative": term.status == "ok",
         }
 
     def glossary_term(self, arguments: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- keep glossary entries with `status=conflict` out of the initial Reviewer's authoritative glossary prompt
- expose glossary `status` and an explicit `authoritative` flag to the evidence-driven Review Agent
- preserve case while searching occurrences of unresolved glossary entries, so a conflicted person name such as `Giant` does not also match the ordinary phrase `giant fingers`
- add regression coverage for both the Reviewer prompt and evidence lookup

## Why

A three-run repeatability audit of the same frozen long-form translation state showed that one conflicted glossary entry could dominate the review:

- two runs produced 16 identical terminology findings in the same chunk
- the third run produced none for the same prompt and chunk plan
- the glossary row already had `status=conflict`, but that status was neither enforced by the initial Reviewer nor visible in Agent evidence

The current implementation therefore presents an unresolved candidate translation as an authoritative rule. Case-insensitive occurrence lookup can then mix the proper-name sense with an unrelated lowercase phrase and reinforce the bad rule.

## Impact

This change narrows the trust boundary without discarding evidence:

- the cheap Reviewer no longer creates hard terminology findings from unresolved glossary rows
- the strong Agent may still query the row, but it can see that the row is not authoritative
- unresolved term occurrence search is less likely to mix proper-name and common-word senses

Resolved (`status=ok`) glossary behavior remains unchanged.

## Validation

- `ruff check` on all changed Python files — passed
- `ruff format --check` on all changed Python files — passed
- `python -m unittest tests.test_review_agent tests.test_review_polish tests.test_glossary.TestGlossary.test_ascii_source_match_respects_word_boundaries` — 47 tests passed
- full Windows unittest discovery reached 302 tests; the only failures were the same two Unix-only path assertions and one SQLite cleanup lock already isolated in #113

No book data, translation state, API keys, or generated outputs are included.

## Full-book release-gate follow-up

A full-book run against the latest PR #110 head confirmed the trust-boundary failure: a conflicted `Giant → 巨指` entry caused 18 incorrect shadow replacements in chapter 6. Later review rounds stopped reporting those replacements, so rereview alone did not recover the frozen baseline. This confirms that conflicted glossary entries must be withheld from authoritative review constraints rather than treated as canonical translations.

After rebasing onto `6e20583`, the full Windows unittest discovery passes: 324 tests. Ruff check and format check also pass.