### PR TITLE
Expose shadow review evidence provenance

### DIFF
--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -293,7 +293,16 @@ class TestBookEvidenceIndex(unittest.TestCase):
 
         self.assertEqual(index.segments[0].target, "影子修订。")
         self.assertEqual(context["segments"][0]["target"], "影子修订。")
+        self.assertEqual(context["segments"][0]["target_origin"], "shadow_override")
+        self.assertEqual(context["segments"][0]["baseline_target"], original)
         self.assertEqual(self.chapters[0].text_segments[0].target, original)
+
+    def test_formal_targets_are_labeled_without_duplicate_baseline_payload(self):
+        context = self.index.segment_context({"chapter": 0, "index": 0, "before": 0, "after": 0})
+
+        segment = context["segments"][0]
+        self.assertEqual(segment["target_origin"], "formal")
+        self.assertNotIn("baseline_target", segment)
 
 
 class TestReviewFixer(unittest.TestCase):

--- a/trans_novel/agents/prompts.py
+++ b/trans_novel/agents/prompts.py
@@ -107,11 +107,16 @@ REVIEW_EVIDENCE_TOOLS = """\
    {"chapter":整数,"index":章内 text_segments 下标,"before":0..6,"after":0..6}。
 4. book_context：读取一项书级信息。
    {"section":"style_guide|book_synopsis|chapter_digest","chapter":可选整数}。
+段落证据中的 target_origin=formal 表示冻结基线译文；target_origin=shadow_override
+表示本次 Review/Fix 循环尚未确认的影子修订，此时 baseline_target 给出冻结基线。
+多个 shadow_override 的重复不构成独立证据，不得据此反向证明术语表或修订正确。
 """
 
 REVIEW_AGENT_SYSTEM = Template("""\
 你是$src_label小说到$tgt_label译文的取证审校 Agent。初审已经给出一组候选问题；你必须核验每项，
 必要时通过 JSON 动作申请有限的全书证据，再给出最终判断。不得假设未取得的上下文。
+术语库和影子修订都是待核验材料，不是不可推翻的事实；须同时对照原文语义、术语 note、
+冻结基线及独立上下文。若它们互相矛盾，应驳回候选或保留基线，不得仅因影子修订重复出现而确认。
 
 $review_evidence_tools
 
@@ -164,6 +169,8 @@ $candidates_json
 REVIEW_ARBITER_SYSTEM = Template("""\
 你是全书 Review 冲突的终局仲裁 Agent。不同审校块针对同一术语、人物代词或固定表达提出了
 互相矛盾的建议。你只能给出供人工确认的裁决建议，不得声称已修改正文或术语库。
+术语库和影子修订都是待核验材料；target_origin=shadow_override 的重复不能作为独立多数证据。
+若术语目标、note、原文语义和冻结基线相互矛盾且无法消解，必须输出 unresolved。
 
 $review_evidence_tools
 优先按 first/middle/last 或明确的第 N 次出现选择性取证，不得请求全量正文。

--- a/trans_novel/pipeline/review_evidence.py
+++ b/trans_novel/pipeline/review_evidence.py
@@ -40,6 +40,8 @@ class SegmentRef:
     segment_index: int
     source: str
     target: str
+    baseline_target: str
+    target_origin: str
     chapter_title: str
 
     @property
@@ -50,7 +52,7 @@ class SegmentRef:
     def compact(self) -> dict[str, Any]:
         """序列化为证据载荷。"""
         limit = 4000
-        return {
+        payload = {
             "ref": self.ref,
             "chapter": self.chapter,
             "text_index": self.text_index,
@@ -58,9 +60,18 @@ class SegmentRef:
             "chapter_title": self.chapter_title,
             "source": self.source[:limit],
             "target": self.target[:limit],
+            "target_origin": self.target_origin,
             "source_truncated": len(self.source) > limit,
             "target_truncated": len(self.target) > limit,
         }
+        if self.target_origin == "shadow_override":
+            payload.update(
+                {
+                    "baseline_target": self.baseline_target[:limit],
+                    "baseline_target_truncated": len(self.baseline_target) > limit,
+                }
+            )
+        return payload
 
 
 class BookEvidenceIndex:
@@ -89,6 +100,8 @@ class BookEvidenceIndex:
             for text_index, segment in enumerate(chapter.text_segments):
                 position = len(flattened)
                 location = (chapter.index, text_index)
+                baseline_target = segment.target or ""
+                has_override = location in overrides
                 flattened.append(
                     SegmentRef(
                         global_ordinal=position,
@@ -96,7 +109,9 @@ class BookEvidenceIndex:
                         text_index=text_index,
                         segment_index=segment.index,
                         source=segment.source,
-                        target=overrides.get(location, segment.target or ""),
+                        target=overrides.get(location, baseline_target),
+                        baseline_target=baseline_target,
+                        target_origin=("shadow_override" if has_override else "formal"),
                         chapter_title=chapter.title,
                     )
                 )


### PR DESCRIPTION
## Problem

Later Review/Fix rounds currently expose shadow overrides as ordinary target evidence. This lets a model treat its own earlier edits as independent full-book consistency evidence. In the full-book release gate, two newly-created `奇迹缔造者` shadow targets were used to confirm a poisoned `worker` glossary entry and overrule the correct baseline `工虫`.

## Change

- Label every evidence target with `target_origin=formal|shadow_override`.
- Include `baseline_target` when an override is present.
- Instruct ReviewAgent and ReviewArbiter that repeated shadow overrides are pending proposals, not independent votes, and that unresolved glossary/source/baseline contradictions must fail closed.

## Verification

- `ruff check` passed
- `ruff format --check` passed
- `python -m unittest tests.test_review_agent`: 35 passed
- `python -m unittest discover -s tests -p "test_*.py"`: 323 passed

No book data, translation state, generated outputs, or secrets are included.
