### PR TITLE
Reject review fixes that drop dialogue quotes

### DIFF
--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -364,6 +364,78 @@ class TestReviewFixer(unittest.TestCase):
                 with self.assertRaisesRegex(ReviewFixerProtocolError, reason):
                     self._propose(payload)
 
+    def test_rejects_dropped_dialogue_quotes(self):
+        client = FakeClient(
+            handler=lambda messages, tier, json_mode: json.dumps(
+                {
+                    "segment_ref": "ch0:text1:seg1",
+                    "before_hash": ReviewFixer.target_hash("“当前译文。”"),
+                    "issue_ids": ["r1-review-00001"],
+                    "replacement": "修订后的完整译文。",
+                    "complete": True,
+                },
+                ensure_ascii=False,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ReviewFixerProtocolError,
+            "dropped_dialogue_quotes",
+        ):
+            ReviewFixer(client, _config()).propose(
+                1,
+                "ch0:text1:seg1",
+                0,
+                1,
+                '"Original sentence."',
+                "“当前译文。”",
+                [
+                    {
+                        "issue_id": "r1-review-00001",
+                        "chapter": 0,
+                        "index": 1,
+                        "type": "mistranslation",
+                        "detail": "原意不完整",
+                        "suggestion": "补全信息",
+                    }
+                ],
+            )
+
+    def test_allows_removing_target_quotes_absent_from_source(self):
+        client = FakeClient(
+            handler=lambda messages, tier, json_mode: json.dumps(
+                {
+                    "segment_ref": "ch0:text1:seg1",
+                    "before_hash": ReviewFixer.target_hash("“当前译文。”"),
+                    "issue_ids": ["r1-review-00001"],
+                    "replacement": "修订后的完整译文。",
+                    "complete": True,
+                },
+                ensure_ascii=False,
+            )
+        )
+
+        patch = ReviewFixer(client, _config()).propose(
+            1,
+            "ch0:text1:seg1",
+            0,
+            1,
+            "Original sentence.",
+            "“当前译文。”",
+            [
+                {
+                    "issue_id": "r1-review-00001",
+                    "chapter": 0,
+                    "index": 1,
+                    "type": "added",
+                    "detail": "原文没有对话引号",
+                    "suggestion": "删除多余引号",
+                }
+            ],
+        )
+
+        self.assertEqual(patch.after, "修订后的完整译文。")
+
 
 class TestReadonlyGlossarySnapshot(unittest.TestCase):
     def test_reads_committed_wal_without_touching_formal_database_files(self):

--- a/trans_novel/agents/review_fixer.py
+++ b/trans_novel/agents/review_fixer.py
@@ -62,6 +62,15 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _dialogue_quote_pairs(text: str) -> int:
+    """粗略计数完整双引号对，用于阻止 Fixer 丢失既有对话边界。"""
+    return (
+        text.count('"') // 2
+        + min(text.count("“"), text.count("”"))
+        + min(text.count("「"), text.count("」"))
+    )
+
+
 def _patch_id(
     *,
     round_number: int,
@@ -308,6 +317,12 @@ class ReviewFixer(Agent):
         replacement = replacement.strip()
         if replacement == current_target.strip():
             raise ReviewFixerProtocolError("unchanged_replacement")
+        required_quote_pairs = min(
+            _dialogue_quote_pairs(source),
+            _dialogue_quote_pairs(current_target),
+        )
+        if _dialogue_quote_pairs(replacement) < required_quote_pairs:
+            raise ReviewFixerProtocolError("dropped_dialogue_quotes")
 
         return ProvisionalPatch(
             patch_id=_patch_id(


### PR DESCRIPTION
## Problem

ReviewFixer can return a semantically plausible replacement while dropping structural dialogue punctuation. In the full-book Ender's Game release gate, 6 of 118 final shadow overrides reduced the number of complete Chinese dialogue quote pairs. Later review rounds did not reliably recover them.

## Change

Count complete source/current-target dialogue quote pairs before accepting a proposed replacement. Reject a replacement with `dropped_dialogue_quotes` when it removes required pairs. Quotes introduced only by the target may still be removed when the source does not require them.

## Verification

- `ruff check` passed
- `ruff format --check` passed
- `python -m unittest tests.test_review_agent`: 36 passed
- `python -m unittest discover -s tests -p "test_*.py"`: 324 passed

No book data, translation state, generated outputs, or secrets are included.
