### PR TITLE
fix: preserve non-linguistic translation segments

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -49,6 +49,42 @@ class TestTranslatorAlignment(unittest.TestCase):
         self.assertEqual(len(out), 3)
         self.assertEqual(out, ["译0", "译1", "译2"])
 
+    def test_nonlinguistic_table_cells_are_preserved_without_model_input(self):
+        def handler(messages, tier, json_mode):
+            user = messages[-1]["content"]
+            self.assertNotIn("-", user.split("【待译", 1)[-1])
+            n = _count_segments(user)
+            return json.dumps({"translations": [f"译{i}" for i in range(n)]}, ensure_ascii=False)
+
+        client = FakeClient(handler=handler)
+        translator = Translator(client, self._config())
+
+        result = translator.translate_batch(["本文", "-", "42", "—", "3.14%"])
+
+        self.assertEqual(result, ["译0", "-", "42", "—", "3.14%"])
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(_count_segments(client.calls[0]["messages"][-1]["content"]), 1)
+
+    def test_all_nonlinguistic_segments_skip_model(self):
+        client = FakeClient(
+            handler=lambda messages, tier, json_mode: self.fail("model must not be called")
+        )
+        translator = Translator(client, self._config())
+
+        result = translator.translate_batch(["-", "42", "……", "(100%)"])
+
+        self.assertEqual(result, ["-", "42", "……", "(100%)"])
+        self.assertEqual(client.calls, [])
+
+    def test_fallback_error_reports_original_segment_index_after_filtering(self):
+        client = FakeClient(
+            handler=lambda messages, tier, json_mode: json.dumps({"translations": []})
+        )
+        translator = Translator(client, self._config())
+
+        with self.assertRaisesRegex(Exception, "第 1 段失败"):
+            translator.translate_batch(["-", "本文", "42"])
+
     def test_fallback_to_per_segment_on_mismatch(self):
         # 多段批次故意少返回一段；单段调用正常 → 触发逐段兜底
         def handler(messages, tier, json_mode):

--- a/trans_novel/assemble/translator.py
+++ b/trans_novel/assemble/translator.py
@@ -21,6 +21,17 @@ class AlignmentError(Exception):
 
 class Translator(Agent):
     @staticmethod
+    def _needs_translation(source: str) -> bool:
+        """仅把含语言文字的非空段落发送给模型。
+
+        PDF 表格经常把 ``-``、纯数字或其它占位符解析为独立段落。模型可能
+        把这些内容返回为空字符串，进而触发对齐失败；这类段落原样保留即可。
+        ``str.isalpha`` 覆盖拉丁、中文、日文、韩文等 Unicode 字母。
+        """
+        stripped = source.strip()
+        return bool(stripped) and any(character.isalpha() for character in stripped)
+
+    @staticmethod
     def _validate_annotation_contexts(
         sources: list[str],
         annotation_contexts: list[list[dict[str, str]]] | None,
@@ -142,37 +153,53 @@ class Translator(Agent):
         if n == 0:
             return []
 
+        translated_indices = [
+            index for index, source in enumerate(sources) if self._needs_translation(source)
+        ]
+        if not translated_indices:
+            return list(sources)
+        translated_sources = [sources[index] for index in translated_indices]
+        translated_annotation_contexts = [
+            annotation_contexts[index] for index in translated_indices
+        ]
+
         attempts = self.config.pipeline.align_retry_limit + 1
         for _ in range(attempts):
             try:
-                return self._call_batch(
-                    sources,
+                translated = self._call_batch(
+                    translated_sources,
                     glossary_terms,
                     style,
                     context,
                     book_synopsis,
                     chapter_digest,
-                    annotation_contexts,
+                    translated_annotation_contexts,
                 )
+                targets = list(sources)
+                for index, target in zip(translated_indices, translated):
+                    targets[index] = target
+                return targets
             except AlignmentError:
                 # 只恢复模型输出协议/对齐错误；传输错误已由 provider 统一处理。
                 continue
 
         # 兜底：逐段翻译。任一段仍失败时显式中断，保留已落盘
         # 批次供续跑；不能用空字符串占位，否则章节会被错误标记为已完成。
-        targets: list[str] = []
-        for index, source in enumerate(sources):
+        targets = list(sources)
+        for index, source, annotation_context in zip(
+            translated_indices,
+            translated_sources,
+            translated_annotation_contexts,
+        ):
             try:
-                targets.append(
-                    self._translate_one(
-                        source,
-                        glossary_terms,
-                        style,
-                        context,
-                        book_synopsis,
-                        chapter_digest,
-                        annotation_contexts[index],
-                    )
+                targets[index] = self._translate_one(
+                    source,
+                    glossary_terms,
+                    style,
+                    context,
+                    book_synopsis,
+                    chapter_digest,
+                    annotation_context,
                 )
             except Exception as error:
                 raise AlignmentError(f"逐段兜底翻译在第 {index} 段失败") from error


### PR DESCRIPTION
## Summary

- preserve non-empty segments that contain no linguistic characters (for example `-`, pure numbers, and punctuation-only PDF table cells) without sending them to the model
- translate only linguistic segments, then merge model outputs back into their original positions
- retain original segment indices in per-segment fallback errors after filtering

## Root cause

PDF table extraction can produce standalone separator cells such as `-`. Some models legitimately return an empty string for those inputs. The strict alignment validator rejects that response, retries the whole batch, and eventually retries each segment individually, where the same separator fails again and aborts the run with `AlignmentError`.

## Impact

Non-linguistic placeholders are now preserved verbatim, so they cannot trigger empty-translation alignment failures and no longer consume model calls. Segments containing Unicode letters, including Latin, Chinese, Japanese, and Korean text, continue through the existing translation and fallback paths.

## Validation

- added regression coverage for mixed text/table placeholders, all-placeholder batches, and original fallback indices
- `461 passed, 41 subtests passed`
- `ruff check trans_novel tests`
- `ruff format --check trans_novel tests`
