### PR TITLE
Recover valid review agent evidence and JSON output

### DIFF
--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -560,7 +560,7 @@ class TestReviewAgentLoop(unittest.TestCase):
                                 "kind": "term",
                                 "proposed_value": "安",
                             },
-                            "evidence_refs": ["ch0:text0:seg0"],
+                            "evidence_refs": ["term-1"],
                         }
                     ],
                     "new_issues": [
@@ -623,6 +623,63 @@ class TestReviewAgentLoop(unittest.TestCase):
         self.assertIn("parsed", trace["turns"][0])
         self.assertIn("evidence_results", trace["turns"][0])
         self.assertTrue(any(event["event"] == "review_evidence_supplied" for event in events))
+
+    def test_malformed_agent_output_is_retried_once(self):
+        calls = 0
+
+        def handler(messages, tier, json_mode):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return ""
+            self.assertIn("不是完整有效的 JSON", messages[-1]["content"])
+            return json.dumps(
+                {
+                    "action": "final",
+                    "decisions": [
+                        {
+                            "candidate_id": "ch0-base0-candidate0",
+                            "verdict": "confirmed",
+                            "detail": "确认漏译",
+                            "suggestion": "补译",
+                            "reason": "",
+                            "consistency": {},
+                            "evidence_refs": [],
+                        }
+                    ],
+                    "new_issues": [],
+                    "complete": True,
+                },
+                ensure_ascii=False,
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            outcome = ReviewAgentLoop(
+                FakeClient(handler=handler),
+                _config(),
+                self._evidence(),
+                debug,
+            ).review_chunk(
+                chapter=0,
+                chunk_base=0,
+                sources=["Ann arrived."],
+                targets=["安到了。"],
+                initial_issues=[
+                    {
+                        "index": 0,
+                        "type": "missing",
+                        "detail": "初审候选",
+                        "suggestion": "补译",
+                    }
+                ],
+            )
+            with open(debug.path("events.jsonl"), encoding="utf-8") as file:
+                events = [json.loads(line) for line in file]
+
+        self.assertEqual(calls, 2)
+        self.assertEqual(outcome.fallback_reason, "")
+        self.assertTrue(any(event["event"] == "review_agent_output_retry" for event in events))
 
     def test_dismissed_summary_is_self_contained_and_links_to_initial_candidate(self):
         initial = {
@@ -933,6 +990,76 @@ class TestReviewAgentLoop(unittest.TestCase):
 
 
 class TestReviewConflictArbiter(unittest.TestCase):
+    def test_arbiter_expands_successful_evidence_request_id(self):
+        evidence = BookEvidenceIndex(
+            [_chapter(0, [("Ann.", "安。"), ("Ann.", "安妮。")])],
+            [GlossaryTerm(source="Ann", target="安", type="人物")],
+            {},
+        )
+        issues = normalize_review_issues(
+            [
+                {
+                    "chapter": 0,
+                    "index": index,
+                    "_chunk_id": f"chunk-{index}",
+                    "type": "terminology",
+                    "detail": "译名问题",
+                    "suggestion": f"统一为{proposed}",
+                    "consistency": {
+                        "kind": "term",
+                        "subject_source": "Ann",
+                        "proposed_value": proposed,
+                    },
+                }
+                for index, proposed in enumerate(("安", "安妮"))
+            ],
+            evidence,
+        )
+        conflict = build_conflict_groups(issues)[0]
+        calls = 0
+
+        def handler(messages, tier, json_mode):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return json.dumps(
+                    {
+                        "action": "request_evidence",
+                        "requests": [
+                            {
+                                "request_id": "arb-1",
+                                "tool": "glossary_term",
+                                "arguments": {"term": "Ann"},
+                            }
+                        ],
+                        "complete": False,
+                    }
+                )
+            return json.dumps(
+                {
+                    "action": "final",
+                    "conflict_id": conflict["conflict_id"],
+                    "status": "suggested",
+                    "recommended_value": "安",
+                    "reason": "术语证据支持现有译名。",
+                    "evidence_refs": ["arb-1"],
+                    "complete": True,
+                },
+                ensure_ascii=False,
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            result = ReviewConflictArbiter(
+                FakeClient(handler=handler),
+                _config(),
+                evidence,
+                ReviewRunStore(directory),
+            ).arbitrate(conflict)
+
+        expected_ref = evidence.glossary_term({"term": "Ann"})["term"]["ref"]
+        self.assertEqual(result["status"], "suggested")
+        self.assertEqual(result["evidence_refs"], [expected_ref])
+
     def test_conflicting_cross_chunk_claims_are_arbitrated(self):
         evidence = BookEvidenceIndex(
             [_chapter(0, [("Ann.", "安。"), ("Ann.", "安妮。")])],

--- a/trans_novel/agents/prompts.py
+++ b/trans_novel/agents/prompts.py
@@ -148,7 +148,8 @@ $review_evidence_tools
 decisions 必须且只能覆盖全部候选 ID。新增问题只能指向当前块，不得替相邻块或其它章节报错。
 只有确需跨块统一的术语、人称或固定表达才填写 consistency；普通漏译、增译、误译留空。
 不填写 consistency 时必须输出空对象 {}，不得照抄示例中的类型占位文字。
-evidence_refs 只能引用系统实际返回或当前块已有的 ref。拿不准就驳回，禁止为了显得认真而保留误报。\
+evidence_refs 应引用工具结果中的 ref；为兼容也可引用成功请求的 request_id，系统会展开为该请求
+实际返回的 ref。不得引用失败请求或编造 ref。拿不准就驳回，禁止为了显得认真而保留误报。\
 """)
 
 REVIEW_AGENT_USER = Template("""\
@@ -188,7 +189,8 @@ $review_evidence_tools
  "evidence_refs":["实际取得的 ref"],
  "complete":true}
 status=suggested 时，recommended_value 必须等于一个输入 proposed_value；系统会据此确定全部支持与否决项，
-无需也不得逐项枚举问题 ID。证据不足时使用 status=unresolved。\
+无需也不得逐项枚举问题 ID。evidence_refs 应引用工具结果中的 ref；为兼容也可引用成功请求的
+request_id，系统会展开为实际 ref。不得引用失败请求或编造 ref。证据不足时使用 status=unresolved。\
 """)
 
 REVIEW_ARBITER_USER = Template("""\

--- a/trans_novel/agents/review_loop.py
+++ b/trans_novel/agents/review_loop.py
@@ -76,6 +76,33 @@ def _safe_id(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "agent"
 
 
+def _expand_evidence_ref_aliases(
+    value: Any,
+    aliases: dict[str, list[str]],
+) -> Any:
+    """把模型引用的 request_id 展开为该请求实际返回的 evidence refs。"""
+    if isinstance(value, list):
+        return [_expand_evidence_ref_aliases(item, aliases) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    expanded: dict[str, Any] = {}
+    for key, item in value.items():
+        if key != "evidence_refs" or not isinstance(item, list):
+            expanded[key] = _expand_evidence_ref_aliases(item, aliases)
+            continue
+        refs: list[Any] = []
+        for ref in item:
+            replacements = aliases.get(ref) if isinstance(ref, str) else None
+            refs.extend(replacements if replacements is not None else [ref])
+        deduplicated: list[Any] = []
+        for ref in refs:
+            if ref not in deduplicated:
+                deduplicated.append(ref)
+        expanded[key] = deduplicated
+    return expanded
+
+
 class _ActionLoop:
     """在普通 messages 接口上模拟 request-evidence/final 工具循环。"""
 
@@ -120,9 +147,11 @@ class _ActionLoop:
         evidence_rounds = 0
         seen_request_ids: set[str] = set()
         seen_requests: set[tuple[str, str]] = set()
+        request_ref_aliases: dict[str, list[str]] = {}
+        malformed_retries_remaining = 1
 
         try:
-            for turn_number in range(1, max_rounds + 2):
+            for turn_number in range(1, max_rounds + 3):
                 sent_messages = [dict(message) for message in messages]
                 turn: dict[str, Any] = {
                     "turn": turn_number,
@@ -153,6 +182,28 @@ class _ActionLoop:
                 try:
                     parsed = parse_json_result(raw)
                 except ValueError as error:
+                    if malformed_retries_remaining:
+                        malformed_retries_remaining -= 1
+                        turn["status"] = "retrying"
+                        turn["retry_reason"] = "malformed_json"
+                        self.debug.write_json(relative, trace)
+                        self.debug.log_event(
+                            "review_agent_output_retry",
+                            agent_id=agent_id,
+                            stage=stage,
+                            reason="malformed_json",
+                        )
+                        messages.append({"role": "assistant", "content": raw})
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": (
+                                    "上一次响应不是完整有效的 JSON。请重新输出同一动作，"
+                                    "只输出一个符合协议且完整闭合的 JSON 对象。"
+                                ),
+                            }
+                        )
+                        continue
                     raise ReviewLoopProtocolError("malformed_json") from error
                 data = parsed.value
                 turn["parsed"] = data
@@ -167,7 +218,14 @@ class _ActionLoop:
                 if action == "final":
                     if data.get("complete") is not True:
                         raise ReviewLoopProtocolError("final_not_complete")
-                    result = validate_final(data, allowed_refs)
+                    normalized_data = _expand_evidence_ref_aliases(
+                        data,
+                        request_ref_aliases,
+                    )
+                    if normalized_data != data:
+                        turn["normalized_final"] = normalized_data
+                        self.debug.write_json(relative, trace)
+                    result = validate_final(normalized_data, allowed_refs)
                     trace["status"] = "finished"
                     trace["result"] = result
                     self.debug.write_json(relative, trace)
@@ -201,6 +259,8 @@ class _ActionLoop:
                         or request_id in current_ids
                     ):
                         raise ReviewLoopProtocolError("duplicate_evidence_request_id")
+                    if request_id in allowed_refs:
+                        raise ReviewLoopProtocolError("evidence_request_id_ref_collision")
                     tool = _text(request.get("tool"))
                     arguments = request.get("arguments")
                     if not tool or not isinstance(arguments, dict):
@@ -233,7 +293,13 @@ class _ActionLoop:
                     results.append(result)
                     batch_size += encoded_size + 1
                 evidence_rounds += 1
-                allowed_refs.update(self.evidence.evidence_refs(results))
+                result_refs = self.evidence.evidence_refs(results)
+                allowed_refs.update(result_refs)
+                for result in results:
+                    request_id = _text(result.get("request_id"))
+                    refs = sorted(self.evidence.evidence_refs(result))
+                    if request_id and refs:
+                        request_ref_aliases[request_id] = refs
                 turn["evidence_results"] = results
                 self.debug.write_json(relative, trace)
                 self.debug.log_event(
@@ -249,7 +315,7 @@ class _ActionLoop:
                         }
                         for request in requests
                     ],
-                    refs=sorted(self.evidence.evidence_refs(results)),
+                    refs=sorted(result_refs),
                 )
                 messages.append({"role": "assistant", "content": raw})
                 evidence_message = "【证据工具返回 JSON】\n" + json.dumps(


### PR DESCRIPTION
## Summary

- map each successful evidence `request_id` to the concrete refs returned by that request
- normalize request IDs in final Agent/Arbiter decisions before strict evidence validation
- retry one malformed or empty Agent JSON response with an explicit protocol correction
- keep failed requests, invented refs, duplicate IDs, and ref/ID collisions fail-closed
- record the retry and normalized final decision in the debug audit trail

## Why

The evidence loop currently exposes both a model-chosen `request_id` and system-generated evidence refs. In real full-book runs, the Agent naturally cited `r1`/`r2`/`r3` after successful tool calls, but the final validator accepted only the generated refs. This turned valid evidence acquisition into `unknown_evidence_ref` fallback.

One additional leaf returned an empty second-turn response and immediately fell back with `malformed_json`, even though the initial Reviewer output retry path already treats malformed structured output as recoverable.

## Impact

The protocol is now closed end to end:

- citing a successful request ID expands to exactly the refs that request returned
- direct concrete refs still work
- a failed request ID or invented ref still triggers `unknown_evidence_ref`
- malformed output receives one bounded retry; a second failure still falls back

The evidence-round limit is unchanged, and the retry does not grant another evidence round.

## Validation

- `ruff check` on all changed Python files — passed
- `ruff format --check` on all changed Python files — passed
- `python -m unittest tests.test_review_agent` — 31 tests passed
- added coverage for request-ID normalization in both ReviewAgent and ReviewArbiter, malformed-output retry, and continued rejection of invented refs
- full Windows unittest discovery reached 302 tests; the only failures were the same two Unix-only path assertions and one SQLite cleanup lock already isolated in #113

No book data, translation state, API keys, or generated outputs are included.

