### PR TITLE
perf(glossary): order terms by insert time for prompt cache

### DIFF
--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -210,6 +210,36 @@ class TestGlossary(unittest.TestCase):
         s = self.store.stats()
         self.assertEqual(s, {"terms": 1, "open_conflicts": 0})
 
+    def test_all_terms_preserves_insert_order_not_type_source_sort(self):
+        """入库先后决定 all_terms 顺序，避免新词插队打乱 prompt 前缀缓存。"""
+        # 故意先插「乙」(type 术语)，再插「甲」(type 人物)：字母/类型序会变成 甲,乙。
+        self.store.upsert_term(
+            GlossaryTerm(source="乙", target="Yi", type="术语"),
+            chapter=0,
+        )
+        self.store.upsert_term(
+            GlossaryTerm(source="甲", target="Jia", type=TYPE_PERSON),
+            chapter=0,
+        )
+        self.assertEqual(
+            [term.source for term in self.store.all_terms()],
+            ["乙", "甲"],
+        )
+        # 人工改定译法（或同 target 合并字段）不得改变入库位置。
+        self.assertTrue(self.store.resolve_term("乙", "Yi-updated"))
+        terms = self.store.all_terms()
+        self.assertEqual([term.source for term in terms], ["乙", "甲"])
+        self.assertEqual(terms[0].target, "Yi-updated")
+        # 新词只能追加在末尾。
+        self.store.upsert_term(
+            GlossaryTerm(source="丙", target="Bing", type=TYPE_PERSON),
+            chapter=1,
+        )
+        self.assertEqual(
+            [term.source for term in self.store.all_terms()],
+            ["乙", "甲", "丙"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -606,7 +606,9 @@ def glossary_list(
     g = GlossaryStore(store.glossary_path)
     try:
         table = Table("原文", "译文", "类型", "状态")
-        for term in g.all_terms():
+        # all_terms() 现按入库顺序返回（供 prompt 注入复用前缀缓存）；
+        # CLI 展示仍按类型/原文分组，只在这里排序，不改共享数据源的顺序。
+        for term in sorted(g.all_terms(), key=lambda t: (t.type, t.source)):
             table.add_row(
                 term.source,
                 term.target,

--- a/trans_novel/glossary/store.py
+++ b/trans_novel/glossary/store.py
@@ -260,7 +260,9 @@ class GlossaryStore:
             conn = sqlite3.connect(snapshot_path)
             conn.row_factory = sqlite3.Row
             try:
-                rows = conn.execute("SELECT * FROM glossary ORDER BY type, source").fetchall()
+                # 按入库顺序（rowid）返回，而非按 type/source 字母序：后者会让新增词条
+                # 插进已有列表中间，使注入 prompt 的对照表整体错位，白白打掉前缀缓存。
+                rows = conn.execute("SELECT * FROM glossary ORDER BY rowid").fetchall()
                 return [GlossaryTerm.from_row(row) for row in rows]
             finally:
                 conn.close()
@@ -352,8 +354,15 @@ class GlossaryStore:
         return cur.rowcount > 0
 
     def all_terms(self) -> list[GlossaryTerm]:
-        """按术语类型和原文排序返回全部术语。"""
-        rows = self.conn.execute("SELECT * FROM glossary ORDER BY type, source").fetchall()
+        """按入库顺序（rowid）返回全部术语。
+
+        这是几乎所有翻译/审校/润色 prompt 注入术语表的唯一数据源：按 rowid
+        排序保证既有词条位置恒定，新词条只会追加在末尾，改动最小化才能让
+        DeepSeek 等按前缀匹配的缓存持续命中；不得改回按 type/source 字母序
+        （新词插入表中间会让后面所有词条错位，整段前缀失效）。人类浏览用的
+        字母序分组排序应在展示层（如 CLI）自行 sorted()，不要动这里。
+        """
+        rows = self.conn.execute("SELECT * FROM glossary ORDER BY rowid").fetchall()
         return [GlossaryTerm.from_row(r) for r in rows]
 
     @staticmethod


### PR DESCRIPTION
Return all_terms() in rowid order so new entries only append in translation prompts. Keep type/source sorting in the CLI list view and lock the behavior with a unit test.