### PR TITLE
fix: park per-run metrics behind a hard off switch

### DIFF
--- a/tests/test_pdf_support.py
+++ b/tests/test_pdf_support.py
@@ -156,33 +156,34 @@ class TestPdfIngest(unittest.TestCase):
                 }
             )
 
-            with (
-                patch(
+            with patch("trans_novel.pipeline.orchestrator._RUN_METRICS_ENABLED", True):
+                with (
+                    patch(
+                        "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
+                        side_effect=RuntimeError("temporary outage"),
+                    ),
+                    self.assertRaises(MinerUError),
+                ):
+                    Orchestrator(config, client=FakeClient()).prepare_for_translation(pdf_path)
+
+                def convert_fresh(_input: str, output: str, **_kwargs) -> None:
+                    os.makedirs(os.path.dirname(output), exist_ok=True)
+                    with open(output, "w", encoding="utf-8") as file:
+                        file.write(_HTML)
+
+                with patch(
                     "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
-                    side_effect=RuntimeError("temporary outage"),
-                ),
-                self.assertRaises(MinerUError),
-            ):
-                Orchestrator(config, client=FakeClient()).prepare_for_translation(pdf_path)
+                    side_effect=convert_fresh,
+                ):
+                    store = Orchestrator(
+                        config,
+                        client=FakeClient(),
+                    ).prepare_for_translation(pdf_path)
 
-            def convert_fresh(_input: str, output: str, **_kwargs) -> None:
-                os.makedirs(os.path.dirname(output), exist_ok=True)
-                with open(output, "w", encoding="utf-8") as file:
-                    file.write(_HTML)
-
-            with patch(
-                "trans_novel.ingest.pdf_to_html.convert_pdf_to_html",
-                side_effect=convert_fresh,
-            ):
-                store = Orchestrator(
-                    config,
-                    client=FakeClient(),
-                ).prepare_for_translation(pdf_path)
-
-            self.assertEqual(
-                [metric["status"] for metric in store.load_run_metrics()],
-                ["failed", "completed"],
-            )
+                self.assertEqual(
+                    [metric["status"] for metric in store.load_run_metrics()],
+                    ["failed", "completed"],
+                )
 
     def test_orchestrator_uses_state_cache_and_resume_skips_pdf_parse(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -696,6 +696,19 @@ class TestUsageIncrementalPersistence(unittest.TestCase):
 
 
 class TestPerRunMetrics(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # 产品默认关闭账本；本类显式打开以覆盖实现路径。
+        cls._run_metrics_enabled = patch(
+            "trans_novel.pipeline.orchestrator._RUN_METRICS_ENABLED",
+            True,
+        )
+        cls._run_metrics_enabled.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._run_metrics_enabled.stop()
+
     @staticmethod
     def _config(directory: str) -> Config:
         return Config.from_dict(

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -68,6 +68,9 @@ from .runstore import STATUS_DONE, RunStore, slugify, source_sha256
 
 ProgressFn = Callable[[int, int, str], None]
 
+# 单次运行账本（run_metrics/）暂不启用；完善后改为 True 即可放量。
+_RUN_METRICS_ENABLED = False
+
 
 def _record_run_metrics(
     operation: str,
@@ -497,7 +500,7 @@ class Orchestrator:
         if active is not None:
             yield active
             return
-        if self._run_metrics_suppressed:
+        if self._run_metrics_suppressed or not _RUN_METRICS_ENABLED:
             yield None
             return
 


### PR DESCRIPTION
Disable writing state/*/run_metrics by default without a config flag. Keep the implementation and enable it only in tests until the feature is ready to ship.