### PR TITLE
fix(epub): skip annotation-only marker blocks

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,7 +245,7 @@ class TestCliConfig(unittest.TestCase):
             )
 
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertIn("--chapter 只翻译并保存指定章节", result.output)
+        self.assertIn("--chapter 只翻译并保存指定章节", " ".join(result.output.split()))
         self.assertIn("--review/--no-review", result.output)
 
     def test_top_level_help_exposes_workflow_without_duplicate_aliases(self):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -422,8 +422,14 @@ class TestEpubIngest(unittest.TestCase):
 
         self.assertEqual(segments, [])
         rendered = BeautifulSoup(template, "html.parser")
-        self.assertEqual(rendered.find("p").get_text(), "[←1]")
-        self.assertEqual(rendered.find("a").get("href"), "#tn2_1")
+        paragraph = rendered.find("p")
+        self.assertIsInstance(paragraph, Tag)
+        assert isinstance(paragraph, Tag)
+        self.assertEqual(paragraph.get_text(), "[←1]")
+        link = rendered.find("a")
+        self.assertIsInstance(link, Tag)
+        assert isinstance(link, Tag)
+        self.assertEqual(link.get("href"), "#tn2_1")
 
     def test_epub_point_annotation_is_excluded_from_source(self):
         html = """<html><body><p>Buck Mulligan<sup id="note-wrap"><a

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -415,6 +415,16 @@ def _write_annotation_context_epub(path: str, *, notes_in_spine: bool) -> None:
 
 
 class TestEpubIngest(unittest.TestCase):
+    def test_epub_annotation_only_marker_is_not_translated(self):
+        html = '<html><body><p>[<a href="#tn2_1">←1</a>]</p></body></html>'
+
+        _title, segments, template = annotate_epub_resource(html, 0, "notes.xhtml")
+
+        self.assertEqual(segments, [])
+        rendered = BeautifulSoup(template, "html.parser")
+        self.assertEqual(rendered.find("p").get_text(), "[←1]")
+        self.assertEqual(rendered.find("a").get("href"), "#tn2_1")
+
     def test_epub_point_annotation_is_excluded_from_source(self):
         html = """<html><body><p>Buck Mulligan<sup id="note-wrap"><a
         id="jpref1" href="notes.xhtml#jpnote1">2</a></sup> came down.</p></body></html>"""

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1030,7 +1030,7 @@ class TestPerRunMetrics(unittest.TestCase):
             self.assertEqual(errors, [])
             self.assertTrue(os.path.isfile(output))
 
-    def test_assemble_hashes_large_input_once_when_file_signature_is_stable(self):
+    def test_assemble_hashes_at_required_source_identity_boundaries(self):
         with tempfile.TemporaryDirectory() as directory:
             source = os.path.join(directory, "novel.txt")
             output = os.path.join(directory, "translated.txt")
@@ -1058,7 +1058,7 @@ class TestPerRunMetrics(unittest.TestCase):
                     out_path=output,
                 )
 
-            self.assertEqual(initial_hash.call_count, 1)
+            self.assertEqual(initial_hash.call_count, 5 if os.name == "nt" else 1)
             self.assertEqual(boundary_hash.call_count, 0)
 
     def test_changed_source_is_rejected_before_reusing_state(self):

--- a/trans_novel/agents/annotation_aligner.py
+++ b/trans_novel/agents/annotation_aligner.py
@@ -394,8 +394,12 @@ class AnnotationAligner(Agent):
             if len(candidates) != 1:
                 results[index] = fallback_alignment(unit)
                 continue
+            marked_target = candidates[0].get("marked_target")
+            if not isinstance(marked_target, str):
+                results[index] = fallback_alignment(unit)
+                continue
             try:
-                placements = validate_marked_target(unit, candidates[0].get("marked_target"))
+                placements = validate_marked_target(unit, marked_target)
             except Exception:  # noqa: BLE001 - one malformed item must not poison its peers
                 results[index] = fallback_alignment(unit)
                 continue

--- a/trans_novel/ingest/epub_reader.py
+++ b/trans_novel/ingest/epub_reader.py
@@ -916,6 +916,12 @@ def annotate_epub_resource(
                 descendant.insert_before(marker)
 
         text, meta = _segment_content(el, anchor, annotations)
+        if (
+            annotations
+            and all(annotation.get("mode") == "point" for annotation in annotations.values())
+            and _ANNOTATION_MARKER_ONLY.fullmatch(text)
+        ):
+            continue
         if not text:
             continue
         el["data-tn-id"] = anchor

--- a/trans_novel/pipeline/metrics.py
+++ b/trans_novel/pipeline/metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import time
 import uuid
@@ -306,7 +307,12 @@ class RunMetricsRecorder:
             return None
         path = Path(input_path)
         current_signature = _source_signature(path)
-        if self._input_signature is not None and current_signature == self._input_signature:
+        # Windows st_ctime is the creation time, so same-size rewrites can keep this signature.
+        if (
+            os.name != "nt"
+            and self._input_signature is not None
+            and current_signature == self._input_signature
+        ):
             return expected
 
         refreshed, signature = _capture_input_identity(input_path)

--- a/trans_novel/pipeline/review_evidence.py
+++ b/trans_novel/pipeline/review_evidence.py
@@ -301,8 +301,16 @@ class BookEvidenceIndex:
         text_index = arguments.get("index")
         before = arguments.get("before", 2)
         after = arguments.get("after", 2)
-        values = (chapter, text_index, before, after)
-        if any(isinstance(value, bool) or not isinstance(value, int) for value in values):
+        if (
+            isinstance(chapter, bool)
+            or not isinstance(chapter, int)
+            or isinstance(text_index, bool)
+            or not isinstance(text_index, int)
+            or isinstance(before, bool)
+            or not isinstance(before, int)
+            or isinstance(after, bool)
+            or not isinstance(after, int)
+        ):
             return {"ok": False, "error": "invalid_segment_context_arguments"}
         if not 0 <= before <= 6 or not 0 <= after <= 6:
             return {"ok": False, "error": "context_limit_exceeded"}
@@ -354,6 +362,13 @@ class BookEvidenceIndex:
             return {"request_id": "", "ok": False, "error": "invalid_request_id"}
         if not isinstance(arguments, dict):
             return {"request_id": request_id, "ok": False, "error": "invalid_arguments"}
+        if not isinstance(tool, str):
+            return {
+                "request_id": request_id,
+                "tool": tool,
+                "ok": False,
+                "error": "unknown_tool",
+            }
         handlers = {
             "glossary_term": self.glossary_term,
             "term_occurrences": self.term_occurrences,


### PR DESCRIPTION
## 问题

EPUB 的纯注释标记块（例如 `[<a>←1</a>]`）在提取注释结构后会留下 `[]`，被误当作正文送入翻译。模型返回空字符串后触发对齐错误；直接允许空译文又会破坏续跑、进度和章节完成状态对非空译文的约定。

## 修改

- 在 EPUB 解析阶段跳过仅由 point 注释和标记字符组成的块，原始注释链接仍保留在 XHTML 模板中。
- CLI 测试比较前折叠空白，兼容 Rich 在 Windows 下的自动换行。
- Windows 的 `st_ctime` 是创建时间，无法可靠发现同尺寸改写；Windows 在状态消费边界重新校验源文件 SHA-256，Linux 保留原有快速路径。

## 验证

- WSL：`450 passed, 41 subtests passed`
- 原生 Windows：`450 passed, 41 subtests passed`
- WSL / Windows Ruff：通过
- `ruff format --check .`、`git diff --check`：通过
- 全部测试离线运行，未调用真实模型 API

已向 issue 提出者索取触发问题的原始 EPUB，目前尚未收到回复；收到后会补充真实样本验证。

Fixes #150
