### PR TITLE
fix: 阻止输出路径覆盖源文件

### DIFF
--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -113,6 +113,43 @@ def _run(input_path, state_dir):
 
 
 class TestAssembleText(unittest.TestCase):
+    def test_epub_output_cannot_replace_source_through_path_aliases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "book.epub")
+            write_sample_epub(source)
+            store, _ = _run(source, os.path.join(directory, "state"))
+            with open(source, "rb") as file:
+                original = file.read()
+
+            aliases = [
+                source,
+                os.path.join(directory, ".", "book.epub"),
+                os.path.relpath(source),
+            ]
+            symlink = os.path.join(directory, "book-link.epub")
+            try:
+                os.symlink(source, symlink)
+            except (NotImplementedError, OSError):
+                pass
+            else:
+                aliases.append(symlink)
+
+            for out_path in aliases:
+                with (
+                    self.subTest(out_path=out_path),
+                    self.assertRaisesRegex(ValueError, "输出路径不能与源文件相同"),
+                ):
+                    assemble(
+                        store,
+                        source,
+                        out_path=out_path,
+                        out_format="epub",
+                        about_page=False,
+                    )
+
+            with open(source, "rb") as file:
+                self.assertEqual(file.read(), original)
+
     def test_fb2_images_and_cover_are_preserved_in_generated_epub(self):
         with tempfile.TemporaryDirectory() as d:
             fb2 = os.path.join(d, "illustrated.fb2")

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -1822,6 +1822,16 @@ def assemble(
         supported = " / ".join(_OUT_EXT)
         raise ValueError(f"不支持的输出格式：{out_format}（支持 {supported}）")
 
+    if out_path is not None:
+        try:
+            same_file = os.path.samefile(source_path, out_path)
+        except OSError:
+            same_file = os.path.normcase(os.path.realpath(source_path)) == os.path.normcase(
+                os.path.realpath(out_path)
+            )
+        if same_file:
+            raise ValueError(f"输出路径不能与源文件相同：{out_path}")
+
     m = store.load_manifest()
     if out_format == "txt":
         out_path = out_path or _default_out(source_path, "txt", "", bilingual=bilingual)


### PR DESCRIPTION
## 问题

`assemble()` 接受 `out_path` 与源文件指向同一文件。EPUB 导出会先以读取模式打开源文件，再以写入模式打开相同路径；写入句柄会立即截断源文件，随后抛出 `BadZipFile: Truncated file header`，并留下损坏的原书。

## 修改

- 在公共 `assemble()` 入口、任何状态读取和输出写入之前检查输入与输出是否指向同一文件。
- 优先使用 `os.path.samefile()` 识别同一文件，并用规范化后的 `realpath()` 处理无法 `stat` 的路径。
- 同一文件时提前抛出明确的 `ValueError`，正常的不同输出路径行为不变。
- 增加行为测试，覆盖相同路径、含 `.` 的路径、真正的相对路径及系统支持时的符号链接别名，并断言源文件字节保持不变。

## 影响

保护位于公共入口，因此 CLI、翻译流水线和 Python API 调用都会受益；默认输出路径不受影响。

## 验证

- 修复前新增测试稳定复现 `BadZipFile: Truncated file header`
- `pytest -q`：282 passed，32 subtests passed
- `ruff check .`：通过
- `ruff format --check .`：通过
- 真实 EPUB 副本验证：提前报错，源文件哈希保持不变

未包含书籍数据、翻译状态、生成文件或密钥。
