### PR TITLE
feat(epub): align multi-note paragraphs one annotation at a time

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,7 @@ pipeline:
     # fast 档免思考，全书概览为恒定前缀可命中缓存复用；关掉省去预扫成本
   prescan_concurrency: 4 # 预扫逐章梗概的并发线程数（各章独立，1=串行）
   annotation_alignment: true # 每个含注释逻辑段译完后串行定位链接；关闭时仅译文侧退化为段末标记
+  annotation_alignment_concurrency: 4 # 单个逻辑段内注释数 >1 时，按条并发请求定位的最大并发数（降低多注释段落回退率）
   review_concurrency: 4 # 最终审校连续分块的并发数（只读最终译文/术语快照，1=串行）
   review_output_retries: 2 # 单段审校输出畸形时额外重试次数（初次+2=最多 3 次）
   review_agent_loop: true # 初审发现候选后，使用强档按需取证并复核

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,7 @@ pipeline:
   book_understanding: true
   prescan_concurrency: 4
   annotation_alignment: true
+  annotation_alignment_concurrency: 4
   review_concurrency: 4
   review_output_retries: 2
   review_agent_loop: true
@@ -200,6 +201,7 @@ pipeline:
 - `book_understanding`: prescan the book to create chapter digests and a whole-book synopsis.
 - `prescan_concurrency`: number of chapter-digest requests that may run concurrently.
 - `annotation_alignment`: enabled by default. After each annotated logical paragraph has been fully translated and polished, finalize its punctuation and immediately locate EPUB footnote/endnote links with one sequential model call. Split continuations are rejoined first, and segments without internal links do not call the model. When disabled, translated links remain clickable but fall back to end-of-paragraph markers; untranslated text and the source side of bilingual output retain the original link positions. This option controls link placement only; resolved source-language note content is supplied to translation automatically.
+- `annotation_alignment_concurrency`: when a paragraph carries more than one annotation, each annotation is aligned through its own independent, concurrently issued request instead of asking one call to place every marker at once (a single mistake used to invalidate the whole paragraph's markers, which is why heavily annotated books tended to fall back to end-of-paragraph placement far more often). This caps how many of those per-annotation requests may run at once for a single paragraph.
 - `review_concurrency`: concurrency limit for contiguous review chunks and same-round Fixer calls against an immutable translation snapshot; set it to `1` for sequential work.
 - `review_output_retries`: extra attempts for a single-segment review whose output still lacks a valid completion receipt after local JSON repair and larger-chunk splitting; `2` means at most three attempts including the first call.
 - `review_agent_loop`: after the unchanged initial Reviewer finds candidates in a successful leaf chunk, let an Agent Loop selectively request evidence and confirm, dismiss, or refine those candidates.

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -197,6 +197,7 @@ pipeline:
   book_understanding: true
   prescan_concurrency: 4
   annotation_alignment: true
+  annotation_alignment_concurrency: 4
   review_concurrency: 4
   review_output_retries: 2
   review_agent_loop: true
@@ -216,6 +217,7 @@ pipeline:
 - `book_understanding`：预扫全书，生成章节梗概和全书概览。
 - `prescan_concurrency`：预扫章节梗概的并发数。
 - `annotation_alignment`：默认开启。EPUB 中存在脚注、尾注等内部链接时，每个含注释的逻辑段在翻译、润色和标点定稿后立即串行调用一次模型定位；超长续段会先重新合并，不含注释的段落不会调用模型。关闭后，译文侧仍保留链接但退化为段末可点击标记；未翻译原文及双语版原文侧保留源 EPUB 中的原始位置。该选项只控制链接定位；已经解析出的原语言注释正文始终会自动提供给对应翻译段落。
+- `annotation_alignment_concurrency`：当一个逻辑段内注释数超过一条时，不再用一次模型调用要求同时摆对所有标记（一条出错就会连累整段全部标记回退），而是给每条注释单独发起一次并发请求；该项限制同一段内这些逐条请求可同时并发的上限。
 - `review_concurrency`：针对同一份不可变译文快照执行连续审校块和同轮 Fixer 调用的并发上限；设为 `1` 时串行执行。
 - `review_output_retries`：本地 JSON 修复和较大审校块拆分后，单段响应仍缺少有效完成回执时的额外重试次数；设为 `2` 表示连同初次调用最多尝试 3 次。
 - `review_agent_loop`：原有 Reviewer 提示词在成功叶块中发现候选后，允许 Agent Loop 选择性请求证据，再确认、驳回或细化这些候选。

--- a/tests/test_annotation_aligner.py
+++ b/tests/test_annotation_aligner.py
@@ -50,6 +50,37 @@ def _point_unit(*, target: str = "你好世界") -> AnnotationUnit:
     )
 
 
+def _multi_item_unit(*, target: str = "你好世界，再见") -> AnnotationUnit:
+    return AnnotationUnit(
+        unit_id="tn2_0",
+        source="Hello world, goodbye",
+        target=target,
+        items=(
+            {
+                "id": "tn2_0_annotation_0",
+                "mode": "point",
+                "source_start": 5,
+                "source_end": 5,
+                "source_text": "",
+                "marker_text": "1",
+            },
+            {
+                "id": "tn2_0_annotation_1",
+                "mode": "point",
+                "source_start": 12,
+                "source_end": 12,
+                "source_text": "",
+                "marker_text": "2",
+            },
+        ),
+    )
+
+
+def _source_with_markers_of(messages: list[dict[str, str]]) -> str:
+    request = json.loads(messages[-1]["content"].split("INPUT JSON:\n", 1)[1])
+    return request["items"][0]["source_with_markers"]
+
+
 def _range_unit() -> AnnotationUnit:
     return AnnotationUnit(
         unit_id="tn1_1",
@@ -310,6 +341,86 @@ class TestAnnotationAligner(unittest.TestCase):
         self.assertEqual(client.calls, [])
         self.assertEqual(len(results), 2)
         self.assertTrue(all(result.used_fallback for result in results))
+
+
+class TestAnnotationAlignerPerItemFanOut(unittest.TestCase):
+    """A block with >1 annotation must not bundle every marker into one call."""
+
+    def test_multi_item_block_issues_one_concurrent_request_per_annotation(self):
+        unit = _multi_item_unit()
+
+        def handler(messages, tier, json_mode):
+            source_with_markers = _source_with_markers_of(messages)
+            if "tn2_0_annotation_0" in source_with_markers:
+                marked = "你好⟪tn2_0_annotation_0⟫世界，再见"
+            else:
+                marked = "你好世界，⟪tn2_0_annotation_1⟫再见"
+            return json.dumps(
+                {"items": [{"unit_id": "tn2_0", "marked_target": marked}]},
+                ensure_ascii=False,
+            )
+
+        client = FakeClient(handler=handler)
+        result = AnnotationAligner(client, _config()).align_unit(unit)
+
+        # One independent request per annotation, not one request for the
+        # whole paragraph asking the model to place both markers at once.
+        self.assertEqual(len(client.calls), 2)
+        self.assertFalse(result.used_fallback)
+        self.assertEqual(
+            [placement["id"] for placement in result.placements],
+            ["tn2_0_annotation_0", "tn2_0_annotation_1"],
+        )
+        placements = {placement["id"]: placement for placement in result.placements}
+        self.assertEqual(placements["tn2_0_annotation_0"]["target_start"], 2)
+        self.assertEqual(placements["tn2_0_annotation_1"]["target_start"], 5)
+
+    def test_one_bad_annotation_response_does_not_sink_its_siblings(self):
+        """Splitting per item means a single mistake only costs that one note."""
+        unit = _multi_item_unit()
+
+        def handler(messages, tier, json_mode):
+            source_with_markers = _source_with_markers_of(messages)
+            if "tn2_0_annotation_0" in source_with_markers:
+                marked = "你好⟪tn2_0_annotation_0⟫世界，再见"
+                return json.dumps(
+                    {"items": [{"unit_id": "tn2_0", "marked_target": marked}]},
+                    ensure_ascii=False,
+                )
+            # Model drops the Chinese comma while copying the target: this
+            # single mistake must only cost annotation_1, not annotation_0.
+            marked = "你好世界再见⟪tn2_0_annotation_1⟫"
+            return json.dumps(
+                {"items": [{"unit_id": "tn2_0", "marked_target": marked}]},
+                ensure_ascii=False,
+            )
+
+        client = FakeClient(handler=handler)
+        result = AnnotationAligner(client, _config()).align_unit(unit)
+
+        self.assertEqual(len(client.calls), 2)
+        self.assertTrue(result.used_fallback)
+        placements = {placement["id"]: placement for placement in result.placements}
+        self.assertEqual(placements["tn2_0_annotation_0"]["status"], "aligned")
+        self.assertEqual(placements["tn2_0_annotation_0"]["target_start"], 2)
+        self.assertEqual(placements["tn2_0_annotation_1"]["status"], "fallback")
+
+    def test_duplicate_ids_within_one_block_fall_back_without_calling_model(self):
+        unit = AnnotationUnit(
+            unit_id="tn3_0",
+            source="Hello world, goodbye",
+            target="你好世界，再见",
+            items=(
+                {"id": "dup", "mode": "point", "source_start": 5, "source_end": 5},
+                {"id": "dup", "mode": "point", "source_start": 12, "source_end": 12},
+            ),
+        )
+        client = FakeClient(handler=lambda messages, tier, json_mode: "should not be called")
+
+        result = AnnotationAligner(client, _config()).align_unit(unit)
+
+        self.assertEqual(client.calls, [])
+        self.assertTrue(result.used_fallback)
 
 
 if __name__ == "__main__":

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -582,6 +582,63 @@ data-tn-annotation-id="ann-0" href="notes.xhtml#note-1">border tunnel
         self.assertNotIn("border tunnel", paragraph.get_text())
         self.assertIsNone(rendered.select_one("[data-tn-annotation-id]"))
 
+    def test_epub_render_separates_multiple_fallback_markers_with_a_comma(self):
+        target = "正文内容。"
+        template = (
+            '<html><body><p data-tn-id="tn1_0">Foo'
+            '<a data-tn-annotation-id="ann-0" href="notes.xhtml#n1">11</a>'
+            " bar"
+            '<a data-tn-annotation-id="ann-1" href="notes.xhtml#n2">12</a>'
+            " baz.</p></body></html>"
+        )
+        segment = Segment(
+            index=0,
+            source="Foo bar baz.",
+            target=target,
+            anchor="tn1_0",
+            meta={
+                "epub_annotations": {
+                    "version": 1,
+                    "source_length": len("Foo bar baz."),
+                    "items": [
+                        {
+                            "id": "ann-0",
+                            "mode": "point",
+                            "source_start": 3,
+                            "source_end": 3,
+                            "source_text": "",
+                            "marker_text": "11",
+                        },
+                        {
+                            "id": "ann-1",
+                            "mode": "point",
+                            "source_start": 7,
+                            "source_end": 7,
+                            "source_text": "",
+                            "marker_text": "12",
+                        },
+                    ],
+                    # 过期摘要强制两条注释都降级为段末回退标记。
+                    "target_digest": "stale",
+                    "placements": [],
+                }
+            },
+        )
+
+        rendered = BeautifulSoup(
+            _render_segments_html(template, [segment]),
+            "html.parser",
+        )
+
+        paragraph = rendered.find("p")
+        self.assertIsInstance(paragraph, Tag)
+        assert isinstance(paragraph, Tag)
+        links = paragraph.find_all("a")
+        self.assertEqual([link.get_text() for link in links], ["11", "12"])
+        # 两个降级标记之间必须有顿号分隔，否则连写成无法轨读的 "1112"。
+        self.assertIn("11、12", paragraph.get_text())
+        self.assertNotIn("1112", paragraph.get_text())
+
     def test_epub_render_keeps_untranslated_annotation_at_source_position(self):
         html = """<html><body><p>Before<sup><a class="noteref"
 href="#n1" id="ref-1">1</a></sup> after.</p></body></html>"""

--- a/trans_novel/agents/annotation_aligner.py
+++ b/trans_novel/agents/annotation_aligner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any
 
@@ -307,6 +308,98 @@ class AnnotationAligner(Agent):
         )
 
     def align_units(self, units: list[AnnotationUnit]) -> list[AnnotationAlignment]:
+        """Align multiple logical blocks, splitting multi-annotation blocks per item.
+
+        A block with N>1 annotations used to go through a single model call
+        that had to reproduce the whole immutable target byte-for-byte *and*
+        place all N markers correctly at once; any single mistake (even in one
+        unrelated marker) invalidated the whole block. That all-or-nothing
+        contract is why annotation-dense books (e.g. a heavily footnoted
+        classic where nearly every paragraph carries a note) tend to fall back
+        to paragraph-end placement far more than the per-annotation model
+        error rate would suggest.
+
+        Blocks with more than one annotation are instead split into one
+        independent, concurrently issued request per annotation: each request
+        only has to place a single marker, so a bad response only costs that
+        one note instead of every note sharing its paragraph. Concurrency
+        (bounded by ``pipeline.annotation_alignment_concurrency``) keeps
+        wall-clock time from growing with the number of notes per block.
+        Results preserve input order regardless of which path a block took.
+        """
+
+        if not units:
+            return []
+
+        results: list[AnnotationAlignment | None] = [None] * len(units)
+        direct_indices = [index for index, unit in enumerate(units) if len(unit.items) <= 1]
+        split_indices = [index for index, unit in enumerate(units) if len(unit.items) > 1]
+
+        if direct_indices:
+            direct_units = [units[index] for index in direct_indices]
+            for index, result in zip(direct_indices, self._align_batch(direct_units)):
+                results[index] = result
+
+        for index in split_indices:
+            results[index] = self._align_split_unit(units[index])
+
+        return [
+            result if result is not None else fallback_alignment(units[index])
+            for index, result in enumerate(results)
+        ]
+
+    def _align_split_unit(self, unit: AnnotationUnit) -> AnnotationAlignment:
+        """Align every annotation of one block through its own concurrent request.
+
+        Validates ids up front (same integrity check ``build_marked_source``
+        would otherwise raise on) so a corrupt item still degrades the whole
+        block deterministically instead of partially. Each well-formed item is
+        then aligned independently: a mistake in one annotation's response
+        never affects its siblings.
+        """
+
+        try:
+            _expected_markers(unit)
+        except AnnotationAlignmentError:
+            return fallback_alignment(unit)
+
+        workers = max(1, self.config.pipeline.annotation_alignment_concurrency)
+        placements_by_id: dict[str, dict[str, Any]] = {}
+        used_fallback = False
+        with ThreadPoolExecutor(max_workers=min(workers, len(unit.items))) as executor:
+            futures = {
+                executor.submit(self._align_single_item, unit, item): _item_id(item)
+                for item in unit.items
+            }
+            for future in as_completed(futures):
+                item_id = futures[future]
+                placement, item_used_fallback = future.result()
+                placements_by_id[item_id] = placement
+                used_fallback = used_fallback or item_used_fallback
+
+        placements = tuple(placements_by_id[_item_id(item)] for item in unit.items)
+        return AnnotationAlignment(
+            unit_id=unit.unit_id,
+            target_digest=target_digest(unit.target),
+            placements=placements,
+            used_fallback=used_fallback,
+        )
+
+    def _align_single_item(
+        self, unit: AnnotationUnit, item: dict[str, Any]
+    ) -> tuple[dict[str, Any], bool]:
+        """Align exactly one annotation against the unchanged immutable target."""
+
+        pseudo_unit = AnnotationUnit(
+            unit_id=unit.unit_id,
+            source=unit.source,
+            target=unit.target,
+            items=(item,),
+        )
+        [alignment] = self._align_batch([pseudo_unit])
+        return alignment.placements[0], alignment.used_fallback
+
+    def _align_batch(self, units: list[AnnotationUnit]) -> list[AnnotationAlignment]:
         """Align multiple logical blocks in one model call.
 
         Results preserve input order.  A missing, duplicate, or invalid response

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -697,7 +697,11 @@ def _render_text_with_nodes(
         el.append(root)
         cursor = end
     append_until(el, cursor, len(text))
-    for fallback in fallbacks:
+    # 多条降级注释挤在段末时，相邻链接之间原本没有任何分隔文本，脚注数字会
+    # 连写成一串（如 11、12、13 会读成 111213）；插入顿号让它们可辨读。
+    for index, fallback in enumerate(fallbacks):
+        if index > 0:
+            el.append("、")
         el.append(fallback)
 
 

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -57,6 +57,7 @@ pipeline:
   book_understanding: true # 翻译前预扫源文，生成全书概览+逐章梗概注入翻译
   prescan_concurrency: 4 # 预扫逐章梗概的并发线程数（各章独立，1=串行）
   annotation_alignment: true # 逐段定位 EPUB 注释链接；关闭时仅译文侧退化为段末标记
+  annotation_alignment_concurrency: 4 # 单段注释数>1时，按条并发定位的最大并发数
   review_concurrency: 4 # 最终审校连续分块的并发数（只读最终译文/术语快照，1=串行）
   review_output_retries: 2 # 单段审校输出畸形时额外重试次数（初次+2=最多 3 次）
   review_agent_loop: true # 初审发现候选后，使用强档按需取证并复核
@@ -129,6 +130,9 @@ class PipelineConfig(BaseModel):
     book_understanding: bool = True
     prescan_concurrency: int = 4  # 预扫逐章梗概的并发线程数（各章独立，1=串行）
     annotation_alignment: bool = True  # 每个含注释逻辑段定稿后串行定位链接
+    # 单个逻辑段内注释数 >1 时，改为逐条并发请求（每请求只定位一条注释），
+    # 避免单次响应要求模型同时摆对多条标记而整体回退到段末；此为并发上限。
+    annotation_alignment_concurrency: int = 4
     review_concurrency: int = 4  # 最终审校连续分块并发数（结果按原块序合并，1=串行）
     review_output_retries: int = Field(
         default=2,


### PR DESCRIPTION
Fan out multi-annotation blocks into concurrent per-item model calls so one bad marker no longer forces every note in the paragraph to fall back. Separate stacked fallback markers with an ideographic comma for readability.