### PR TITLE
Add real-time ETA and LLM activity status

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ from typer.testing import CliRunner
 from trans_novel.cli import (
     _apply_store_languages,
     _configure_windows_console,
+    _EstimatedRemainingColumn,
+    _llm_stage_label,
     _RichProgressBridge,
     _validate_pdf_engine,
     app,
@@ -30,7 +32,15 @@ class FakeStore:
 
 
 class TestCliConfig(unittest.TestCase):
-    def test_progress_bridge_reuses_one_task_across_review_stages(self):
+    @staticmethod
+    def _stage_task(progress, bridge):
+        return next(task for task in progress.tasks if task.id == bridge.task)
+
+    @staticmethod
+    def _overall_task(progress, bridge):
+        return next(task for task in progress.tasks if task.id == bridge.overall_task)
+
+    def test_progress_bridge_reuses_stage_task_across_review_stages(self):
         progress = Progress(disable=True)
         bridge = _RichProgressBridge(progress, "准备全书审校…")
 
@@ -40,11 +50,125 @@ class TestCliConfig(unittest.TestCase):
         bridge(58, 58, "影子修订 R1")
         bridge(0, 6386, "全书盲审 R2")
 
-        self.assertEqual(len(progress.tasks), 1)
-        task = progress.tasks[0]
-        self.assertEqual(task.description, "全书盲审 R2")
+        self.assertEqual(len(progress.tasks), 2)
+        task = self._stage_task(progress, bridge)
+        self.assertEqual(task.description, "全书盲审 R2 · LLM: idle")
         self.assertEqual(task.completed, 0)
         self.assertEqual(task.total, 6386)
+        self.assertIsNone(self._overall_task(progress, bridge).total)
+
+    def test_llm_stage_labels_include_known_and_readable_fallbacks(self):
+        self.assertEqual(_llm_stage_label("Translator"), "Translating text")
+        self.assertEqual(_llm_stage_label("custom_stage"), "Custom stage")
+        self.assertEqual(_llm_stage_label("NewReviewAgent"), "New Review Agent")
+        self.assertEqual(_llm_stage_label(None), "Model request")
+
+    def test_progress_bridge_aggregates_concurrent_activity_and_returns_idle(self):
+        progress = Progress(disable=True)
+        bridge = _RichProgressBridge(progress, "预扫章节梗概")
+
+        bridge.on_llm_activity(
+            "request_started", request_id="r1", stage="Synopsizer", tier="fast"
+        )
+        bridge.on_llm_activity(
+            "request_started", request_id="r2", stage="Synopsizer", tier="fast"
+        )
+        bridge.on_llm_activity(
+            "request_started", request_id="r3", stage="Translator", tier="strong"
+        )
+        description = self._stage_task(progress, bridge).description
+        self.assertIn("LLM: Translating text [strong]", description)
+        self.assertIn("+2 other requests", description)
+
+        bridge.on_llm_activity(
+            "request_retry_wait",
+            request_id="r1",
+            stage="Synopsizer",
+            tier="fast",
+            attempt=2,
+            max_attempts=5,
+            wait_seconds=3.2,
+            reason="http_502",
+        )
+        description = self._stage_task(progress, bridge).description
+        self.assertIn(
+            "LLM: Retrying Building book understanding [fast] 2/5 in 3.2s ×2",
+            description,
+        )
+        self.assertIn("+1 other request", description)
+
+        for request_id in ("r2", "r1", "r3"):
+            bridge.on_llm_activity("request_finished", request_id=request_id)
+        self.assertTrue(
+            self._stage_task(progress, bridge).description.endswith("LLM: idle")
+        )
+
+    def test_activity_changes_do_not_change_counts_or_eta_samples(self):
+        clock = [0.0]
+        progress = Progress(disable=True, get_time=lambda: clock[0])
+        bridge = _RichProgressBridge(progress, "第一章")
+        bridge(0, 10, "第一章")
+        clock[0] = 5.0
+        bridge(2, 10, "第一章")
+        task = self._stage_task(progress, bridge)
+        completed = task.completed
+        samples = list(task._progress)
+
+        bridge.on_llm_activity(
+            "request_started", request_id="r1", stage="Translator", tier="strong"
+        )
+        bridge.on_llm_activity("request_finished", request_id="r1")
+
+        task = self._stage_task(progress, bridge)
+        self.assertEqual(task.completed, completed)
+        self.assertEqual(list(task._progress), samples)
+
+    def test_eta_is_calculated_and_stage_rollback_clears_speed(self):
+        clock = [0.0]
+        progress = Progress(disable=True, get_time=lambda: clock[0])
+        bridge = _RichProgressBridge(progress, "全书审校 R1")
+        eta = _EstimatedRemainingColumn()
+
+        bridge(0, 10, "全书审校 R1")
+        self.assertIn("计算中", eta.render(self._stage_task(progress, bridge)).plain)
+        clock[0] = 5.0
+        bridge(2, 10, "全书审校 R1")
+        clock[0] = 10.0
+        bridge(4, 10, "全书审校 R1")
+        self.assertEqual(
+            eta.render(self._stage_task(progress, bridge)).plain,
+            "阶段剩余 00:15",
+        )
+
+        bridge(0, 10, "全书盲审 R2")
+        self.assertIn("计算中", eta.render(self._stage_task(progress, bridge)).plain)
+
+    def test_translation_uses_local_stage_and_preserves_overall_progress(self):
+        progress = Progress(disable=True)
+        bridge = _RichProgressBridge(
+            progress,
+            "准备中…",
+            overall_predictable=True,
+        )
+
+        bridge.update_translation(2, 10, 12, 100, "第一章")
+        stage = self._stage_task(progress, bridge)
+        overall = self._overall_task(progress, bridge)
+        self.assertEqual((stage.completed, stage.total), (2, 10))
+        self.assertEqual((overall.completed, overall.total), (12, 100))
+        overall_task_id = bridge.overall_task
+
+        bridge.update_translation(0, 5, 20, 100, "第二章")
+        stage = self._stage_task(progress, bridge)
+        overall = self._overall_task(progress, bridge)
+        self.assertEqual((stage.completed, stage.total), (0, 5))
+        self.assertEqual(bridge.overall_task, overall_task_id)
+        self.assertEqual((overall.completed, overall.total), (20, 100))
+
+        bridge(0, 0, "翻译章节标题…")
+        overall = self._overall_task(progress, bridge)
+        self.assertEqual(bridge.overall_task, overall_task_id)
+        self.assertEqual((overall.completed, overall.total), (20, 100))
 
     def test_pdf_engine_validation_accepts_both_backends(self):
         self.assertEqual(_validate_pdf_engine("WeasyPrint"), "weasyprint")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 from trans_novel.llm.json_parser import parse_json_loose, parse_json_result
@@ -65,6 +67,105 @@ class TestFakeClient(unittest.TestCase):
         self.assertEqual(c.complete([{"role": "user", "content": "x"}]), "hello")
         self.assertEqual(c.complete_json([{"role": "user", "content": "x"}]), ["A", "B"])
         self.assertEqual(len(c.calls), 2)
+
+    def test_activity_lifecycle_reports_success_and_failure(self):
+        events = []
+
+        def failing_handler(messages, tier, json_mode):
+            del messages, tier, json_mode
+            raise RuntimeError("provider failed")
+
+        client = FakeClient()
+        client.set_activity_sink(
+            lambda event, **data: events.append({"event": event, **data})
+        )
+        self.assertEqual(
+            client.complete(
+                [{"role": "user", "content": "x"}],
+                tier="fast",
+                stage="Synopsizer",
+            ),
+            "",
+        )
+        self.assertEqual(
+            [event["event"] for event in events],
+            ["request_started", "request_finished"],
+        )
+        self.assertEqual(events[0]["request_id"], events[1]["request_id"])
+        self.assertEqual(events[0]["stage"], "Synopsizer")
+        self.assertEqual(events[0]["tier"], "fast")
+        self.assertEqual(events[1]["status"], "success")
+
+        events.clear()
+        client.handler = failing_handler
+        with self.assertRaisesRegex(RuntimeError, "provider failed"):
+            client.complete(
+                [{"role": "user", "content": "x"}],
+                tier="strong",
+                stage="Translator",
+            )
+        self.assertEqual(
+            [event["event"] for event in events],
+            ["request_started", "request_finished"],
+        )
+        self.assertEqual(events[-1]["status"], "failed")
+
+    def test_concurrent_activity_uses_unique_request_ids(self):
+        barrier = threading.Barrier(2)
+        events = []
+        event_lock = threading.Lock()
+
+        def handler(messages, tier, json_mode):
+            del messages, tier, json_mode
+            barrier.wait(timeout=2)
+            return "ok"
+
+        def sink(event, **data):
+            with event_lock:
+                events.append({"event": event, **data})
+
+        clients = [FakeClient(handler=handler), FakeClient(handler=handler)]
+        for client in clients:
+            client.set_activity_sink(sink)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(
+                pool.map(
+                    lambda item: item[0].complete(
+                        [{"role": "user", "content": item[1]}],
+                        stage=item[1],
+                    ),
+                    zip(clients, ["Analyzer", "Synopsizer"]),
+                )
+            )
+
+        self.assertEqual(results, ["ok", "ok"])
+        started = [event for event in events if event["event"] == "request_started"]
+        finished = [event for event in events if event["event"] == "request_finished"]
+        self.assertEqual(len({event["request_id"] for event in started}), 2)
+        self.assertEqual(
+            {event["request_id"] for event in started},
+            {event["request_id"] for event in finished},
+        )
+
+    def test_activity_sink_failure_does_not_change_result_or_original_error(self):
+        def broken_sink(event, **data):
+            del event, data
+            raise RuntimeError("UI unavailable")
+
+        client = FakeClient()
+        client.set_activity_sink(broken_sink)
+        self.assertEqual(client.complete([{"role": "user", "content": "x"}]), "")
+
+        original = ValueError("original provider failure")
+
+        def failing_handler(messages, tier, json_mode):
+            del messages, tier, json_mode
+            raise original
+
+        client.handler = failing_handler
+        with self.assertRaises(ValueError) as raised:
+            client.complete([{"role": "user", "content": "x"}])
+        self.assertIs(raised.exception, original)
 
 
 class TestParseJsonLooseRepairs(unittest.TestCase):

--- a/tests/test_llm_gemini.py
+++ b/tests/test_llm_gemini.py
@@ -166,6 +166,10 @@ def test_gemini_client_complete_and_usage():
 
     client = GeminiClient(cfg)
     client._client = mock_client_instance
+    activity = []
+    client.set_activity_sink(
+        lambda event, **data: activity.append({"event": event, **data})
+    )
 
     res = client.complete([{"role": "user", "content": "test"}], stage="translation")
 
@@ -178,6 +182,12 @@ def test_gemini_client_complete_and_usage():
     summary = client.usage_summary()
     assert summary["totals"]["prompt_tokens"] == 80
     assert summary["totals"]["completion_tokens"] == 25
+    assert [item["event"] for item in activity] == [
+        "request_started",
+        "request_finished",
+    ]
+    assert activity[0]["request_id"] == activity[1]["request_id"]
+    assert activity[1]["status"] == "success"
 
 
 def test_gemini_client_retries_server_error_and_records_wait():
@@ -278,9 +288,18 @@ def test_gemini_client_safety_block():
 
     client = GeminiClient(cfg)
     client._client = mock_client_instance
+    activity = []
+    client.set_activity_sink(
+        lambda event, **data: activity.append({"event": event, **data})
+    )
 
     with pytest.raises(RuntimeError, match="安全拦截"):
         client.complete([{"role": "user", "content": "unsafe content"}])
+    assert [item["event"] for item in activity] == [
+        "request_started",
+        "request_finished",
+    ]
+    assert activity[-1]["status"] == "failed"
 
 
 def test_factory_build_client_gemini():

--- a/tests/test_llm_retrying.py
+++ b/tests/test_llm_retrying.py
@@ -123,7 +123,11 @@ def test_transient_error_retries_once_and_records_wait_event():
     )
     client._client = stub
     events: list[dict[str, Any]] = []
+    activity: list[dict[str, Any]] = []
     client.set_event_sink(lambda event, **data: events.append({"event": event, **data}))
+    client.set_activity_sink(
+        lambda event, **data: activity.append({"event": event, **data})
+    )
 
     assert client.complete([{"role": "user", "content": "x"}], stage="Translator") == "ok"
     assert stub.completions.calls == 2
@@ -135,6 +139,19 @@ def test_transient_error_retries_once_and_records_wait_event():
     assert events[0]["wait_source"] == "server"
     assert events[0]["stage"] == "Translator"
     assert events[0]["request_id"] == "req-test"
+    assert [item["event"] for item in activity] == [
+        "request_started",
+        "request_retry_wait",
+        "request_finished",
+    ]
+    assert len({item["request_id"] for item in activity}) == 1
+    assert activity[1]["stage"] == "Translator"
+    assert activity[1]["tier"] == "strong"
+    assert activity[1]["attempt"] == 2
+    assert activity[1]["max_attempts"] == 2
+    assert activity[1]["wait_seconds"] == 0
+    assert activity[1]["reason"] == "http_502"
+    assert activity[-1]["status"] == "success"
 
 
 def test_retry_exhaustion_is_recorded_and_reraises_last_error():
@@ -167,13 +184,22 @@ def test_permanent_error_is_not_retried_or_reported_as_exhaustion():
     stub = _ClientStub([_HttpError(401)])
     client._client = stub
     events: list[dict[str, Any]] = []
+    activity: list[dict[str, Any]] = []
     client.set_event_sink(lambda event, **data: events.append({"event": event, **data}))
+    client.set_activity_sink(
+        lambda event, **data: activity.append({"event": event, **data})
+    )
 
     with pytest.raises(_HttpError):
         client.complete([{"role": "user", "content": "x"}])
 
     assert stub.completions.calls == 1
     assert events == []
+    assert [item["event"] for item in activity] == [
+        "request_started",
+        "request_finished",
+    ]
+    assert activity[-1]["status"] == "failed"
 
 
 def test_orchestrator_retry_sink_writes_book_event_log():
@@ -181,11 +207,26 @@ def test_orchestrator_retry_sink_writes_book_event_log():
         store = RunStore(directory)
         client = DeepSeekClient(_config(max_retries=0))
         orchestrator = Orchestrator(Config(), client=client)
-        orchestrator._bind_llm_events(store)
+        activity = []
+
+        class ProgressBridge:
+            @staticmethod
+            def on_llm_activity(event, **data):
+                activity.append({"event": event, **data})
+
+        orchestrator._bind_llm_events(store, ProgressBridge())
 
         client._emit_event("llm_retry_wait", reason="http_502", wait_seconds=1.0)
+        client._emit_activity("request_started", request_id="llm-test")
 
         with open(store.event_log_path, encoding="utf-8") as file:
-            event = json.loads(file.readline())
+            events = [json.loads(line) for line in file]
+        assert len(events) == 1
+        event = events[0]
         assert event["event"] == "llm_retry_wait"
         assert event["reason"] == "http_502"
+        assert activity == [{"event": "request_started", "request_id": "llm-test"}]
+
+        orchestrator._bind_llm_events(store)
+        client._emit_activity("request_started", request_id="not-forwarded")
+        assert len(activity) == 1

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -6,8 +6,11 @@
 
 from __future__ import annotations
 
+import math
 import os
+import re
 import sys
+import threading
 from collections.abc import Sequence
 from importlib.metadata import version as package_version
 from typing import Any, Protocol
@@ -18,11 +21,14 @@ from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
     Progress,
+    ProgressColumn,
     SpinnerColumn,
+    Task,
     TextColumn,
     TimeElapsedColumn,
 )
 from rich.table import Table
+from rich.text import Text
 from typer.core import TyperGroup
 
 from .config import Config
@@ -107,27 +113,287 @@ glossary_app = typer.Typer(
 console = Console()
 
 
+_LLM_STAGE_LABELS = {
+    "language_detect": "Detecting language",
+    "Analyzer": "Analyzing book style",
+    "Synopsizer": "Building book understanding",
+    "Translator": "Translating text",
+    "Polisher": "Polishing translation",
+    "GlossaryExtractor": "Extracting glossary terms",
+    "AnnotationAligner": "Aligning annotations",
+    "BackTranslator": "Back-translating samples",
+    "title_translate": "Translating chapter titles",
+    "Reviewer": "Reviewing translation",
+    "ReviewAgent": "Investigating review issues",
+    "ReviewArbiter": "Arbitrating review conflicts",
+    "ReviewFixer": "Drafting review fixes",
+    "ConsistencyChecker": "Checking consistency",
+}
+
+
+def _llm_stage_label(stage: object) -> str:
+    """把内部用量归因 stage 转成短小、可读的英文业务步骤。"""
+    if not isinstance(stage, str) or not stage.strip():
+        return "Model request"
+    normalized = stage.strip()
+    mapped = _LLM_STAGE_LABELS.get(normalized)
+    if mapped:
+        return mapped
+    words = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", normalized)
+    words = re.sub(r"[_-]+", " ", words).strip()
+    return words[:1].upper() + words[1:] if words else "Model request"
+
+
+class _ConditionalProgressColumn(ProgressColumn):
+    """在汇总行隐藏进度专用列，使未知全程 ETA 保持紧凑。"""
+
+    def __init__(self, inner: ProgressColumn) -> None:
+        super().__init__(table_column=inner.get_table_column())
+        self.inner = inner
+
+    def render(self, task: Task):
+        if not task.fields.get("show_progress", True):
+            return Text("")
+        return self.inner(task)
+
+
+class _EstimatedRemainingColumn(ProgressColumn):
+    """显示带作用域标签的紧凑 ETA；无可靠样本时明确标记为计算中。"""
+
+    max_refresh = 0.5
+
+    def render(self, task: Task) -> Text:
+        label = str(task.fields.get("eta_label") or "阶段剩余")
+        remaining = task.time_remaining
+        if task.total is None or remaining is None:
+            value = "计算中"
+        else:
+            seconds = max(0, math.ceil(remaining))
+            minutes, seconds = divmod(seconds, 60)
+            hours, minutes = divmod(minutes, 60)
+            value = (
+                f"{hours}:{minutes:02d}:{seconds:02d}"
+                if hours
+                else f"{minutes:02d}:{seconds:02d}"
+            )
+        return Text(f"{label} {value}", style="progress.remaining")
+
+
+def _new_progress() -> Progress:
+    """创建所有模型命令共用的 Rich 进度展示。"""
+    return Progress(
+        _ConditionalProgressColumn(SpinnerColumn()),
+        TextColumn("[progress.description]{task.description}"),
+        _ConditionalProgressColumn(BarColumn()),
+        _ConditionalProgressColumn(MofNCompleteColumn()),
+        _ConditionalProgressColumn(TimeElapsedColumn()),
+        _EstimatedRemainingColumn(),
+        console=console,
+    )
+
+
 class _RichProgressBridge:
     """把流水线的阶段进度映射到同一个 Rich 任务。"""
 
-    def __init__(self, progress: Progress, initial_description: str) -> None:
+    def __init__(
+        self,
+        progress: Progress,
+        initial_description: str,
+        *,
+        overall_predictable: bool = False,
+    ) -> None:
         self.progress = progress
-        self.task = progress.add_task(initial_description, total=None)
+        self._lock = threading.RLock()
+        self._base_description = initial_description
+        self._overall_predictable = overall_predictable
+        self._nested_translation = False
+        self._activity_sequence = 0
+        self._activities: dict[str, dict[str, Any]] = {}
+        self.task = progress.add_task(
+            self._stage_description(),
+            total=None,
+            eta_label="阶段剩余",
+            show_progress=True,
+        )
+        self.overall_task = progress.add_task(
+            "全程",
+            total=None,
+            eta_label="全程剩余",
+            show_progress=False,
+        )
+
+    def _task(self, task_id: int) -> Task:
+        return next(task for task in self.progress.tasks if task.id == task_id)
+
+    def _activity_status(self) -> str:
+        if not self._activities:
+            return "LLM: idle"
+        active = list(self._activities.values())
+        retrying = [item for item in active if item.get("retry")]
+        primary = max(retrying or active, key=lambda item: int(item["sequence"]))
+        stage = primary.get("stage")
+        tier = str(primary.get("tier") or "unknown")
+        same_group = [
+            item
+            for item in active
+            if item.get("stage") == stage and str(item.get("tier") or "unknown") == tier
+        ]
+        label = _llm_stage_label(stage)
+        retry = primary.get("retry")
+        if isinstance(retry, dict):
+            status = (
+                f"LLM: Retrying {label} [{tier}] "
+                f"{retry.get('attempt', '?')}/{retry.get('max_attempts', '?')} "
+                f"in {float(retry.get('wait_seconds', 0.0)):.1f}s"
+            )
+        else:
+            status = f"LLM: {label} [{tier}]"
+        if len(same_group) > 1:
+            status += f" ×{len(same_group)}"
+        others = len(active) - len(same_group)
+        if others:
+            status += f" (+{others} other request{'s' if others != 1 else ''})"
+        return status
+
+    def _stage_description(self) -> str:
+        return f"{self._base_description} · {self._activity_status()}"
+
+    def _refresh_stage_description(self) -> None:
+        self.progress.update(self.task, description=self._stage_description())
+
+    def on_llm_activity(self, event: str, **data: Any) -> None:
+        """聚合并发模型请求，并只刷新当前阶段标题。"""
+        request_id = data.get("request_id")
+        if not isinstance(request_id, str) or not request_id:
+            return
+        with self._lock:
+            if event == "request_started":
+                self._activity_sequence += 1
+                self._activities[request_id] = {
+                    "stage": data.get("stage"),
+                    "tier": data.get("tier"),
+                    "sequence": self._activity_sequence,
+                }
+            elif event == "request_retry_wait":
+                activity = self._activities.get(request_id)
+                if activity is not None:
+                    self._activity_sequence += 1
+                    activity["sequence"] = self._activity_sequence
+                    activity["retry"] = {
+                        "attempt": data.get("attempt"),
+                        "max_attempts": data.get("max_attempts"),
+                        "wait_seconds": data.get("wait_seconds", 0.0),
+                    }
+            elif event == "request_finished":
+                self._activities.pop(request_id, None)
+            else:
+                return
+            self._refresh_stage_description()
+
+    def close(self) -> None:
+        """释放仅属于当前 Rich 上下文的瞬时请求状态。"""
+        with self._lock:
+            self._activities.clear()
+
+    def _reset_stage(self, done: int, total: int, label: str) -> None:
+        self._base_description = label
+        self.progress.reset(
+            self.task,
+            total=total,
+            completed=done,
+            description=self._stage_description(),
+            eta_label="阶段剩余",
+            show_progress=True,
+        )
+
+    def update_translation(
+        self,
+        chapter_done: int,
+        chapter_total: int,
+        overall_done: int,
+        overall_total: int,
+        label: str,
+    ) -> None:
+        """同时更新当前章节和全书正文的双层进度。"""
+        with self._lock:
+            stage_task = self._task(self.task)
+            if (
+                not self._nested_translation
+                or label != self._base_description
+                or stage_task.total != chapter_total
+                or chapter_done < stage_task.completed
+            ):
+                self._reset_stage(chapter_done, chapter_total, label)
+            else:
+                self.progress.update(
+                    self.task,
+                    completed=chapter_done,
+                    total=chapter_total,
+                    description=self._stage_description(),
+                )
+
+            overall_task = self._task(self.overall_task)
+            description = "全程" if self._overall_predictable else "全程计算中（正文）"
+            eta_label = "全程剩余" if self._overall_predictable else "正文剩余"
+            if (
+                not self._nested_translation
+                or overall_task.total != overall_total
+                or overall_done < overall_task.completed
+            ):
+                self.progress.reset(
+                    self.overall_task,
+                    total=overall_total,
+                    completed=overall_done,
+                    description=description,
+                    eta_label=eta_label,
+                    show_progress=True,
+                )
+            else:
+                self.progress.update(
+                    self.overall_task,
+                    completed=overall_done,
+                    total=overall_total,
+                    description=description,
+                    eta_label=eta_label,
+                    show_progress=True,
+                )
+            self._nested_translation = True
 
     def __call__(self, done: int, total: int, label: str) -> None:
         """刷新当前阶段的标题与计数，避免阶段切换产生多行进度条。"""
-        if total > 0:
-            self.progress.update(
-                self.task,
-                completed=done,
-                total=total,
-                description=label,
+        with self._lock:
+            if self._nested_translation:
+                self._nested_translation = False
+            self._base_description = label
+            if total > 0:
+                task = self._task(self.task)
+                if task.total != total or done < task.completed:
+                    self._reset_stage(done, total, label)
+                else:
+                    self.progress.update(
+                        self.task,
+                        completed=done,
+                        total=total,
+                        description=self._stage_description(),
+                    )
+                return
+            # Rich 的 update(total=None) 表示“不修改 total”，无法从上一阶段的
+            # 确定总数切回滚动模式；重建任务以清除残留的阶段计数和测速样本。
+            self.progress.remove_task(self.task)
+            self.task = self.progress.add_task(
+                self._stage_description(),
+                total=None,
+                eta_label="阶段剩余",
+                show_progress=True,
             )
-            return
-        # Rich 的 update(total=None) 表示“不修改 total”，无法从上一阶段的
-        # 确定总数切回滚动模式；重建任务以清除残留的章节/段落计数。
-        self.progress.remove_task(self.task)
-        self.task = self.progress.add_task(label, total=None)
+
+
+def _close_progress_activity(client: object, bridge: _RichProgressBridge) -> None:
+    """在 Rich 上下文结束前解除客户端对桥接器的引用。"""
+    set_activity_sink = getattr(client, "set_activity_sink", None)
+    if callable(set_activity_sink):
+        set_activity_sink(None)
+    bridge.close()
 
 
 def _version_callback(value: bool) -> None:
@@ -319,34 +585,37 @@ def _translate_impl_or_raise(
 
     orch = Orchestrator(config)
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        MofNCompleteColumn(),
-        TimeElapsedColumn(),
-        console=console,
-    ) as prog:
-        cb = _RichProgressBridge(prog, "准备中…")
-
-        if chapter is not None:
-            try:
-                store = orch.run(input_path, only_chapter=chapter, progress=cb)
-            except ValueError as error:
-                console.print(f"[red]{error}[/]")
-                raise typer.Exit(2) from error
-            console.print(f"[green]已翻第 {chapter} 章[/]，状态目录：{store.run_dir}")
-            _print_usage({"usage": store.load_usage() or {}})
-            return
-
-        result = orch.run_all(
-            input_path,
-            progress=cb,
-            out_format=fmt,
-            out_path=out,
-            do_qa=qa,
-            pdf_engine=pdf_engine,
+    qa_enabled = qa if qa is not None else config.pipeline.consistency_qa
+    overall_predictable = chapter is not None or (
+        not config.pipeline.review and not qa_enabled
+    )
+    with _new_progress() as prog:
+        cb = _RichProgressBridge(
+            prog,
+            "准备中…",
+            overall_predictable=overall_predictable,
         )
+        try:
+            if chapter is not None:
+                try:
+                    store = orch.run(input_path, only_chapter=chapter, progress=cb)
+                except ValueError as error:
+                    console.print(f"[red]{error}[/]")
+                    raise typer.Exit(2) from error
+                console.print(f"[green]已翻第 {chapter} 章[/]，状态目录：{store.run_dir}")
+                _print_usage({"usage": store.load_usage() or {}})
+                return
+
+            result = orch.run_all(
+                input_path,
+                progress=cb,
+                out_format=fmt,
+                out_path=out,
+                do_qa=qa,
+                pdf_engine=pdf_engine,
+            )
+        finally:
+            _close_progress_activity(getattr(orch, "client", None), cb)
 
     s = result["report"]["summary"]
     console.print(
@@ -375,26 +644,12 @@ def _prepare_impl(input_path: str) -> None:
         _require_input_file(input_path)
         config = _load_config()
         orch = Orchestrator(config)
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            console=console,
-        ) as prog:
-            task = prog.add_task("准备中…", total=None)
-
-            def cb(done: int, total: int, label: str) -> None:
-                """把译前准备进度同步到 Rich 任务。"""
-                nonlocal task
-                if total > 0:
-                    prog.update(task, completed=done, total=total, description=label)
-                    return
-                prog.remove_task(task)
-                task = prog.add_task(label, total=None)
-
-            store = orch.prepare_for_translation(input_path, progress=cb)
+        with _new_progress() as prog:
+            cb = _RichProgressBridge(prog, "准备中…")
+            try:
+                store = orch.prepare_for_translation(input_path, progress=cb)
+            finally:
+                _close_progress_activity(getattr(orch, "client", None), cb)
     except (IngestError, ImportError, OSError, ValueError) as error:
         console.print(f"[red]错误：{error}[/]")
         raise typer.Exit(1) from None
@@ -535,16 +790,12 @@ def review(
     orch = Orchestrator(config)
 
     try:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            console=console,
-        ) as prog:
+        with _new_progress() as prog:
             cb = _RichProgressBridge(prog, "准备全书审校…")
-            result = orch.run_review(input, progress=cb)
+            try:
+                result = orch.run_review(input, progress=cb)
+            finally:
+                _close_progress_activity(getattr(orch, "client", None), cb)
     except (IngestError, ImportError, OSError, ValueError) as error:
         console.print(f"[red]错误：{error}[/]")
         raise typer.Exit(1) from None
@@ -765,7 +1016,15 @@ def qa(
     try:
         client = build_client(config)
         client.set_event_sink(store.log_event)
-        issues = ConsistencyChecker(client, config).check(store, g)
+        with _new_progress() as prog:
+            cb = _RichProgressBridge(prog, "一致性 QA…")
+            set_activity_sink = getattr(client, "set_activity_sink", None)
+            if callable(set_activity_sink):
+                set_activity_sink(cb.on_llm_activity)
+            try:
+                issues = ConsistencyChecker(client, config).check(store, g)
+            finally:
+                _close_progress_activity(client, cb)
     finally:
         g.close()
     console.print(f"一致性问题 {len(issues)} 项：")

--- a/trans_novel/llm/base.py
+++ b/trans_novel/llm/base.py
@@ -6,14 +6,19 @@ import logging
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any
+from contextlib import contextmanager
+from itertools import count
+from typing import Any, Iterator
 
 from .json_parser import parse_json_loose
 from .usage import UsageTracker
 
 Messages = list[dict[str, str]]
 EventSink = Callable[..., None]
+ActivitySink = Callable[..., None]
 _LOGGER = logging.getLogger(__name__)
+_ACTIVITY_REQUEST_IDS = count(1)
+_ACTIVITY_REQUEST_ID_LOCK = threading.Lock()
 
 
 class LLMClient(ABC):
@@ -24,11 +29,18 @@ class LLMClient(ABC):
         self.usage = UsageTracker()
         self._event_sink: EventSink | None = None
         self._event_sink_lock = threading.Lock()
+        self._activity_sink: ActivitySink | None = None
+        self._activity_sink_lock = threading.Lock()
 
     def set_event_sink(self, sink: EventSink | None) -> None:
         """绑定运行事件出口；Orchestrator 用它把重试实时写入书籍日志。"""
         with self._event_sink_lock:
             self._event_sink = sink
+
+    def set_activity_sink(self, sink: ActivitySink | None) -> None:
+        """绑定仅供实时 UI 使用的模型请求活动出口。"""
+        with self._activity_sink_lock:
+            self._activity_sink = sink
 
     def _emit_event(self, event: str, **data: Any) -> None:
         """线程安全地发送 provider 事件，日志失败不得掩盖原始模型异常。"""
@@ -40,6 +52,48 @@ class LLMClient(ABC):
                 sink(event, **data)
             except Exception:  # noqa: BLE001 - 可观察性故障不能改变模型调用语义
                 _LOGGER.exception("Failed to write LLM event: %s", event)
+
+    def _emit_activity(self, event: str, **data: Any) -> None:
+        """线程安全地发送瞬时模型活动；观察器失败不得影响请求。"""
+        with self._activity_sink_lock:
+            sink = self._activity_sink
+            if sink is None:
+                return
+            try:
+                sink(event, **data)
+            except Exception:  # noqa: BLE001 - UI 故障不能改变模型调用语义
+                _LOGGER.exception("Failed to publish LLM activity: %s", event)
+
+    @contextmanager
+    def request_activity(self, *, stage: str | None, tier: str) -> Iterator[str]:
+        """为一次顶层模型请求发送 started/finished 生命周期事件。"""
+        with _ACTIVITY_REQUEST_ID_LOCK:
+            request_id = f"llm-{next(_ACTIVITY_REQUEST_IDS)}"
+        self._emit_activity(
+            "request_started",
+            request_id=request_id,
+            stage=stage,
+            tier=tier,
+        )
+        try:
+            yield request_id
+        except BaseException:
+            self._emit_activity(
+                "request_finished",
+                request_id=request_id,
+                stage=stage,
+                tier=tier,
+                status="failed",
+            )
+            raise
+        else:
+            self._emit_activity(
+                "request_finished",
+                request_id=request_id,
+                stage=stage,
+                tier=tier,
+                status="success",
+            )
 
     def usage_summary(self) -> dict[str, Any]:
         """返回累计 token 用量快照（totals + by_tier + cache_hit_rate）。"""

--- a/trans_novel/llm/providers/_openai_compatible.py
+++ b/trans_novel/llm/providers/_openai_compatible.py
@@ -213,29 +213,35 @@ class OpenAICompatibleBaseClient(LLMClient, Generic[OptionsT]):
         stage: str | None = None,
     ) -> str:
         """按指定档位调用兼容接口，自动重试并记录标准化用量。"""
-        tier_config = resolve_tier(self.tiers, tier)
-        kwargs = self._build_request_kwargs(
-            tier_config,
-            messages,
-            json_mode=json_mode,
-            max_tokens=max_tokens,
-        )
-        client = self._ensure_client()
+        with self.request_activity(stage=stage, tier=tier) as request_id:
+            tier_config = resolve_tier(self.tiers, tier)
+            kwargs = self._build_request_kwargs(
+                tier_config,
+                messages,
+                json_mode=json_mode,
+                max_tokens=max_tokens,
+            )
+            client = self._ensure_client()
 
-        reporter = RetryReporter(
-            provider=self.provider_name,
-            tier=tier,
-            stage=stage,
-            max_attempts=max(1, self.cfg.max_retries + 1),
-            emit=self._emit_event,
-        )
+            reporter = RetryReporter(
+                provider=self.provider_name,
+                tier=tier,
+                stage=stage,
+                max_attempts=max(1, self.cfg.max_retries + 1),
+                emit=self._emit_event,
+                activity_emit=lambda event, **data: self._emit_activity(
+                    event,
+                    request_id=request_id,
+                    **data,
+                ),
+            )
 
-        @provider_retry(self.cfg.max_retries, reporter)
-        def _call() -> str:
-            """执行一次实际请求；异常交由 tenacity 重试装饰器处理。"""
-            response = client.chat.completions.create(**kwargs)
-            sample = self._normalize_usage(getattr(response, "usage", None))
-            self.usage.record(tier, sample, stage)
-            return response.choices[0].message.content or ""
+            @provider_retry(self.cfg.max_retries, reporter)
+            def _call() -> str:
+                """执行一次实际请求；异常交由 tenacity 重试装饰器处理。"""
+                response = client.chat.completions.create(**kwargs)
+                sample = self._normalize_usage(getattr(response, "usage", None))
+                self.usage.record(tier, sample, stage)
+                return response.choices[0].message.content or ""
 
-        return _call()
+            return _call()

--- a/trans_novel/llm/providers/fake.py
+++ b/trans_novel/llm/providers/fake.py
@@ -34,17 +34,18 @@ class FakeClient(LLMClient):
         stage: str | None = None,
     ) -> str:
         """记录调用并返回处理器结果；未配置处理器时返回最小默认响应。"""
-        self.calls.append(
-            {
-                # Agent Loop 会在后续轮次 append transcript；保存快照，避免历史
-                # 调用记录随同一个 mutable list 被追改。
-                "messages": [dict(message) for message in messages],
-                "tier": tier,
-                "json_mode": json_mode,
-                "max_tokens": max_tokens,
-                "stage": stage,
-            }
-        )
-        if self.handler is not None:
-            return self.handler(messages, tier, json_mode)
-        return "[]" if json_mode else ""
+        with self.request_activity(stage=stage, tier=tier):
+            self.calls.append(
+                {
+                    # Agent Loop 会在后续轮次 append transcript；保存快照，避免历史
+                    # 调用记录随同一个 mutable list 被追改。
+                    "messages": [dict(message) for message in messages],
+                    "tier": tier,
+                    "json_mode": json_mode,
+                    "max_tokens": max_tokens,
+                    "stage": stage,
+                }
+            )
+            if self.handler is not None:
+                return self.handler(messages, tier, json_mode)
+            return "[]" if json_mode else ""

--- a/trans_novel/llm/providers/gemini.py
+++ b/trans_novel/llm/providers/gemini.py
@@ -210,6 +210,27 @@ class GeminiClient(LLMClient):
         stage: str | None = None,
     ) -> str:
         """调用 Gemini 模型并支持重试、JSON 模式与用量归因。"""
+        with self.request_activity(stage=stage, tier=tier) as request_id:
+            return self._complete_with_activity(
+                messages,
+                tier=tier,
+                json_mode=json_mode,
+                max_tokens=max_tokens,
+                stage=stage,
+                request_id=request_id,
+            )
+
+    def _complete_with_activity(
+        self,
+        messages: Messages,
+        *,
+        tier: str,
+        json_mode: bool,
+        max_tokens: int | None,
+        stage: str | None,
+        request_id: str,
+    ) -> str:
+        """在已建立活动生命周期的上下文中执行 Gemini 请求。"""
         tier_config: ResolvedTier[GeminiTierOptions] = resolve_tier(self.tiers, tier)
         client = self._ensure_client()
 
@@ -257,6 +278,11 @@ class GeminiClient(LLMClient):
             stage=stage,
             max_attempts=max(1, self.cfg.max_retries + 1),
             emit=self._emit_event,
+            activity_emit=lambda event, **data: self._emit_activity(
+                event,
+                request_id=request_id,
+                **data,
+            ),
         )
 
         @provider_retry(self.cfg.max_retries, reporter)

--- a/trans_novel/llm/retrying.py
+++ b/trans_novel/llm/retrying.py
@@ -193,6 +193,7 @@ class RetryReporter:
     stage: str | None
     max_attempts: int
     emit: Callable[..., None]
+    activity_emit: Callable[..., None] | None = None
 
     def _error_fields(self, error: Any) -> dict[str, Any]:
         """生成不含请求正文、响应正文和密钥的安全错误字段。"""
@@ -222,6 +223,16 @@ class RetryReporter:
             **fields,
         }
         self.emit("llm_retry_wait", **payload)
+        if self.activity_emit is not None:
+            self.activity_emit(
+                "request_retry_wait",
+                stage=self.stage,
+                tier=self.tier,
+                attempt=retry_state.attempt_number + 1,
+                max_attempts=self.max_attempts,
+                wait_seconds=round(wait_seconds, 3),
+                reason=fields["reason"],
+            )
         _LOGGER.warning(
             "LLM request retrying: provider=%s stage=%s tier=%s attempt=%s/%s "
             "wait=%.3fs reason=%s error=%s request_id=%s",

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -64,6 +64,31 @@ from .runstore import STATUS_DONE, RunStore, slugify
 ProgressFn = Callable[[int, int, str], None]
 
 
+def _report_translation_progress(
+    progress: ProgressFn | None,
+    *,
+    chapter_done: int,
+    chapter_total: int,
+    overall_done: int,
+    overall_total: int,
+    label: str,
+) -> None:
+    """向 Rich 桥报告双层进度，普通回调仍接收原有全书累计值。"""
+    if progress is None:
+        return
+    nested_update = getattr(progress, "update_translation", None)
+    if callable(nested_update):
+        nested_update(
+            chapter_done,
+            chapter_total,
+            overall_done,
+            overall_total,
+            label,
+        )
+        return
+    progress(overall_done, overall_total, label)
+
+
 # 语言名/代码 → ISO 639-1 两字母代码（模型检测结果归一化）
 _LANG_ALIASES = {
     "japanese": "ja",
@@ -369,9 +394,17 @@ class Orchestrator:
         self.extractor = GlossaryExtractor(self.client, config)
         self.annotation_aligner = AnnotationAligner(self.client, config)
 
-    def _bind_llm_events(self, store: RunStore) -> None:
-        """把 provider 重试事件实时写入当前书籍的追加式事件日志。"""
+    def _bind_llm_events(
+        self,
+        store: RunStore,
+        progress: ProgressFn | None = None,
+    ) -> None:
+        """绑定正式重试日志，并把瞬时模型活动交给可选 UI 桥。"""
         self.client.set_event_sink(store.log_event)
+        activity_sink = getattr(progress, "on_llm_activity", None)
+        set_activity_sink = getattr(self.client, "set_activity_sink", None)
+        if callable(set_activity_sink):
+            set_activity_sink(activity_sink if callable(activity_sink) else None)
 
     def _punctuation_enabled(self) -> bool:
         """判断当前目标语言是否应启用中文标点规范化。"""
@@ -455,7 +488,7 @@ class Orchestrator:
         )
         if not store.exists():
             raise ValueError("尚无翻译进度。请先运行 translate。")
-        self._bind_llm_events(store)
+        self._bind_llm_events(store, progress)
         return store
 
     def prepare(self, input_path: str, *, progress: ProgressFn | None = None) -> RunStore:
@@ -469,7 +502,7 @@ class Orchestrator:
             pdf_title = os.path.splitext(os.path.basename(input_path))[0]
             run_dir = os.path.join(self.config.state_dir, slugify(pdf_title))
             store = RunStore(run_dir)
-            self._bind_llm_events(store)
+            self._bind_llm_events(store, progress)
             with store.lock():
                 if store.exists():
                     store.log_event(
@@ -500,7 +533,7 @@ class Orchestrator:
         )
         run_dir = os.path.join(self.config.state_dir, slugify(doc.title))
         store = RunStore(run_dir)
-        self._bind_llm_events(store)
+        self._bind_llm_events(store, progress)
         with store.lock():
             return self._prepare_locked(doc, store, input_path, progress)
 
@@ -1338,11 +1371,22 @@ class Orchestrator:
         chapter_digest = chapter.meta.get("source_digest", "")
 
         batches = _resume_batches(text_segs, self.config.segment.max_chars_per_batch)
+        chapter_done = sum(
+            len(batch)
+            for batch in batches
+            if all(segment.target and segment.target.strip() for segment in batch)
+        )
         label = self._chapter_progress_label(chapter.title, ci)
         # prepare() 的最后一个标签通常是“解析文档…”。续跑首批可能先恢复术语，
         # 若不在章首刷新，整个模型请求期间都会错误地显示成仍在解析源文件。
-        if progress:
-            progress(done, total, label)
+        _report_translation_progress(
+            progress,
+            chapter_done=chapter_done,
+            chapter_total=len(text_segs),
+            overall_done=done,
+            overall_total=total,
+            label=label,
+        )
         glossary_checkpoints = store.completed_batch_glossary_keys(ci)
         # 章内术语快照会在每个批次术语抽取后刷新，让新确认的称呼/口癖/固定表达
         # 立即影响后续批次。glossary_scope=chapter 时仍按本章源文裁剪，避免全量表过大。
@@ -1405,8 +1449,14 @@ class Orchestrator:
                     ],
                 )
                 seg_base += len(b)
-                if progress:
-                    progress(done, total, label)
+                _report_translation_progress(
+                    progress,
+                    chapter_done=chapter_done,
+                    chapter_total=len(text_segs),
+                    overall_done=done,
+                    overall_total=total,
+                    label=label,
+                )
                 continue
 
             ctx_text = context.render(self.config.pipeline.rolling_context_segments)
@@ -1452,9 +1502,16 @@ class Orchestrator:
                 ],
             )
             done += len(b)
+            chapter_done += len(b)
             seg_base += len(b)
-            if progress:
-                progress(done, total, label)
+            _report_translation_progress(
+                progress,
+                chapter_done=chapter_done,
+                chapter_total=len(text_segs),
+                overall_done=done,
+                overall_total=total,
+                label=label,
+            )
             # 译文落盘后再抽取术语，避免中断时术语库领先章节产物。
             self._extract_batch_glossary(
                 glossary,


### PR DESCRIPTION
## What changed

- Add compact current-stage ETA and conservative whole-run ETA to the existing Rich progress area.
- Show the active LLM business step and tier, including concurrent request aggregation, retry waits, and an explicit idle state.
- Add an optional in-process activity observer to the shared LLM client without changing the existing persisted event sink.
- Cover OpenAI-compatible, Gemini, and Fake request lifecycles.
- Report current-chapter and whole-book translation progress to the Rich bridge while preserving the public three-argument progress callback.
- Reuse the same progress bridge for translate, prepare, review, and standalone QA.

## Why

Long translation and review runs previously showed progress counts and elapsed time but did not expose an estimated remaining time or which model-backed business step was currently active. This makes long-running CLI work easier to understand without adding scrolling logs or exposing prompts, responses, provider details, credentials, or model reasoning.

## Compatibility and impact

- No new CLI arguments, configuration fields, state files, or database fields.
- No provider streaming changes.
- No changes to translation output, request ordering, request count, concurrency, resumability, usage stage names, or the existing `events.jsonl` format.
- Custom clients that do not implement the optional activity observer continue to work and simply omit live model status.

## Validation

- `uv run pytest -q` — 400 passed, 38 subtests passed.
- `uv run pytest tests/test_cli.py tests/test_llm.py tests/test_llm_retrying.py tests/test_llm_gemini.py -q` — 92 passed, 20 subtests passed.
- `uv run ruff check .` — passed.
- `git diff --check` — passed.

## Scope note

This PR intentionally excludes the separate universal LLM provider/configuration refactor and contains only the real-time ETA and model-activity feature.
