### PR TITLE
build: add macOS Intel and Apple Silicon release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,22 +22,42 @@ jobs:
         include:
           - name: Windows x64
             runner: windows-latest
+            python_arch: x64
             artifact: wenyi-windows-x64
             binary: ./dist/wenyi.exe
             archive: ./dist/wenyi-windows-x64.zip
+            expected_machine: "8664"
+          - name: Windows ARM64
+            runner: windows-11-arm
+            python_arch: arm64
+            artifact: wenyi-windows-arm64
+            binary: ./dist/wenyi.exe
+            archive: ./dist/wenyi-windows-arm64.zip
+            expected_machine: "AA64"
           - name: Linux x64
             runner: ubuntu-latest
+            python_arch: x64
             artifact: wenyi-linux-x64
             binary: ./dist/wenyi
             archive: ./dist/wenyi-linux-x64.tar.gz
+            expected_arch: x86-64
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            python_arch: arm64
+            artifact: wenyi-linux-arm64
+            binary: ./dist/wenyi
+            archive: ./dist/wenyi-linux-arm64.tar.gz
+            expected_arch: aarch64
           - name: macOS Apple Silicon
             runner: macos-15
+            python_arch: arm64
             artifact: wenyi-macos-arm64
             binary: ./dist/wenyi
             archive: ./dist/wenyi-macos-arm64.tar.gz
             expected_arch: arm64
           - name: macOS Intel
             runner: macos-15-intel
+            python_arch: x64
             artifact: wenyi-macos-x64
             binary: ./dist/wenyi
             archive: ./dist/wenyi-macos-x64.tar.gz
@@ -51,6 +71,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          architecture: ${{ matrix.python_arch }}
 
       - name: Install build dependencies
         run: python -m pip install . pyinstaller
@@ -65,10 +86,30 @@ jobs:
           --distpath dist trans_novel/__main__.py
 
       - name: Smoke test executable
-        shell: bash
         run: |
           ${{ matrix.binary }} --help
           ${{ matrix.binary }} --version
+
+      - name: Verify Windows executable
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bytes = [System.IO.File]::ReadAllBytes("${{ matrix.binary }}")
+          $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
+          $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+          $actual = "{0:X4}" -f $machine
+          Write-Host "PE machine: 0x$actual"
+          if ($actual -ne "${{ matrix.expected_machine }}") {
+            throw "Expected PE machine 0x${{ matrix.expected_machine }}, got 0x$actual"
+          }
+
+      - name: Verify Linux executable
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          file_output="$(file "${{ matrix.binary }}")"
+          echo "$file_output"
+          grep -q "${{ matrix.expected_arch }}" <<<"$file_output"
 
       - name: Verify macOS executable
         if: runner.os == 'macOS'
@@ -84,7 +125,7 @@ jobs:
         shell: pwsh
         run: >
           Compress-Archive -LiteralPath dist/wenyi.exe
-          -DestinationPath dist/wenyi-windows-x64.zip -Force
+          -DestinationPath "${{ matrix.archive }}" -Force
 
       - name: Package POSIX executable
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build executables
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [dev]
+    paths:
+      - .github/workflows/build.yml
   release:
     types: [published]
 
@@ -26,6 +30,18 @@ jobs:
             artifact: wenyi-linux-x64
             binary: ./dist/wenyi
             archive: ./dist/wenyi-linux-x64.tar.gz
+          - name: macOS Apple Silicon
+            runner: macos-15
+            artifact: wenyi-macos-arm64
+            binary: ./dist/wenyi
+            archive: ./dist/wenyi-macos-arm64.tar.gz
+            expected_arch: arm64
+          - name: macOS Intel
+            runner: macos-15-intel
+            artifact: wenyi-macos-x64
+            binary: ./dist/wenyi
+            archive: ./dist/wenyi-macos-x64.tar.gz
+            expected_arch: x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +70,15 @@ jobs:
           ${{ matrix.binary }} --help
           ${{ matrix.binary }} --version
 
+      - name: Verify macOS executable
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          file_output="$(file "${{ matrix.binary }}")"
+          echo "$file_output"
+          grep -q "${{ matrix.expected_arch }}" <<<"$file_output"
+          codesign --verify --deep --strict "${{ matrix.binary }}"
+
       - name: Package Windows executable
         if: runner.os == 'Windows'
         shell: pwsh
@@ -61,10 +86,10 @@ jobs:
           Compress-Archive -LiteralPath dist/wenyi.exe
           -DestinationPath dist/wenyi-windows-x64.zip -Force
 
-      - name: Package Linux executable
-        if: runner.os == 'Linux'
+      - name: Package POSIX executable
+        if: runner.os != 'Windows'
         shell: bash
-        run: tar -C dist -czf dist/wenyi-linux-x64.tar.gz wenyi
+        run: tar -czf "${{ matrix.archive }}" -C dist wenyi
 
       - name: Upload packaged executable
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,6 @@ jobs:
             binary: ./dist/wenyi.exe
             archive: ./dist/wenyi-windows-x64.zip
             expected_machine: "8664"
-          - name: Windows ARM64
-            runner: windows-11-arm
-            python_arch: arm64
-            artifact: wenyi-windows-arm64
-            binary: ./dist/wenyi.exe
-            archive: ./dist/wenyi-windows-arm64.zip
-            expected_machine: "AA64"
           - name: Linux x64
             runner: ubuntu-latest
             python_arch: x64

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,8 +20,8 @@ Whenever the program starts, it checks for `config.yaml` in the current director
 
 ## Windows
 
-Releases provide `wenyi-windows-x64.zip` and `wenyi-windows-arm64.zip`. Download
-the archive matching your processor and verify it against `SHA256SUMS.txt`.
+Windows releases provide `wenyi-windows-x64.zip`. Verify the archive against
+`SHA256SUMS.txt` before running it.
 
 When using a packaged `wenyi.exe`, set the API key in PowerShell:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,9 @@ Whenever the program starts, it checks for `config.yaml` in the current director
 
 ## Windows
 
+Releases provide `wenyi-windows-x64.zip` and `wenyi-windows-arm64.zip`. Download
+the archive matching your processor and verify it against `SHA256SUMS.txt`.
+
 When using a packaged `wenyi.exe`, set the API key in PowerShell:
 
 ```powershell
@@ -35,6 +38,18 @@ setx DEEPSEEK_API_KEY "sk-..."
 ```
 
 You may also set `language.source` to a known ISO language code to avoid an additional model call for language detection.
+
+## Linux
+
+Releases provide `wenyi-linux-x64.tar.gz` and `wenyi-linux-arm64.tar.gz`. Download
+the archive matching your processor, verify it against `SHA256SUMS.txt`, and run:
+
+```bash
+tar -xzf wenyi-linux-arm64.tar.gz  # use wenyi-linux-x64.tar.gz on x64 systems
+chmod +x wenyi
+export DEEPSEEK_API_KEY=sk-...
+./wenyi translate book.epub
+```
 
 ## macOS
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,23 @@ setx DEEPSEEK_API_KEY "sk-..."
 
 You may also set `language.source` to a known ISO language code to avoid an additional model call for language detection.
 
+## macOS
+
+Releases provide separate terminal executables for Apple Silicon (`wenyi-macos-arm64.tar.gz`)
+and Intel (`wenyi-macos-x64.tar.gz`) Macs. Download the archive matching your processor,
+verify it against `SHA256SUMS.txt`, and run:
+
+```bash
+tar -xzf wenyi-macos-arm64.tar.gz  # use wenyi-macos-x64.tar.gz on Intel Macs
+chmod +x wenyi
+export DEEPSEEK_API_KEY=sk-...
+./wenyi translate book.epub
+```
+
+These command-line executables are ad-hoc signed by PyInstaller but are not notarized with an
+Apple Developer certificate. macOS may quarantine a downloaded build; after verifying the
+checksum, approve it in **System Settings → Privacy & Security** if prompted.
+
 ## Input and output
 
 - Input formats: EPUB, FB2, TXT, Markdown, HTML, and PDF.

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -35,6 +35,23 @@ setx DEEPSEEK_API_KEY "sk-..."
 
 也可把 `language.source` 设为已知的语言代码，避免调用模型自动识别源语言。
 
+## macOS
+
+Release 分别提供适用于 Apple Silicon 的 `wenyi-macos-arm64.tar.gz` 和适用于
+Intel Mac 的 `wenyi-macos-x64.tar.gz` 终端程序。下载与处理器匹配的压缩包，先用
+`SHA256SUMS.txt` 核对文件，再执行：
+
+```bash
+tar -xzf wenyi-macos-arm64.tar.gz  # Intel Mac 请改用 wenyi-macos-x64.tar.gz
+chmod +x wenyi
+export DEEPSEEK_API_KEY=sk-...
+./wenyi translate book.epub
+```
+
+这些命令行程序由 PyInstaller 做 ad-hoc 签名，但没有使用 Apple 开发者证书完成
+notarization。macOS 仍可能隔离下载的程序；确认校验和无误后，如系统提示拦截，
+可在 **系统设置 → 隐私与安全性** 中批准运行。
+
 ## 输入与输出
 
 - 输入格式：EPUB、FB2、TXT、Markdown、HTML、PDF。

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -19,6 +19,9 @@ uv run trans-novel translate book.epub
 
 ## Windows
 
+Release 提供 `wenyi-windows-x64.zip` 和 `wenyi-windows-arm64.zip`。请下载与
+处理器架构匹配的压缩包，并使用 `SHA256SUMS.txt` 校验文件。
+
 使用打包版 `wenyi.exe` 时，在 PowerShell 中设置 API Key：
 
 ```powershell
@@ -34,6 +37,18 @@ setx DEEPSEEK_API_KEY "sk-..."
 ```
 
 也可把 `language.source` 设为已知的语言代码，避免调用模型自动识别源语言。
+
+## Linux
+
+Release 提供 `wenyi-linux-x64.tar.gz` 和 `wenyi-linux-arm64.tar.gz`。请下载与
+处理器架构匹配的压缩包，使用 `SHA256SUMS.txt` 校验后执行：
+
+```bash
+tar -xzf wenyi-linux-arm64.tar.gz  # x64 系统请改用 wenyi-linux-x64.tar.gz
+chmod +x wenyi
+export DEEPSEEK_API_KEY=sk-...
+./wenyi translate book.epub
+```
 
 ## macOS
 

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -19,8 +19,8 @@ uv run trans-novel translate book.epub
 
 ## Windows
 
-Release 提供 `wenyi-windows-x64.zip` 和 `wenyi-windows-arm64.zip`。请下载与
-处理器架构匹配的压缩包，并使用 `SHA256SUMS.txt` 校验文件。
+Windows Release 提供 `wenyi-windows-x64.zip`，运行前请使用
+`SHA256SUMS.txt` 校验文件。
 
 使用打包版 `wenyi.exe` 时，在 PowerShell 中设置 API Key：
 


### PR DESCRIPTION
## 背景

#128 希望 Wenyi 提供 macOS 版本；维护者也说明当前缺少实体 Mac 进行构建和验证。现有 Release 工作流只生成 Windows x64 与 Linux x64 产物。

## 改动

- 使用 `macos-15` 构建 Apple Silicon ARM64 版本：
  `wenyi-macos-arm64.tar.gz`
- 使用 `macos-15-intel` 构建 Intel x64 版本：
  `wenyi-macos-x64.tar.gz`
- 在真实 macOS runner 上运行 `--help`、`--version`，检查 Mach-O 架构并验证 PyInstaller ad-hoc 签名。
- 复用 POSIX tar 打包流程，现有 Release 上传与 SHA256 校验会自动包含两种 macOS 产物。
- 补充中英文 macOS 下载、运行和 Gatekeeper 边界说明。
- 仅在 PR 修改构建工作流时运行四平台打包矩阵，普通代码 PR 不增加额外构建成本。

## 验证

- YAML、触发条件及双架构矩阵语义检查通过。
- `ruff check .`：通过。
- `ruff format --check .`：91 个文件格式正确。
- `python -m unittest discover -s tests -p "test_*.py"`：324 项通过。
- Draft PR 创建后，将由 GitHub Actions 在 Windows、Linux、macOS ARM64 与 macOS Intel runner 上完成真实打包验证。

## 边界

本 PR 提供的是终端 CLI 可执行程序，不是原生 `.app`。PyInstaller 会执行 ad-hoc 签名，但产物没有使用 Apple Developer 证书完成 notarization，因此 macOS 仍可能显示 Gatekeeper 提示。

不修改翻译、审校、术语或模型调用逻辑，也不新增运行时依赖。

Closes #128
