### PR TITLE
feat: review 断点续跑（chunk 级缓存 + agent turn 级复用 + 审查修复）

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1114,6 +1114,8 @@ class TestReviewReporting(unittest.TestCase):
                     "result.json",
                     "rounds",
                     "usage.json",
+                    "chunks",
+                    "checkpoint.json",
                 },
             )
 
@@ -1270,8 +1272,8 @@ class TestReviewReporting(unittest.TestCase):
             with self.assertRaisesRegex(ReviewOutputError, "invalid_issue_index"):
                 orch.run_review(txt)
 
-    def test_review_always_reruns_and_creates_a_new_review_directory(self):
-        """每次执行都是一轮独立全书 Review。"""
+    def test_review_skips_when_already_completed_with_same_content(self):
+        """已完成且内容指纹一致的 Review 自动跳过，复用结果。"""
         with tempfile.TemporaryDirectory() as d:
             txt = os.path.join(d, "novel.txt")
             write_sample_txt(txt)
@@ -1282,15 +1284,88 @@ class TestReviewReporting(unittest.TestCase):
 
             first = orch.run_review(txt)
             first_count = sum("译文审校" in call["messages"][0]["content"] for call in client.calls)
-            manifest = orch.prepare(txt).load_manifest()
-            self.assertTrue(all("review_status" not in chapter for chapter in manifest["chapters"]))
+            self.assertGreater(first_count, 0)
 
             second = orch.run_review(txt)
             second_count = sum(
                 "译文审校" in call["messages"][0]["content"] for call in client.calls
             )
-            self.assertEqual(second_count, first_count * 2)
+            # 内容未变 → 跳过，不产生新 LLM 调用
+            self.assertEqual(second_count, first_count)
+            # 复用同一结果
+            self.assertEqual(first["review_dir"], second["review_dir"])
+
+    def test_review_reruns_when_review_config_changed(self):
+        """内容未变但审校配置变化时不得复用旧结果，必须重审。"""
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(os.path.join(d, "state"))
+            client = FakeClient(handler=routing_handler)
+            orch = Orchestrator(cfg, client=client)
+            orch.run(txt)
+
+            first = orch.run_review(txt)
+            first_count = sum("译文审校" in call["messages"][0]["content"] for call in client.calls)
+
+            cfg.pipeline.review_agent_max_evidence_rounds = 1  # 配置变化
+            orch2 = Orchestrator(cfg, client=client)
+            second = orch2.run_review(txt)
+            second_count = sum(
+                "译文审校" in call["messages"][0]["content"] for call in client.calls
+            )
+            self.assertGreater(second_count, first_count)  # 重新审校
             self.assertNotEqual(first["review_dir"], second["review_dir"])
+
+    def test_review_resume_reuses_initial_and_agent_traces(self):
+        """删掉一个 chunk 缓存后续跑：初筛 + agent loop 都走 trace 复用，零调用。"""
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(os.path.join(d, "state"))
+            orch = Orchestrator(cfg, client=FakeClient(handler=self._handler()))
+            store = orch.run(txt)
+            result = orch.run_review(txt)
+
+            # 模拟中断：把已完成 Review 的状态改回 running，并删掉轮级检查点
+            # （真实中断在扫描中途时无 checkpoint，重跑会从 round 1 重新扫描）
+            review_dir = result["review_dir"]
+            result_path = os.path.join(review_dir, "result.json")
+            with open(result_path, encoding="utf-8") as f:
+                state = json.load(f)
+            state["status"] = "running"
+            with open(result_path, "w", encoding="utf-8") as f:
+                json.dump(state, f, ensure_ascii=False, indent=2)
+            checkpoint = os.path.join(review_dir, "checkpoint.json")
+            if os.path.isfile(checkpoint):
+                os.remove(checkpoint)
+
+            # 删除第一个 chunk 缓存，保留其 initial/agent trace
+            chunks_dir = os.path.join(review_dir, "chunks")
+            chunk_files = sorted(os.listdir(chunks_dir))
+            self.assertTrue(chunk_files)
+            removed = os.path.join(chunks_dir, chunk_files[0])
+            removed_bytes = Path(removed).read_bytes()
+            os.remove(removed)
+
+            meter = MeteredFakeClient(handler=self._handler())
+            orch2 = Orchestrator(cfg, client=meter)
+            orch2.run_review(txt)
+
+            reused_stages = [
+                call["stage"]
+                for call in meter.calls
+                if call["stage"] in ("Reviewer", "ReviewAgent")
+            ]
+            self.assertEqual(reused_stages, [])
+            self.assertTrue(os.path.isfile(removed))  # chunk 重新落盘
+            # 复用路径输出与首次运行逐字节一致
+            self.assertEqual(Path(removed).read_bytes(), removed_bytes)
+            # 续跑事件流：agent trace 复用应留痕（本测试中 agent 走 finished 短路，
+            # 不发 review_agent_resumed；仅确认事件日志可正常读取）
+            with open(os.path.join(review_dir, "events.jsonl"), encoding="utf-8") as f:
+                events = [json.loads(line) for line in f if line.strip()]
+            self.assertTrue(any(e["event"] == "review_leaf_finished" for e in events))
 
     def test_review_rejects_incomplete_book(self):
         """独立最终审校要求全书所有章节均已翻译完成。"""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1317,6 +1317,76 @@ class TestReviewReporting(unittest.TestCase):
             self.assertGreater(second_count, first_count)  # 重新审校
             self.assertNotEqual(first["review_dir"], second["review_dir"])
 
+    def test_review_running_resume_rejects_config_change(self):
+        """running 续跑在审校配置变化时不得复用旧目录，应新开 Review。"""
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(os.path.join(d, "state"))
+            client = FakeClient(handler=routing_handler)
+            orch = Orchestrator(cfg, client=client)
+            orch.run(txt)
+
+            first = orch.run_review(txt)
+            review_dir = first["review_dir"]
+            result_path = os.path.join(review_dir, "result.json")
+            with open(result_path, encoding="utf-8") as f:
+                state = json.load(f)
+            state["status"] = "running"
+            with open(result_path, "w", encoding="utf-8") as f:
+                json.dump(state, f, ensure_ascii=False, indent=2)
+            checkpoint = os.path.join(review_dir, "checkpoint.json")
+            if os.path.isfile(checkpoint):
+                os.remove(checkpoint)
+
+            cfg.pipeline.review_agent_max_evidence_rounds = 1
+            orch2 = Orchestrator(cfg, client=client)
+            second = orch2.run_review(txt)
+            self.assertNotEqual(first["review_dir"], second["review_dir"])
+
+    def test_try_cached_subchunks_partial_hit_does_not_record(self):
+        """半边子块命中不得提前写入 initial 快照，避免父块重跑重复计数。"""
+        from trans_novel.pipeline.review_run import ReviewRunStore
+
+        with tempfile.TemporaryDirectory() as d:
+            debug = ReviewRunStore(d)
+            debug.start(
+                reviewed_content_digest="digest",
+                metadata={"config": {}, "glossary_fingerprint": "g"},
+            )
+            # 仅缓存左半：base0-n2；父块 base0-n4 与右半缺失
+            debug.mark_chunk_done(
+                "r1-ch0-base0-n2",
+                {
+                    "issues": [{"index": 0, "type": "mistranslation"}],
+                    "initial_issues": [{"index": 0, "type": "mistranslation"}],
+                    "dismissed": [],
+                },
+            )
+            pieces = [object(), object(), object(), object()]
+            with debug.round_scope(1):
+                missed = Orchestrator._try_cached_subchunks(0, pieces, debug, "r1-", 0)
+            self.assertIsNone(missed)
+            initial, dismissed = debug.result_snapshots(1)
+            self.assertEqual(initial, [])
+            self.assertEqual(dismissed, [])
+
+            debug.mark_chunk_done(
+                "r1-ch0-base2-n2",
+                {
+                    "issues": [{"index": 0, "type": "missing"}],
+                    "initial_issues": [{"index": 0, "type": "missing"}],
+                    "dismissed": [],
+                },
+            )
+            with debug.round_scope(1):
+                hit = Orchestrator._try_cached_subchunks(0, pieces, debug, "r1-", 0)
+            self.assertIsNotNone(hit)
+            assert hit is not None
+            self.assertEqual(len(hit), 2)
+            initial, _dismissed = debug.result_snapshots(1)
+            self.assertEqual(len(initial), 2)
+
     def test_review_resume_reuses_initial_and_agent_traces(self):
         """删掉一个 chunk 缓存后续跑：初筛 + agent loop 都走 trace 复用，零调用。"""
         with tempfile.TemporaryDirectory() as d:
@@ -1324,7 +1394,7 @@ class TestReviewReporting(unittest.TestCase):
             write_sample_txt(txt)
             cfg = _config(os.path.join(d, "state"))
             orch = Orchestrator(cfg, client=FakeClient(handler=self._handler()))
-            store = orch.run(txt)
+            orch.run(txt)
             result = orch.run_review(txt)
 
             # 模拟中断：把已完成 Review 的状态改回 running，并删掉轮级检查点

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -504,6 +504,171 @@ class TestReviewRunStore(unittest.TestCase):
             [1, 2],
         )
 
+    @staticmethod
+    def _usage_summary(calls: int, tokens: int) -> dict:
+        """构造与 usage_delta 输出同构的用量摘要。"""
+        return {
+            "totals": {
+                "calls": calls,
+                "prompt_tokens": tokens,
+                "completion_tokens": 0,
+                "total_tokens": tokens,
+                "cache_hit_tokens": 0,
+                "cache_miss_tokens": tokens,
+            },
+            "by_tier": {
+                "cheap": {
+                    "calls": calls,
+                    "prompt_tokens": tokens,
+                    "completion_tokens": 0,
+                    "total_tokens": tokens,
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": tokens,
+                }
+            },
+            "by_stage": {
+                "Reviewer": {
+                    "calls": calls,
+                    "prompt_tokens": tokens,
+                    "completion_tokens": 0,
+                    "total_tokens": tokens,
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": tokens,
+                }
+            },
+        }
+
+    def test_save_usage_merges_increments_across_resumes(self):
+        """save_usage 必须与已落盘用量合并，跨进程续跑不丢。"""
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            debug.save_usage(self._usage_summary(2, 100))
+            debug.save_usage(self._usage_summary(3, 50))
+            with open(os.path.join(debug.run_dir, "usage.json"), encoding="utf-8") as file:
+                saved = json.load(file)
+
+        self.assertEqual(saved["totals"]["calls"], 5)
+        self.assertEqual(saved["totals"]["total_tokens"], 150)
+        self.assertEqual(saved["by_stage"]["Reviewer"]["calls"], 5)
+
+    def test_rebuild_snapshots_skips_stale_subchunks_contained_in_parent(self):
+        """rebuild 时父块与陈旧子块并存，只统计一次（大块优先）。"""
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            debug.mark_chunk_done(
+                "r1-ch0-base0-n55",
+                {
+                    "status": "finished",
+                    "issues": [],
+                    "initial_issues": [
+                        {"index": 0, "type": "missing", "detail": "父块问题", "suggestion": "补译"}
+                    ],
+                    "dismissed": [
+                        {"index": 1, "type": "terminology", "detail": "父块驳回", "suggestion": ""}
+                    ],
+                },
+            )
+            debug.mark_chunk_done(
+                "r1-ch0-base0-n27",
+                {
+                    "status": "finished",
+                    "issues": [],
+                    "initial_issues": [
+                        {"index": 0, "type": "missing", "detail": "陈旧子块", "suggestion": "补译"}
+                    ],
+                    "dismissed": [],
+                },
+            )
+            debug.mark_chunk_done(
+                "r1-ch0-base55-n5",
+                {
+                    "status": "finished",
+                    "issues": [],
+                    "initial_issues": [],
+                    "dismissed": [
+                        {"index": 0, "type": "terminology", "detail": "独立子块驳回", "suggestion": ""}
+                    ],
+                },
+            )
+            with debug.round_scope(1):
+                debug.rebuild_snapshots_from_chunks(1)
+            initial, dismissed = debug.result_snapshots(1)
+
+        self.assertEqual([issue["detail"] for issue in initial], ["父块问题"])
+        self.assertEqual(
+            [issue["detail"] for issue in dismissed],
+            ["父块驳回", "独立子块驳回"],
+        )
+
+    def test_rebuild_snapshots_is_idempotent_across_resumes(self):
+        """多次恢复（每次新进程重建内存聚合）后快照不重复叠加。"""
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            debug.mark_chunk_done(
+                "r1-ch0-base0-n55",
+                {
+                    "status": "finished",
+                    "issues": [],
+                    "initial_issues": [
+                        {"index": 0, "type": "missing", "detail": "问题A", "suggestion": "补译"}
+                    ],
+                    "dismissed": [
+                        {"index": 1, "type": "terminology", "detail": "驳回B", "suggestion": ""}
+                    ],
+                },
+            )
+            debug.mark_chunk_done(
+                "r1-ch0-base55-n5",
+                {
+                    "status": "finished",
+                    "issues": [],
+                    "initial_issues": [
+                        {"index": 0, "type": "missing", "detail": "问题C", "suggestion": "补译"}
+                    ],
+                    "dismissed": [],
+                },
+            )
+
+            def snapshot_counts() -> tuple[int, int]:
+                # 模拟一次恢复进程：全新 ReviewRunStore 从磁盘重建
+                fresh = ReviewRunStore(directory)
+                with fresh.round_scope(1):
+                    fresh.rebuild_snapshots_from_chunks(1)
+                initial, dismissed = fresh.result_snapshots(1)
+                keys = [
+                    (issue["review_round"], issue["chapter"], issue["index"], issue["candidate_id"])
+                    for issue in [*initial, *dismissed]
+                ]
+                return len(keys), len(set(keys))
+
+            first, first_unique = snapshot_counts()
+            # 第二次、第三次“进程”恢复：行数与唯一性必须保持不变
+            for _ in range(2):
+                count, unique = snapshot_counts()
+                self.assertEqual(count, first)
+                self.assertEqual(unique, first_unique)
+            self.assertEqual(first_unique, first)  # 任何一次恢复内部都无重复行
+
+    def test_from_existing_restores_started_at_from_result(self):
+        """续跑恢复时 started_at 必须从 result.json 恢复。"""
+        with tempfile.TemporaryDirectory() as directory:
+            moment = datetime(2026, 7, 27, 12, 30, tzinfo=timezone.utc)
+            debug = ReviewRunStore(directory, now=moment)
+            debug.start(reviewed_content_digest="abc", metadata={})
+            restored = ReviewRunStore._from_existing(debug.run_dir, debug.review_id)
+
+        self.assertEqual(restored.started_at, debug.started_at)
+
+    def test_load_json_reads_round_scoped_and_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            self.assertIsNone(debug.load_json("agents/r1-chunk-ch0-base0-n2.json"))
+            with debug.round_scope(1):
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {"status": "running"})
+                loaded = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+                self.assertEqual(loaded["status"], "running")
+            self.assertIsNone(debug.load_json("agents/r1-chunk-ch0-base0-n2.json"))
+
 
 class TestReviewAgentLoop(unittest.TestCase):
     def _evidence(self) -> BookEvidenceIndex:
@@ -520,6 +685,332 @@ class TestReviewAgentLoop(unittest.TestCase):
             [GlossaryTerm(source="Ann", target="安", type="人物")],
             {},
         )
+
+    def test_run_resumes_finished_trace_without_calls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "finished",
+                    "turns": [],
+                    "result": {"issues": [], "dismissed": []},
+                })
+                calls = []
+                loop = ReviewAgentLoop(
+                    FakeClient(handler=lambda m, t, j: calls.append(1) or ""),
+                    _config(), self._evidence(), debug,
+                )
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[],
+                    review_round=1,
+                )
+            self.assertEqual(calls, [])
+            self.assertEqual(outcome.issues, [])
+
+    def test_run_resumes_fallback_trace_without_calls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "fallback",
+                    "fallback_reason": "malformed_json: broken",
+                    "turns": [],
+                })
+                calls = []
+                loop = ReviewAgentLoop(
+                    FakeClient(handler=lambda m, t, j: calls.append(1) or ""),
+                    _config(), self._evidence(), debug,
+                )
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            self.assertEqual(calls, [])
+            self.assertEqual(outcome.fallback_reason, "malformed_json: broken")
+            self.assertEqual(len(outcome.issues), 1)
+            self.assertTrue(outcome.issues[0]["agent_fallback"])
+            self.assertEqual(outcome.issues[0]["fallback_reason"], "malformed_json: broken")
+            self.assertEqual(outcome.issues[0]["origin"], "initial")
+
+    def test_run_reissues_only_inflight_turn_on_resume(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                evidence_turn = {
+                    "turn": 1,
+                    "messages": [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}],
+                    "status": "responded",
+                    "raw_response": json.dumps({
+                        "action": "request_evidence",
+                        "requests": [{"request_id": "term-1", "tool": "term_occurrences",
+                                      "arguments": {"term": "Ann", "selectors": [1], "context_radius": 0}}],
+                        "complete": False,
+                    }, ensure_ascii=False),
+                    "parsed": {"action": "request_evidence",
+                               "requests": [{"request_id": "term-1", "tool": "term_occurrences",
+                                             "arguments": {"term": "Ann", "selectors": [1], "context_radius": 0}}],
+                               "complete": False},
+                    "json_repaired": False,
+                    "evidence_results": [{"request_id": "term-1", "tool": "term_occurrences",
+                                          "ok": True, "occurrences": []}],
+                }
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "running",
+                    "turns": [evidence_turn],
+                })
+                calls = []
+
+                def handler(messages, tier, json_mode):
+                    calls.append(messages)
+                    assert messages[-1]["role"] == "user" and "【证据工具返回 JSON】" in messages[-1]["content"]
+                    return json.dumps({
+                        "action": "final",
+                        "decisions": [{"candidate_id": "r1-ch0-base0-candidate0", "index": 0,
+                                       "verdict": "confirmed", "reason": "ok"}],
+                        "complete": True,
+                    }, ensure_ascii=False)
+
+                loop = ReviewAgentLoop(FakeClient(handler=handler), _config(),
+                                       self._evidence(), debug)
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(outcome.issues, [{"index": 0, "type": "terminology",
+                                               "detail": "术语不一致", "suggestion": "统一",
+                                               "origin": "initial",
+                                               "candidate_id": "r1-ch0-base0-candidate0",
+                                               "consistency": {},
+                                               "evidence_refs": ["ch0:text0:seg0"]}])
+            with debug.round_scope(1):
+                saved = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+            self.assertEqual(saved["status"], "finished")
+            self.assertEqual(len(saved["turns"]), 2)
+            events = [
+                json.loads(line)
+                for line in Path(debug.run_dir, "events.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertIn(
+                "review_agent_resumed",
+                [event["event"] for event in events],
+            )
+            # 已缓存证据轮不重复发事件（该事件属于上次进程的审计流）
+            self.assertEqual(
+                sum(1 for e in events if e["event"] == "review_evidence_supplied"),
+                0,
+            )
+
+    def test_run_resumes_parsed_final_turn_without_calls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                final_raw = json.dumps({
+                    "action": "final",
+                    "decisions": [{"candidate_id": "r1-ch0-base0-candidate0",
+                                   "index": 0, "verdict": "confirmed", "reason": "ok"}],
+                    "complete": True,
+                }, ensure_ascii=False)
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "running",
+                    "turns": [{
+                        "turn": 1,
+                        "messages": [{"role": "system", "content": "s"},
+                                     {"role": "user", "content": "u"}],
+                        "status": "responded",
+                        "raw_response": final_raw,
+                        "parsed": json.loads(final_raw),
+                        "json_repaired": False,
+                    }],
+                })
+                calls = []
+                loop = ReviewAgentLoop(
+                    FakeClient(handler=lambda m, t, j: calls.append(1) or ""),
+                    _config(), self._evidence(), debug,
+                )
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            self.assertEqual(calls, [])
+            self.assertEqual(outcome.issues[0]["candidate_id"], "r1-ch0-base0-candidate0")
+            self.assertEqual(outcome.issues[0]["origin"], "initial")
+            with debug.round_scope(1):
+                saved = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+            self.assertEqual(saved["status"], "finished")
+
+    def test_run_resumes_reexecutes_evidence_without_llm_call(self):
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                evidence_raw = json.dumps({
+                    "action": "request_evidence",
+                    "requests": [{"request_id": "term-1", "tool": "term_occurrences",
+                                  "arguments": {"term": "Ann", "selectors": [1],
+                                                "context_radius": 0}}],
+                    "complete": False,
+                }, ensure_ascii=False)
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "running",
+                    "turns": [{
+                        "turn": 1,
+                        "messages": [{"role": "system", "content": "s"},
+                                     {"role": "user", "content": "u"}],
+                        "status": "responded",
+                        "raw_response": evidence_raw,
+                        "parsed": json.loads(evidence_raw),
+                        "json_repaired": False,
+                    }],
+                })
+                calls = []
+                handler = lambda m, t, j: calls.append(1) or json.dumps({
+                    "action": "final",
+                    "decisions": [{"candidate_id": "r1-ch0-base0-candidate0",
+                                   "index": 0, "verdict": "confirmed", "reason": "ok"}],
+                    "complete": True,
+                }, ensure_ascii=False)
+                loop = ReviewAgentLoop(FakeClient(handler=handler), _config(),
+                                       self._evidence(), debug)
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            self.assertEqual(len(calls), 1)  # 仅 final turn 一次调用
+            self.assertEqual(outcome.issues[0]["candidate_id"], "r1-ch0-base0-candidate0")
+            with debug.round_scope(1):
+                saved = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+            self.assertEqual(saved["status"], "finished")
+            self.assertEqual(len(saved["turns"]), 2)
+            self.assertIn("evidence_results", saved["turns"][0])
+
+    def test_run_resumes_with_reduced_evidence_rounds_still_finalizes(self):
+        """新配置 max_evidence_rounds 低于已缓存证据轮数时，恢复仍须发出 final 调用。"""
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                evidence_raw = json.dumps({
+                    "action": "request_evidence",
+                    "requests": [{"request_id": "term-1", "tool": "term_occurrences",
+                                  "arguments": {"term": "Ann", "selectors": [1],
+                                                "context_radius": 0}}],
+                    "complete": False,
+                }, ensure_ascii=False)
+                turns = []
+                for turn_number in (1, 2):
+                    turns.append({
+                        "turn": turn_number,
+                        "messages": [{"role": "system", "content": "s"},
+                                     {"role": "user", "content": "u"}],
+                        "status": "responded",
+                        "raw_response": evidence_raw,
+                        "parsed": json.loads(evidence_raw),
+                        "json_repaired": False,
+                        "evidence_results": [{"request_id": "term-1", "tool": "term_occurrences",
+                                              "ok": True, "occurrences": []}],
+                    })
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "running",
+                    "turns": turns,
+                })
+                calls = []
+                handler = lambda m, t, j: calls.append(1) or json.dumps({
+                    "action": "final",
+                    "decisions": [{"candidate_id": "r1-ch0-base0-candidate0",
+                                   "index": 0, "verdict": "confirmed", "reason": "ok"}],
+                    "complete": True,
+                }, ensure_ascii=False)
+                config = _config()
+                config.pipeline.review_agent_max_evidence_rounds = 1  # 低于已缓存的两轮
+                loop = ReviewAgentLoop(FakeClient(handler=handler), config,
+                                       self._evidence(), debug)
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            # 修复前：空 turn 范围 → 0 调用 + trace 永远 running
+            self.assertEqual(len(calls), 1)  # 必须发出 final 调用
+            self.assertEqual(outcome.issues[0]["candidate_id"], "r1-ch0-base0-candidate0")
+            self.assertFalse(outcome.issues[0].get("agent_fallback"))
+            with debug.round_scope(1):
+                saved = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+            self.assertEqual(saved["status"], "finished")
+            self.assertEqual(len(saved["turns"]), 3)
+
+    def test_run_resumes_requesting_turn_without_data(self):
+        """中断发生在调用进行中：缓存 turn 只有 requesting 状态、无任何数据。"""
+        with tempfile.TemporaryDirectory() as directory:
+            debug = ReviewRunStore(directory)
+            with debug.round_scope(1):
+                debug.write_json("agents/r1-chunk-ch0-base0-n2.json", {
+                    "agent_id": "r1-chunk-ch0-base0-n2",
+                    "stage": "review_agent",
+                    "status": "running",
+                    "turns": [{
+                        "turn": 1,
+                        "messages": [{"role": "system", "content": "s"},
+                                     {"role": "user", "content": "u"}],
+                        "status": "requesting",
+                    }],
+                })
+                calls = []
+                handler = lambda m, t, j: calls.append(1) or json.dumps({
+                    "action": "final",
+                    "decisions": [{"candidate_id": "r1-ch0-base0-candidate0",
+                                   "index": 0, "verdict": "confirmed", "reason": "ok"}],
+                    "complete": True,
+                }, ensure_ascii=False)
+                loop = ReviewAgentLoop(FakeClient(handler=handler), _config(),
+                                       self._evidence(), debug)
+                outcome = loop.review_chunk(
+                    chapter=0, chunk_base=0,
+                    sources=["Ann arrived.", "Ann spoke."],
+                    targets=["安到了。", "安开口了。"],
+                    initial_issues=[{"index": 0, "type": "terminology",
+                                     "detail": "术语不一致", "suggestion": "统一"}],
+                    review_round=1,
+                )
+            # requesting 空 turn 必须原地重入并发出调用（start_turn=1，不 +1）
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(outcome.issues[0]["candidate_id"], "r1-ch0-base0-candidate0")
+            with debug.round_scope(1):
+                saved = debug.load_json("agents/r1-chunk-ch0-base0-n2.json")
+            self.assertEqual(saved["status"], "finished")
+            self.assertEqual(len(saved["turns"]), 1)
 
     def test_requests_selected_evidence_then_confirms_and_adds(self):
         calls = 0

--- a/trans_novel/agents/review_loop.py
+++ b/trans_novel/agents/review_loop.py
@@ -116,47 +116,152 @@ class _ActionLoop:
             "turns": [],
         }
         relative = f"agents/{_safe_id(agent_id)}.json"
-        self.debug.write_json(relative, trace)
+        # 断点续跑：先探测已有 trace（必须先 load 再写，否则覆盖自己）
+        existing = self.debug.load_json(relative)
+        resume_turns: list[dict[str, Any]] = []
+        if existing is not None:
+            existing_status = existing.get("status")
+            if existing_status == "finished" and isinstance(existing.get("result"), dict):
+                self.debug.log_event(
+                    "review_agent_finished",
+                    agent_id=agent_id,
+                    stage=stage,
+                    turns=len(existing.get("turns", [])),
+                    resumed=True,
+                )
+                return existing["result"], ""
+            if existing_status == "fallback":
+                self.debug.log_event(
+                    "review_agent_fallback",
+                    agent_id=agent_id,
+                    stage=stage,
+                    reason=str(existing.get("fallback_reason", "")),
+                    resumed=True,
+                )
+                return None, str(existing.get("fallback_reason", ""))
+            if existing_status == "running":
+                resume_turns = [
+                    dict(turn)
+                    for turn in existing.get("turns", [])
+                    if isinstance(turn, dict)
+                ]
+        trace["turns"] = resume_turns
         evidence_rounds = 0
         seen_request_ids: set[str] = set()
         seen_requests: set[tuple[str, str]] = set()
+        start_turn = 1
+        if resume_turns:
+            # 断点续跑：重放已完成取证轮，重建消息历史与去重状态。
+            # 消息顺序、证据 JSON 与取证轮次提示必须与原始运行逐字节
+            # 一致，后续 in-flight 调用才能无缝续上。
+            first_messages = resume_turns[0].get("messages")
+            if isinstance(first_messages, list):
+                messages = [dict(message) for message in first_messages]
+            self.debug.log_event(
+                "review_agent_resumed",
+                agent_id=agent_id,
+                stage=stage,
+                turns=len(resume_turns),
+            )
+            for cached in resume_turns:
+                cached_results = cached.get("evidence_results")
+                cached_raw = cached.get("raw_response")
+                if not isinstance(cached_results, list) or not isinstance(cached_raw, str):
+                    continue
+                messages.append({"role": "assistant", "content": cached_raw})
+                evidence_message = "【证据工具返回 JSON】\n" + json.dumps(
+                    cached_results, ensure_ascii=False, indent=2
+                )
+                evidence_rounds += 1
+                if evidence_rounds >= max_rounds:
+                    evidence_message += (
+                        "\n取证轮次已用完。下一次响应只能输出 action=final，不得再次请求证据。"
+                    )
+                messages.append({"role": "user", "content": evidence_message})
+                allowed_refs.update(self.evidence.evidence_refs(cached_results))
+                cached_parsed = cached.get("parsed")
+                if isinstance(cached_parsed, dict):
+                    for request in cached_parsed.get("requests", []):
+                        if not isinstance(request, dict):
+                            continue
+                        request_id = _text(request.get("request_id"))
+                        if request_id:
+                            seen_request_ids.add(request_id)
+                        tool = _text(request.get("tool"))
+                        arguments = request.get("arguments")
+                        if tool and isinstance(arguments, dict):
+                            seen_requests.add(
+                                (tool, json.dumps(arguments, ensure_ascii=False, sort_keys=True))
+                            )
+            # 从第一个未完成 turn 续跑：最后一个缓存 turn 若无证据结果
+            # （in-flight 请求、取证执行中或 final 已解析未落盘）原地重入。
+            start_turn = len(resume_turns)
+            if "evidence_results" in resume_turns[-1]:
+                start_turn += 1
+        self.debug.write_json(relative, trace)
+        cached_by_turn = {
+            turn["turn"]: turn
+            for turn in resume_turns
+            if isinstance(turn.get("turn"), int)
+        }
 
         try:
-            for turn_number in range(1, max_rounds + 2):
+            for turn_number in range(start_turn, max(start_turn, max_rounds + 1) + 1):
                 sent_messages = [dict(message) for message in messages]
-                turn: dict[str, Any] = {
-                    "turn": turn_number,
-                    "messages": sent_messages,
-                    "status": "requesting",
-                }
-                trace["turns"].append(turn)
-                self.debug.write_json(relative, trace)
-                try:
-                    raw = self.client.complete(
-                        sent_messages,
-                        tier=self.config.pipeline.review_agent_tier,
-                        json_mode=True,
-                        stage=stage,
-                    )
-                except Exception as error:
-                    turn["status"] = "failed"
-                    turn["error"] = {
-                        "type": type(error).__name__,
-                        "message": str(error),
+                cached_turn = cached_by_turn.get(turn_number)
+                if cached_turn is not None:
+                    turn = cached_turn
+                    turn["messages"] = sent_messages
+                else:
+                    turn: dict[str, Any] = {
+                        "turn": turn_number,
+                        "messages": sent_messages,
+                        "status": "requesting",
                     }
-                    self.debug.write_json(relative, trace)
-                    raise
-                turn["status"] = "responded"
-                turn["raw_response"] = raw
+                    trace["turns"].append(turn)
+                self.debug.write_json(relative, trace)
+                if cached_turn is not None and isinstance(cached_turn.get("raw_response"), str):
+                    raw = cached_turn["raw_response"]
+                    turn["status"] = "responded"
+                    turn["raw_response"] = raw
+                else:
+                    try:
+                        raw = self.client.complete(
+                            sent_messages,
+                            tier=self.config.pipeline.review_agent_tier,
+                            json_mode=True,
+                            stage=stage,
+                        )
+                    except Exception as error:
+                        turn["status"] = "failed"
+                        turn["error"] = {
+                            "type": type(error).__name__,
+                            "message": str(error),
+                        }
+                        self.debug.write_json(relative, trace)
+                        raise
+                    turn["status"] = "responded"
+                    turn["raw_response"] = raw
                 self.debug.write_json(relative, trace)
 
-                try:
-                    parsed = parse_json_result(raw)
-                except ValueError as error:
-                    raise ReviewLoopProtocolError("malformed_json") from error
-                data = parsed.value
-                turn["parsed"] = data
-                turn["json_repaired"] = parsed.repaired
+                # 仅当 raw 与 parsed 都来自同一缓存响应时才复用 parsed；
+                # 无 raw 的残留 parsed（手工篡改/损坏 trace）不得遮蔽新调用结果。
+                if (
+                    cached_turn is not None
+                    and isinstance(cached_turn.get("raw_response"), str)
+                    and isinstance(cached_turn.get("parsed"), dict)
+                ):
+                    data = cached_turn["parsed"]
+                    turn["parsed"] = data
+                    turn["json_repaired"] = bool(cached_turn.get("json_repaired"))
+                else:
+                    try:
+                        parsed = parse_json_result(raw)
+                    except ValueError as error:
+                        raise ReviewLoopProtocolError("malformed_json") from error
+                    data = parsed.value
+                    turn["parsed"] = data
+                    turn["json_repaired"] = parsed.repaired
                 self.debug.write_json(relative, trace)
                 if not isinstance(data, dict):
                     raise ReviewLoopProtocolError("response_not_object")
@@ -276,6 +381,9 @@ class _ActionLoop:
                 reason=reason,
             )
             return None, reason
+        trace["status"] = "fallback"
+        trace["fallback_reason"] = "loop_ended_without_final"
+        self.debug.write_json(relative, trace)
         return None, "loop_ended_without_final"
 
 

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -2368,6 +2368,59 @@ class Orchestrator:
         )
         return patches, [*skipped, *failures]
 
+    def _review_config_snapshot(self) -> dict[str, Any]:
+        """当前审校相关配置快照，供 metadata 落盘与 skip 判定对比。"""
+        return {
+            "review_concurrency": self.config.pipeline.review_concurrency,
+            "review_output_retries": self.config.pipeline.review_output_retries,
+            "review_agent_loop": self.config.pipeline.review_agent_loop,
+            "review_agent_tier": self.config.pipeline.review_agent_tier,
+            "review_agent_max_evidence_rounds": (
+                self.config.pipeline.review_agent_max_evidence_rounds
+            ),
+            "review_conflict_arbitration": (
+                self.config.pipeline.review_conflict_arbitration
+            ),
+            "review_fix_loop": self.config.pipeline.review_fix_loop,
+            "review_fix_max_rounds": self.config.pipeline.review_fix_max_rounds,
+            "review_clean_confirmations": (self.config.pipeline.review_clean_confirmations),
+        }
+
+    @staticmethod
+    def _review_glossary_fingerprint(terms: list[GlossaryTerm]) -> str:
+        """术语表内容指纹：术语表变化后已完成的 Review 结果不得复用。"""
+        ordered = sorted(
+            (term.source, term.target, term.type) for term in terms
+        )
+        return hashlib.sha256(json.dumps(ordered, ensure_ascii=False).encode("utf-8")).hexdigest()
+
+    def _review_skip_eligible(
+        self,
+        store: RunStore,
+        latest: dict[str, Any],
+        terms: list[GlossaryTerm],
+    ) -> bool:
+        """已完成 Review 结果能否安全复用：内容、配置与术语表必须全部一致。"""
+        review_id = latest.get("review_id")
+        if not isinstance(review_id, str) or not review_id:
+            return False
+        metadata_path = os.path.join(
+            store.run_dir, "reviews", review_id, "rounds", "metadata.json"
+        )
+        try:
+            with open(metadata_path, encoding="utf-8") as f:
+                metadata = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return False
+        saved_config = metadata.get("config")
+        saved_glossary = metadata.get("glossary_fingerprint")
+        return (
+            isinstance(saved_config, dict)
+            and saved_config == self._review_config_snapshot()
+            and isinstance(saved_glossary, str)
+            and saved_glossary == self._review_glossary_fingerprint(terms)
+        )
+
     def _run_review_session(
         self,
         store: RunStore,
@@ -2397,7 +2450,13 @@ class Orchestrator:
         total = sum(len(chapter.text_segments) for chapter in loaded)
         analysis = store.load_analysis() or {}
         reviewed_content_digest = _review_content_digest(loaded)
-        debug = ReviewRunStore(store.run_dir)
+
+        # 断点续跑：检查是否有未完成的 Review（内容指纹必须一致）
+        debug = ReviewRunStore.find_resumable(store.run_dir, reviewed_content_digest)
+        if debug is not None:
+            debug.log_event("review_resumed_from_checkpoint", review_id=debug.review_id)
+        else:
+            debug = ReviewRunStore(store.run_dir)
         debug.start(
             reviewed_content_digest=reviewed_content_digest,
             metadata={
@@ -2407,21 +2466,8 @@ class Orchestrator:
                 "target_lang": self.config.target_lang,
                 "chapter_count": len(loaded),
                 "total_segments": total,
-                "config": {
-                    "review_concurrency": self.config.pipeline.review_concurrency,
-                    "review_output_retries": self.config.pipeline.review_output_retries,
-                    "review_agent_loop": self.config.pipeline.review_agent_loop,
-                    "review_agent_tier": self.config.pipeline.review_agent_tier,
-                    "review_agent_max_evidence_rounds": (
-                        self.config.pipeline.review_agent_max_evidence_rounds
-                    ),
-                    "review_conflict_arbitration": (
-                        self.config.pipeline.review_conflict_arbitration
-                    ),
-                    "review_fix_loop": self.config.pipeline.review_fix_loop,
-                    "review_fix_max_rounds": self.config.pipeline.review_fix_max_rounds,
-                    "review_clean_confirmations": (self.config.pipeline.review_clean_confirmations),
-                },
+                "config": self._review_config_snapshot(),
+                "glossary_fingerprint": self._review_glossary_fingerprint(all_terms),
             },
         )
         store.log_event(
@@ -2452,12 +2498,105 @@ class Orchestrator:
         termination = "not_started"
         fix_loop = self.config.pipeline.review_fix_loop
         required_clean = self.config.pipeline.review_clean_confirmations if fix_loop else 1
-        # 每次 Fix 前最多可能先出现 ``required_clean - 1`` 轮干净结果；
-        # 每个已接受补丁后仍须保留完整盲审，并最终容纳连续 clean 确认。
-        # 该上界避免在最后一轮接受一个从未被下一轮 Reviewer 看见的补丁。
         max_review_rounds = (
             (self.config.pipeline.review_fix_max_rounds + 1) * required_clean if fix_loop else 1
         )
+
+        # 断点续跑：加载轮级检查点
+        _checkpoint = debug.load_checkpoint()
+        _resume_scan_done = False
+        _resume_latest: _ReviewRoundResult | None = None
+        if _checkpoint is not None:
+            start_round = _checkpoint.get("next_round", 1)
+            # 配置收紧（如降低 review_clean_confirmations）后轮次上限可能变小；
+            # 若检查点轮次已超出上限，直接收敛到最后一轮，避免空循环 + RuntimeError。
+            start_round = min(start_round, max_review_rounds)
+            target_overrides = {
+                (o["chapter"], o["index"]): o["target"]
+                for o in _checkpoint.get("target_overrides", [])
+            }
+            seen_overlays = set(_checkpoint.get("seen_overlays", []))
+            patch_records = _checkpoint.get("patch_records", [])
+            active_patches = {
+                (p["chapter"], p["index"]): p
+                for p in _checkpoint.get("active_patches", [])
+            }
+            fix_failures = _checkpoint.get("fix_failures", [])
+            blocked_issues = _checkpoint.get("blocked_issues", {})
+            round_summaries = _checkpoint.get("round_summaries", [])
+            clean_streak = _checkpoint.get("clean_streak", 0)
+            fix_rounds = _checkpoint.get("fix_rounds", 0)
+            # 恢复 round 内部相位：scan_done 表示扫描已完成，可跳过
+            if _checkpoint.get("phase") == "scan_done":
+                _resume_scan_done = True
+                start_round = _checkpoint.get("next_round", 1)
+                # 配置收紧导致上限小于检查点轮次时，不能复用旧轮的扫描结果
+                if start_round > max_review_rounds:
+                    _resume_scan_done = False
+                    _resume_latest = None
+                    start_round = max_review_rounds
+                else:
+                    _resume_latest = _ReviewRoundResult(
+                        issues=_checkpoint.get("latest_issues", []),
+                        pre_arbitration_issues=_checkpoint.get("latest_pre_arbitration_issues", []),
+                        arbitration_superseded=_checkpoint.get("latest_arbitration_superseded", []),
+                        conflict_groups=_checkpoint.get("latest_conflict_groups", []),
+                        residual_conflicts=_checkpoint.get("latest_residual_conflicts", []),
+                        fallback_agent_count=_checkpoint.get("latest_fallback_agent_count", 0),
+                    )
+                debug.log_event(
+                    "review_checkpoint_restored",
+                    next_round=start_round,
+                    phase="scan_done",
+                    override_count=len(target_overrides),
+                    fix_rounds=fix_rounds,
+                    clean_streak=clean_streak,
+                )
+            else:
+                debug.log_event(
+                    "review_checkpoint_restored",
+                    next_round=start_round,
+                    phase="round_done",
+                    override_count=len(target_overrides),
+                    fix_rounds=fix_rounds,
+                    clean_streak=clean_streak,
+                )
+        else:
+            start_round = 1
+
+        def _save_checkpoint(
+            current_round: int,
+            phase: str = "round_done",
+            latest: _ReviewRoundResult | None = None,
+        ) -> None:
+            """保存轮级检查点。phase: round_done | scan_done"""
+            state: dict[str, Any] = {
+                "phase": phase,
+                "next_round": current_round + 1 if phase == "round_done" else current_round,
+                "target_overrides": [
+                    {"chapter": c, "index": i, "target": t}
+                    for (c, i), t in sorted(target_overrides.items())
+                ],
+                "seen_overlays": sorted(seen_overlays),
+                "patch_records": patch_records,
+                "active_patches": [
+                    {**p, "chapter": c, "index": i}
+                    for (c, i), p in sorted(active_patches.items())
+                ],
+                "fix_failures": fix_failures,
+                "blocked_issues": blocked_issues,
+                "round_summaries": round_summaries,
+                "clean_streak": clean_streak,
+                "fix_rounds": fix_rounds,
+            }
+            if latest is not None:
+                state["latest_issues"] = latest.issues
+                state["latest_pre_arbitration_issues"] = latest.pre_arbitration_issues
+                state["latest_arbitration_superseded"] = latest.arbitration_superseded
+                state["latest_conflict_groups"] = latest.conflict_groups
+                state["latest_residual_conflicts"] = latest.residual_conflicts
+                state["latest_fallback_agent_count"] = latest.fallback_agent_count
+            debug.save_checkpoint(state)
 
         def register_blocked(
             issues: list[dict[str, Any]],
@@ -2516,7 +2655,7 @@ class Orchestrator:
             )
 
         try:
-            for review_round in range(1, max_review_rounds + 1):
+            for review_round in range(start_round, max_review_rounds + 1):
                 overlay_digest = _review_overlay_digest(loaded, target_overrides)
                 evidence = BookEvidenceIndex(
                     loaded,
@@ -2541,15 +2680,29 @@ class Orchestrator:
                             for (chapter, index), target in sorted(target_overrides.items())
                         ],
                     )
-                    latest = self._review_round(
-                        loaded,
-                        all_terms,
-                        evidence,
-                        debug,
-                        review_round=review_round,
-                        target_overrides=target_overrides,
-                        progress=progress,
-                    )
+                    # 断点续跑：scan_done 恢复时跳过扫描，直接用缓存结果
+                    if _resume_scan_done and review_round == start_round and _resume_latest is not None:
+                        latest = _resume_latest
+                        _resume_scan_done = False
+                        _resume_latest = None
+                        # 跳过扫描后重建初审/驳回快照，保证最终报告数据完整
+                        debug.rebuild_snapshots_from_chunks(review_round)
+                        debug.log_event("review_scan_skipped", review_round=review_round)
+                    else:
+                        latest = self._review_round(
+                            loaded,
+                            all_terms,
+                            evidence,
+                            debug,
+                            review_round=review_round,
+                            target_overrides=target_overrides,
+                            progress=progress,
+                        )
+                        # 断点续跑：扫描完成，保存 mid-round 检查点
+                        _save_checkpoint(review_round, phase="scan_done", latest=latest)
+                        # 提前落盘本次扫描用量，避免 fix 阶段崩溃导致用量丢失
+                        save_review_usage()
+                        usage_before = self.client.usage_summary()
 
                     current_issue_keys = {
                         str(issue["issue_key"])
@@ -2600,6 +2753,7 @@ class Orchestrator:
                             round_summary["termination"] = termination
                             debug.write_json("summary.json", round_summary)
                             round_summaries.append(round_summary)
+                            _save_checkpoint(review_round)
                             break
                         clean_streak += 1
                         if progress:
@@ -2612,7 +2766,9 @@ class Orchestrator:
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
                         if termination == "clean_confirmed":
+                            _save_checkpoint(review_round)
                             break
+                        _save_checkpoint(review_round)
                         continue
 
                     if clean_streak and progress:
@@ -2625,6 +2781,7 @@ class Orchestrator:
                         round_summary["termination"] = termination
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
+                        _save_checkpoint(review_round)
                         break
                     if fix_rounds >= self.config.pipeline.review_fix_max_rounds:
                         termination = "max_rounds"
@@ -2632,6 +2789,7 @@ class Orchestrator:
                         round_summary["termination"] = termination
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
+                        _save_checkpoint(review_round)
                         break
 
                     patches, failures = self._propose_review_patches(
@@ -2673,6 +2831,7 @@ class Orchestrator:
                         debug.write_json("fix_failures.json", failures)
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
+                        _save_checkpoint(review_round)
                         break
 
                     issue_keys_by_id = {
@@ -2729,6 +2888,7 @@ class Orchestrator:
                         round_summary["termination"] = termination
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
+                        _save_checkpoint(review_round)
                         break
                     if candidate_digest in seen_overlays:
                         termination = "cycle_detected"
@@ -2748,6 +2908,7 @@ class Orchestrator:
                         round_summary["termination"] = termination
                         debug.write_json("summary.json", round_summary)
                         round_summaries.append(round_summary)
+                        _save_checkpoint(review_round)
                         break
 
                     fix_rounds += 1
@@ -2772,8 +2933,10 @@ class Orchestrator:
                     round_summary["fix_round"] = fix_rounds
                     debug.write_json("summary.json", round_summary)
                     round_summaries.append(round_summary)
+                    _save_checkpoint(review_round)
             else:
                 termination = "max_rounds"
+                _save_checkpoint(max_review_rounds)
 
             if latest is None:  # pragma: no cover - max_review_rounds 至少为 1
                 raise RuntimeError("Review loop finished without a review round")
@@ -2982,9 +3145,44 @@ class Orchestrator:
                 )
 
             tgts = [target_for(local_index, segment) for local_index, segment in enumerate(chunk)]
+
+            # 断点续跑：chunk 缓存检查（跳过 reviewer + agent loop LLM 调用）
+            round_prefix = f"r{review_round}-" if review_round is not None else ""
+            chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
+            if debug is not None and debug.is_chunk_done(chunk_id):
+                cached = debug.load_chunk_result(chunk_id)
+                if cached is not None:
+                    # 恢复聚合状态（report 需要 initial/dismissed 数据）
+                    if chapter_index is not None:
+                        debug.record_initial_issues(
+                            chapter=chapter_index,
+                            chunk_base=chunk_base,
+                            issues=cached.get("initial_issues", []),
+                        )
+                        debug.record_dismissed(
+                            chapter=chapter_index,
+                            chunk_base=chunk_base,
+                            issues=cached.get("dismissed", []),
+                        )
+                    return cached.get("issues", [])
+
+            # 断点续跑：子 chunk 缓存探测（借鉴翻译 _resume_batches 边界切分）
+            # 与 review_adaptive 的递归拆半对齐：如果所有子 chunk 都有缓存，
+            # 直接合并返回，避免触发一次 reviewer LLM 调用。
+            if debug is not None and len(chunk) > 1:
+                cached_sub = self._try_cached_subchunks(
+                    chunk_base, chunk, debug, round_prefix,
+                    chapter_index,
+                )
+                if cached_sub is not None:
+                    return cached_sub
+
             local_issues: list[dict] = []
             initial_trace: dict[str, Any] | None = None
             initial_path = ""
+            initial_issue_count = 0
+            repaired = False
+            reused_initial: dict[str, Any] | None = None
             if debug is not None:
                 round_prefix = f"r{review_round}-" if review_round is not None else ""
                 initial_id = (
@@ -2992,65 +3190,101 @@ class Orchestrator:
                     f"-n{len(chunk)}-attempt{attempt}"
                 )
                 initial_path = f"initial/{initial_id}.json"
-                initial_trace = {
-                    "agent_id": initial_id,
-                    "chapter": chapter_index,
-                    "chunk_base": chunk_base,
-                    "segment_count": len(chunk),
-                    "attempt": attempt,
-                    "status": "running",
-                }
-                debug.write_json(initial_path, initial_trace)
-
-            def trace(event: str, data: dict[str, Any]) -> None:
-                """逐步保存初审完整请求、原始响应或服务错误。"""
-                if debug is None or initial_trace is None:
-                    return
-                initial_trace[event] = data
-                debug.write_json(initial_path, initial_trace)
-
-            try:
-                review_result = self.reviewer.review_result(
-                    srcs,
-                    tgts,
-                    terms,
-                    trace=trace if debug is not None else None,
-                )
-            except Exception as error:
-                if debug is not None and initial_trace is not None:
-                    initial_trace["status"] = "failed"
-                    initial_trace["error"] = {
-                        "type": type(error).__name__,
-                        "message": str(error),
+                # 断点续跑：初筛已完成的结果直接复用（跳过最贵的 reviewer 调用）。
+                # 结果在首次运行中已校验过块内 index，可直接信任。
+                existing_initial = debug.load_json(initial_path)
+                if (
+                    existing_initial is not None
+                    and existing_initial.get("status") == "finished"
+                    and isinstance(existing_initial.get("issues"), list)
+                ):
+                    reused_initial = existing_initial
+                else:
+                    initial_trace = {
+                        "agent_id": initial_id,
+                        "chapter": chapter_index,
+                        "chunk_base": chunk_base,
+                        "segment_count": len(chunk),
+                        "attempt": attempt,
+                        "status": "running",
                     }
                     debug.write_json(initial_path, initial_trace)
-                raise
-            if review_result.repaired:
-                record_recovery(
-                    "review_json_repaired",
-                    start_index=chunk_base,
-                    count=len(chunk),
-                )
-            for it in review_result.issues:
-                it = dict(it)
-                idx = it.get("index")
-                if isinstance(idx, int) and not isinstance(idx, bool) and 0 <= idx < len(chunk):
-                    it["index"] = idx
-                    local_issues.append(it)
-                else:
-                    raise ReviewOutputError("invalid_issue_index")
-            if debug is not None and initial_trace is not None:
-                initial_trace["status"] = "finished"
-                initial_trace["json_repaired"] = review_result.repaired
-                initial_trace["issues"] = local_issues
-                debug.write_json(initial_path, initial_trace)
+
+            if reused_initial is not None:
+                # 复用路径与 fresh 路径的错误语义不同：越界 index 不再抛
+                # ReviewOutputError，而是静默丢弃。这有意为之——首次运行已
+                # 校验并通过，越界只可能来自人工篡改；宁可少报也不让恢复
+                # 因陈旧 trace 把整个 chunk 打成 fallback。会话级内容指纹
+                # 守卫已排除正常内容变化场景。
+                local_issues = [dict(issue) for issue in reused_initial["issues"]]
+                repaired = bool(reused_initial.get("json_repaired"))
+                if repaired:
+                    record_recovery(
+                        "review_json_repaired",
+                        start_index=chunk_base,
+                        count=len(chunk),
+                    )
                 if chapter_index is not None:
                     debug.record_initial_issues(
                         chapter=chapter_index,
                         chunk_base=chunk_base,
                         issues=local_issues,
                     )
+                initial_issue_count = len(local_issues)
+            else:
+                def trace(event: str, data: dict[str, Any]) -> None:
+                    """逐步保存初审完整请求、原始响应或服务错误。"""
+                    if debug is None or initial_trace is None:
+                        return
+                    initial_trace[event] = data
+                    debug.write_json(initial_path, initial_trace)
 
+                try:
+                    review_result = self.reviewer.review_result(
+                        srcs,
+                        tgts,
+                        terms,
+                        trace=trace if debug is not None else None,
+                    )
+                except Exception as error:
+                    if debug is not None and initial_trace is not None:
+                        initial_trace["status"] = "failed"
+                        initial_trace["error"] = {
+                            "type": type(error).__name__,
+                            "message": str(error),
+                        }
+                        debug.write_json(initial_path, initial_trace)
+                    raise
+                repaired = review_result.repaired
+                if repaired:
+                    record_recovery(
+                        "review_json_repaired",
+                        start_index=chunk_base,
+                        count=len(chunk),
+                    )
+                for it in review_result.issues:
+                    it = dict(it)
+                    idx = it.get("index")
+                    if isinstance(idx, int) and not isinstance(idx, bool) and 0 <= idx < len(chunk):
+                        it["index"] = idx
+                        local_issues.append(it)
+                    else:
+                        raise ReviewOutputError("invalid_issue_index")
+                initial_issue_count = len(review_result.issues)
+                if debug is not None and initial_trace is not None:
+                    initial_trace["status"] = "finished"
+                    initial_trace["json_repaired"] = repaired
+                    initial_trace["issues"] = local_issues
+                    debug.write_json(initial_path, initial_trace)
+                    if chapter_index is not None:
+                        debug.record_initial_issues(
+                            chapter=chapter_index,
+                            chunk_base=chunk_base,
+                            issues=local_issues,
+                        )
+
+            # 保存 agent loop 前的初始 issues（供 chunk 缓存落盘）
+            local_issues_before_agent = list(local_issues)
             dismissed: list[dict[str, Any]] = []
             fallback_reason = ""
             if (
@@ -3082,8 +3316,6 @@ class Orchestrator:
                     issues=dismissed,
                 )
 
-            round_prefix = f"r{review_round}-" if review_round is not None else ""
-            chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
             mapped: list[dict[str, Any]] = []
             for issue in local_issues:
                 local_index = issue.get("index")
@@ -3104,11 +3336,19 @@ class Orchestrator:
                     chapter=chapter_index,
                     chunk_base=chunk_base,
                     segment_count=len(chunk),
-                    initial_issue_count=len(review_result.issues),
+                    initial_issue_count=initial_issue_count,
                     final_issue_count=len(mapped),
                     dismissed_count=len(dismissed),
                     fallback=bool(fallback_reason),
                 )
+            # 断点续跑：落盘 chunk 结果（在 review_once 内，有完整数据）
+            if debug is not None and chapter_index is not None:
+                debug.mark_chunk_done(chunk_id, {
+                    "issues": mapped,
+                    "initial_issues": local_issues_before_agent,
+                    "dismissed": dismissed,
+                    "fallback_reason": fallback_reason,
+                })
             return mapped
 
         def review_adaptive(chunk_base: int, chunk: list) -> list[dict]:
@@ -3220,6 +3460,57 @@ class Orchestrator:
         return [issue for chunk_issues in results for issue in chunk_issues]
 
     @staticmethod
+    def _try_cached_subchunks(
+        chunk_base: int,
+        chunk: list,
+        debug: ReviewRunStore,
+        round_prefix: str,
+        chapter_index: int | None,
+    ) -> list[dict] | None:
+        """递归探测子 chunk 缓存，与 review_adaptive 的拆半对齐。
+
+        翻译的 ``_resume_batches`` 按完成状态边界切分批，只补译缺失段。
+        借鉴此模式：当父 chunk 缓存未命中时，递归检查所有子 chunk 是否有
+        缓存。如果全部命中，合并返回，跳过 reviewer LLM 调用。
+        """
+        if not chunk:
+            return []
+        chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
+        if debug.is_chunk_done(chunk_id):
+            cached = debug.load_chunk_result(chunk_id)
+            if cached is not None:
+                if chapter_index is not None:
+                    debug.record_initial_issues(
+                        chapter=chapter_index,
+                        chunk_base=chunk_base,
+                        issues=cached.get("initial_issues", []),
+                    )
+                    debug.record_dismissed(
+                        chapter=chapter_index,
+                        chunk_base=chunk_base,
+                        issues=cached.get("dismissed", []),
+                    )
+                return cached.get("issues", [])
+        # 单段 chunk 无法再拆分
+        if len(chunk) <= 1:
+            return None
+        # 递归探测：与 review_adaptive 拆半对齐
+        mid = len(chunk) // 2
+        left = Orchestrator._try_cached_subchunks(
+            chunk_base, chunk[:mid], debug, round_prefix,
+            chapter_index,
+        )
+        if left is None:
+            return None
+        right = Orchestrator._try_cached_subchunks(
+            chunk_base + mid, chunk[mid:], debug, round_prefix,
+            chapter_index,
+        )
+        if right is None:
+            return None
+        return left + right
+
+    @staticmethod
     def _pack_contiguous(segs, budget: int) -> list[list]:
         """按源文字符预算把段保序打包成若干连续块。"""
         chunks: list[list] = []
@@ -3298,13 +3589,30 @@ class Orchestrator:
             manifest = store.load_manifest()
             self._apply_manifest_languages(manifest)
             terms = GlossaryStore.load_terms_readonly(store.glossary_path)
-            outcome = self._measure_stage_call(
-                "review",
-                self._run_review_session,
-                store,
-                terms,
-                progress=progress,
-            )
+            # 跳过已完成 review：内容指纹一致则复用结果
+            loaded = [store.load_chapter(ch["index"]) for ch in manifest.get("chapters", [])]
+            digest = _review_content_digest(loaded)
+            latest = store.load_latest_review_result()
+            if (
+                latest is not None
+                and latest.get("status") == "completed"
+                and latest.get("reviewed_content_digest") == digest
+                and self._review_skip_eligible(store, latest, terms)
+            ):
+                store.log_event("review_skipped", reason="already_completed")
+                outcome = ReviewOutcome(
+                    run_dir=os.path.join(store.run_dir, "reviews", latest.get("review_id", "")),
+                    result=latest,
+                    usage=self._review_usage_from_dir(store, latest.get("review_id", "")),
+                )
+            else:
+                outcome = self._measure_stage_call(
+                    "review",
+                    self._run_review_session,
+                    store,
+                    terms,
+                    progress=progress,
+                )
             self._capture_metrics_state(store)
         return {
             "store": store,
@@ -3313,6 +3621,19 @@ class Orchestrator:
             "review_result": outcome.result,
             "review_dir": outcome.run_dir,
         }
+
+    @staticmethod
+    def _review_usage_from_dir(store: RunStore, review_id: str) -> dict[str, Any]:
+        """读取已完成的 Review 目录用量；缺失时返回空（调用方容忍）。"""
+        try:
+            with open(
+                os.path.join(store.run_dir, "reviews", review_id, "usage.json"),
+                encoding="utf-8",
+            ) as f:
+                usage = json.load(f)
+            return usage if isinstance(usage, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
 
     def _run_existing_steps(
         self,
@@ -3559,17 +3880,37 @@ class Orchestrator:
             if "review" in steps:
                 # 先保存此前阶段的增量，使会话 usage.json 只包含 Review 调用。
                 self._flush_usage(store, scope="pipeline")
-                outcome = self._measure_stage_call(
-                    "review",
-                    self._run_review_session,
-                    store,
-                    (
-                        glossary.all_terms()
-                        if glossary is not None
-                        else GlossaryStore.load_terms_readonly(store.glossary_path)
-                    ),
-                    progress=progress,
+                # 跳过已完成 review：内容指纹一致则复用结果
+                manifest = store.load_manifest()
+                ch_rows = manifest.get("chapters", [])
+                loaded_chs = [store.load_chapter(ch["index"]) for ch in ch_rows]
+                digest = _review_content_digest(loaded_chs)
+                prev = store.load_latest_review_result()
+                review_terms = (
+                    glossary.all_terms()
+                    if glossary is not None
+                    else GlossaryStore.load_terms_readonly(store.glossary_path)
                 )
+                if (
+                    prev is not None
+                    and prev.get("status") == "completed"
+                    and prev.get("reviewed_content_digest") == digest
+                    and self._review_skip_eligible(store, prev, review_terms)
+                ):
+                    store.log_event("review_skipped", reason="already_completed")
+                    outcome = ReviewOutcome(
+                        run_dir=os.path.join(store.run_dir, "reviews", prev.get("review_id", "")),
+                        result=prev,
+                        usage=self._review_usage_from_dir(store, prev.get("review_id", "")),
+                    )
+                else:
+                    outcome = self._measure_stage_call(
+                        "review",
+                        self._run_review_session,
+                        store,
+                        review_terms,
+                        progress=progress,
+                    )
                 review_issues = outcome.issues
                 review_changes = outcome.changes
                 review_result = outcome.result

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -2378,9 +2378,7 @@ class Orchestrator:
             "review_agent_max_evidence_rounds": (
                 self.config.pipeline.review_agent_max_evidence_rounds
             ),
-            "review_conflict_arbitration": (
-                self.config.pipeline.review_conflict_arbitration
-            ),
+            "review_conflict_arbitration": (self.config.pipeline.review_conflict_arbitration),
             "review_fix_loop": self.config.pipeline.review_fix_loop,
             "review_fix_max_rounds": self.config.pipeline.review_fix_max_rounds,
             "review_clean_confirmations": (self.config.pipeline.review_clean_confirmations),
@@ -2389,9 +2387,7 @@ class Orchestrator:
     @staticmethod
     def _review_glossary_fingerprint(terms: list[GlossaryTerm]) -> str:
         """术语表内容指纹：术语表变化后已完成的 Review 结果不得复用。"""
-        ordered = sorted(
-            (term.source, term.target, term.type) for term in terms
-        )
+        ordered = sorted((term.source, term.target, term.type) for term in terms)
         return hashlib.sha256(json.dumps(ordered, ensure_ascii=False).encode("utf-8")).hexdigest()
 
     def _review_skip_eligible(
@@ -2404,9 +2400,7 @@ class Orchestrator:
         review_id = latest.get("review_id")
         if not isinstance(review_id, str) or not review_id:
             return False
-        metadata_path = os.path.join(
-            store.run_dir, "reviews", review_id, "rounds", "metadata.json"
-        )
+        metadata_path = os.path.join(store.run_dir, "reviews", review_id, "rounds", "metadata.json")
         try:
             with open(metadata_path, encoding="utf-8") as f:
                 metadata = json.load(f)
@@ -2451,8 +2445,13 @@ class Orchestrator:
         analysis = store.load_analysis() or {}
         reviewed_content_digest = _review_content_digest(loaded)
 
-        # 断点续跑：检查是否有未完成的 Review（内容指纹必须一致）
-        debug = ReviewRunStore.find_resumable(store.run_dir, reviewed_content_digest)
+        # 断点续跑：未完成 Review 须内容、审校配置、术语表指纹一致
+        debug = ReviewRunStore.find_resumable(
+            store.run_dir,
+            reviewed_content_digest,
+            config=self._review_config_snapshot(),
+            glossary_fingerprint=self._review_glossary_fingerprint(all_terms),
+        )
         if debug is not None:
             debug.log_event("review_resumed_from_checkpoint", review_id=debug.review_id)
         else:
@@ -2518,8 +2517,7 @@ class Orchestrator:
             seen_overlays = set(_checkpoint.get("seen_overlays", []))
             patch_records = _checkpoint.get("patch_records", [])
             active_patches = {
-                (p["chapter"], p["index"]): p
-                for p in _checkpoint.get("active_patches", [])
+                (p["chapter"], p["index"]): p for p in _checkpoint.get("active_patches", [])
             }
             fix_failures = _checkpoint.get("fix_failures", [])
             blocked_issues = _checkpoint.get("blocked_issues", {})
@@ -2580,8 +2578,7 @@ class Orchestrator:
                 "seen_overlays": sorted(seen_overlays),
                 "patch_records": patch_records,
                 "active_patches": [
-                    {**p, "chapter": c, "index": i}
-                    for (c, i), p in sorted(active_patches.items())
+                    {**p, "chapter": c, "index": i} for (c, i), p in sorted(active_patches.items())
                 ],
                 "fix_failures": fix_failures,
                 "blocked_issues": blocked_issues,
@@ -2681,7 +2678,11 @@ class Orchestrator:
                         ],
                     )
                     # 断点续跑：scan_done 恢复时跳过扫描，直接用缓存结果
-                    if _resume_scan_done and review_round == start_round and _resume_latest is not None:
+                    if (
+                        _resume_scan_done
+                        and review_round == start_round
+                        and _resume_latest is not None
+                    ):
                         latest = _resume_latest
                         _resume_scan_done = False
                         _resume_latest = None
@@ -3150,16 +3151,17 @@ class Orchestrator:
             round_prefix = f"r{review_round}-" if review_round is not None else ""
             chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
             if debug is not None and debug.is_chunk_done(chunk_id):
-                cached = debug.load_chunk_result(chunk_id)
+                review_debug = debug
+                cached = review_debug.load_chunk_result(chunk_id)
                 if cached is not None:
                     # 恢复聚合状态（report 需要 initial/dismissed 数据）
                     if chapter_index is not None:
-                        debug.record_initial_issues(
+                        review_debug.record_initial_issues(
                             chapter=chapter_index,
                             chunk_base=chunk_base,
                             issues=cached.get("initial_issues", []),
                         )
-                        debug.record_dismissed(
+                        review_debug.record_dismissed(
                             chapter=chapter_index,
                             chunk_base=chunk_base,
                             issues=cached.get("dismissed", []),
@@ -3171,7 +3173,10 @@ class Orchestrator:
             # 直接合并返回，避免触发一次 reviewer LLM 调用。
             if debug is not None and len(chunk) > 1:
                 cached_sub = self._try_cached_subchunks(
-                    chunk_base, chunk, debug, round_prefix,
+                    chunk_base,
+                    chunk,
+                    debug,
+                    round_prefix,
                     chapter_index,
                 )
                 if cached_sub is not None:
@@ -3224,7 +3229,8 @@ class Orchestrator:
                         start_index=chunk_base,
                         count=len(chunk),
                     )
-                if chapter_index is not None:
+                # reused_initial 仅在 debug 非空时赋值；显式收窄供类型检查。
+                if debug is not None and chapter_index is not None:
                     debug.record_initial_issues(
                         chapter=chapter_index,
                         chunk_base=chunk_base,
@@ -3232,6 +3238,7 @@ class Orchestrator:
                     )
                 initial_issue_count = len(local_issues)
             else:
+
                 def trace(event: str, data: dict[str, Any]) -> None:
                     """逐步保存初审完整请求、原始响应或服务错误。"""
                     if debug is None or initial_trace is None:
@@ -3343,12 +3350,15 @@ class Orchestrator:
                 )
             # 断点续跑：落盘 chunk 结果（在 review_once 内，有完整数据）
             if debug is not None and chapter_index is not None:
-                debug.mark_chunk_done(chunk_id, {
-                    "issues": mapped,
-                    "initial_issues": local_issues_before_agent,
-                    "dismissed": dismissed,
-                    "fallback_reason": fallback_reason,
-                })
+                debug.mark_chunk_done(
+                    chunk_id,
+                    {
+                        "issues": mapped,
+                        "initial_issues": local_issues_before_agent,
+                        "dismissed": dismissed,
+                        "fallback_reason": fallback_reason,
+                    },
+                )
             return mapped
 
         def review_adaptive(chunk_base: int, chunk: list) -> list[dict]:
@@ -3472,43 +3482,48 @@ class Orchestrator:
         翻译的 ``_resume_batches`` 按完成状态边界切分批，只补译缺失段。
         借鉴此模式：当父 chunk 缓存未命中时，递归检查所有子 chunk 是否有
         缓存。如果全部命中，合并返回，跳过 reviewer LLM 调用。
+
+        探测阶段不写 initial/dismissed 快照；仅整棵子树命中后才统一落盘，
+        避免半边命中返回 None 后父块重跑导致重复计数。
         """
-        if not chunk:
-            return []
-        chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
-        if debug.is_chunk_done(chunk_id):
-            cached = debug.load_chunk_result(chunk_id)
-            if cached is not None:
-                if chapter_index is not None:
-                    debug.record_initial_issues(
-                        chapter=chapter_index,
-                        chunk_base=chunk_base,
-                        issues=cached.get("initial_issues", []),
-                    )
-                    debug.record_dismissed(
-                        chapter=chapter_index,
-                        chunk_base=chunk_base,
-                        issues=cached.get("dismissed", []),
-                    )
-                return cached.get("issues", [])
-        # 单段 chunk 无法再拆分
-        if len(chunk) <= 1:
+        hits: list[tuple[int, dict[str, Any]]] = []
+
+        def probe(base: int, pieces: list) -> list[dict] | None:
+            if not pieces:
+                return []
+            chunk_id = f"{round_prefix}ch{chapter_index}-base{base}-n{len(pieces)}"
+            if debug.is_chunk_done(chunk_id):
+                cached = debug.load_chunk_result(chunk_id)
+                if cached is not None:
+                    hits.append((base, cached))
+                    return list(cached.get("issues", []))
+            if len(pieces) <= 1:
+                return None
+            mid = len(pieces) // 2
+            left = probe(base, pieces[:mid])
+            if left is None:
+                return None
+            right = probe(base + mid, pieces[mid:])
+            if right is None:
+                return None
+            return left + right
+
+        merged = probe(chunk_base, chunk)
+        if merged is None:
             return None
-        # 递归探测：与 review_adaptive 拆半对齐
-        mid = len(chunk) // 2
-        left = Orchestrator._try_cached_subchunks(
-            chunk_base, chunk[:mid], debug, round_prefix,
-            chapter_index,
-        )
-        if left is None:
-            return None
-        right = Orchestrator._try_cached_subchunks(
-            chunk_base + mid, chunk[mid:], debug, round_prefix,
-            chapter_index,
-        )
-        if right is None:
-            return None
-        return left + right
+        if chapter_index is not None:
+            for base, cached in hits:
+                debug.record_initial_issues(
+                    chapter=chapter_index,
+                    chunk_base=base,
+                    issues=cached.get("initial_issues", []),
+                )
+                debug.record_dismissed(
+                    chapter=chapter_index,
+                    chunk_base=base,
+                    issues=cached.get("dismissed", []),
+                )
+        return merged
 
     @staticmethod
     def _pack_contiguous(segs, budget: int) -> list[list]:

--- a/trans_novel/pipeline/review_run.py
+++ b/trans_novel/pipeline/review_run.py
@@ -225,8 +225,8 @@ class ReviewRunStore:
                     existing = json.load(f)
                 if existing.get("status") == "running":
                     # 续跑：保留已有结果和 metadata，只更新时间戳
-                    existing["resumed_at"] = datetime.now().astimezone().isoformat(
-                        timespec="microseconds"
+                    existing["resumed_at"] = (
+                        datetime.now().astimezone().isoformat(timespec="microseconds")
                     )
                     self._atomic_json(result_path, existing)
                     self.log_event("review_resumed", review_id=self.review_id)
@@ -350,7 +350,7 @@ class ReviewRunStore:
             cached = self.load_chunk_result(name[:-5])
             if cached is None:
                 continue
-            tail = name[len(prefix):]
+            tail = name[len(prefix) :]
             try:
                 chapter_part, rest = tail.split("-base", 1)
                 chapter = int(chapter_part)
@@ -405,11 +405,14 @@ class ReviewRunStore:
     def find_resumable(
         book_run_dir: str,
         content_digest: str | None = None,
+        *,
+        config: dict[str, Any] | None = None,
+        glossary_fingerprint: str | None = None,
     ) -> "ReviewRunStore | None":
         """找到最近一次未完成的 Review 用于续跑，没有则返回 None。
 
-        如果提供 ``content_digest``，只恢复内容指纹一致的会话，
-        防止用户中断后修改译文/术语导致加载陈旧缓存。
+        ``content_digest`` / ``config`` / ``glossary_fingerprint`` 若提供，
+        必须与该次 Review 的 metadata 一致，避免改配置或术语后续跑复用陈旧缓存。
         """
         review_root = os.path.join(book_run_dir, "reviews")
         if not os.path.isdir(review_root):
@@ -430,8 +433,10 @@ class ReviewRunStore:
                 continue
             if result.get("status") != "running":
                 continue
-            # 内容指纹校验：防止加载陈旧缓存
-            if content_digest is not None:
+            need_meta = (
+                content_digest is not None or config is not None or glossary_fingerprint is not None
+            )
+            if need_meta:
                 meta_path = os.path.join(run_dir, "rounds", "metadata.json")
                 if not os.path.isfile(meta_path):
                     continue
@@ -440,7 +445,17 @@ class ReviewRunStore:
                         meta = json.load(f)
                 except (json.JSONDecodeError, OSError):
                     continue
-                if meta.get("reviewed_content_digest") != content_digest:
+                if (
+                    content_digest is not None
+                    and meta.get("reviewed_content_digest") != content_digest
+                ):
+                    continue
+                if config is not None and meta.get("config") != config:
+                    continue
+                if (
+                    glossary_fingerprint is not None
+                    and meta.get("glossary_fingerprint") != glossary_fingerprint
+                ):
                     continue
             return ReviewRunStore._from_existing(run_dir, name)
         return None

--- a/trans_novel/pipeline/review_run.py
+++ b/trans_novel/pipeline/review_run.py
@@ -1,4 +1,4 @@
-"""正式但只读的全书 Review 运行记录。"""
+"""正式但只读的全书 Review 运行记录，支持断点续跑。"""
 
 from __future__ import annotations
 
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from threading import Lock
 from typing import Any
+
+from ..llm.usage import merge_usage_summaries
 
 
 def review_candidate_id(
@@ -104,6 +106,15 @@ class ReviewRunStore:
         path = self.path(relative)
         self._atomic_json(path, data)
         return path
+
+    def load_json(self, relative: str) -> dict[str, Any] | None:
+        """按 round 作用域读取一个逐轮 JSON；缺失或损坏时返回 None。"""
+        path = self.path(relative)
+        try:
+            with open(path, encoding="utf-8") as file:
+                return json.load(file)
+        except (OSError, json.JSONDecodeError):
+            return None
 
     def log_event(self, event: str, **data: Any) -> None:
         """线程安全地追加本次 Review 的结构化事件。"""
@@ -202,11 +213,32 @@ class ReviewRunStore:
         return sorted(initial, key=position), sorted(dismissed, key=position)
 
     def start(self, *, reviewed_content_digest: str, metadata: dict[str, Any]) -> None:
-        """在首个模型调用前创建运行中结果并保存运行参数。"""
+        """在首个模型调用前创建运行中结果并保存运行参数。
+
+        如果是续跑（status=running），保留已有结果和 metadata 不覆盖。
+        """
         self._reviewed_content_digest = reviewed_content_digest
+        result_path = os.path.join(self.run_dir, "result.json")
+        if os.path.isfile(result_path):
+            try:
+                with open(result_path, "r", encoding="utf-8") as f:
+                    existing = json.load(f)
+                if existing.get("status") == "running":
+                    # 续跑：保留已有结果和 metadata，只更新时间戳
+                    existing["resumed_at"] = datetime.now().astimezone().isoformat(
+                        timespec="microseconds"
+                    )
+                    self._atomic_json(result_path, existing)
+                    self.log_event("review_resumed", review_id=self.review_id)
+                    return
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # 首次运行：保存 metadata 并创建新结果
+        metadata["reviewed_content_digest"] = reviewed_content_digest
         self.write_json("rounds/metadata.json", metadata)
         self._atomic_json(
-            os.path.join(self.run_dir, "result.json"),
+            result_path,
             {
                 "review_id": self.review_id,
                 "status": "running",
@@ -256,6 +288,219 @@ class ReviewRunStore:
         return result
 
     def save_usage(self, usage: dict[str, Any]) -> None:
-        """保存本次 Review 的 Token 增量。"""
+        """合并保存本次 Review 的 Token 增量（跨进程续跑不丢失）。"""
+        existing = self.load_usage()
+        if existing is not None:
+            usage = merge_usage_summaries(existing, usage)
         self._atomic_json(os.path.join(self.run_dir, "usage.json"), usage)
         self.log_event("review_usage_recorded", **usage["totals"])
+
+    def load_usage(self) -> dict[str, Any] | None:
+        """读取已落盘的 Review 用量；文件缺失时返回 None。"""
+        path = os.path.join(self.run_dir, "usage.json")
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    # ── 断点续跑：chunk 级别完成状态 ──────────────────────────────────────
+
+    def mark_chunk_done(self, chunk_id: str, result: dict[str, Any]) -> None:
+        """标记一个审校块为已完成，保存结果用于续跑。"""
+        chunks_dir = os.path.join(self.run_dir, "chunks")
+        os.makedirs(chunks_dir, exist_ok=True)
+        self._atomic_json(os.path.join(chunks_dir, f"{chunk_id}.json"), result)
+
+    def load_chunk_result(self, chunk_id: str) -> dict[str, Any] | None:
+        """加载已完成的审校块结果，未完成返回 None。"""
+        path = os.path.join(self.run_dir, "chunks", f"{chunk_id}.json")
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def is_chunk_done(self, chunk_id: str) -> bool:
+        """检查审校块是否已完成。"""
+        return self.load_chunk_result(chunk_id) is not None
+
+    def rebuild_snapshots_from_chunks(self, review_round: int) -> None:
+        """从已落盘的 chunk 缓存重建初审/驳回快照。
+
+        用于 scan_done 断点续跑：跳过整轮扫描后，review_once 不再
+        重放 record_initial_issues/record_dismissed，这里按 chunk 文件
+        恢复内存聚合状态，保证最终报告的数据完整。
+
+        大块优先重建；若父块与拆半残留的子块同时存在（如整块重跑
+        成功后旧叶子未清理），跳过完全包含在已记录块内的子块，避免重复计数。
+        """
+        chunks_dir = os.path.join(self.run_dir, "chunks")
+        if not os.path.isdir(chunks_dir):
+            return
+        prefix = f"r{review_round}-ch"
+        entries: list[tuple[int, int, int, dict[str, Any]]] = []
+        for name in os.listdir(chunks_dir):
+            if not name.startswith(prefix) or not name.endswith(".json"):
+                continue
+            cached = self.load_chunk_result(name[:-5])
+            if cached is None:
+                continue
+            tail = name[len(prefix):]
+            try:
+                chapter_part, rest = tail.split("-base", 1)
+                chapter = int(chapter_part)
+                base_part, n_part = rest.split("-n", 1)
+                chunk_base = int(base_part)
+                size = int(n_part[:-5])
+            except ValueError:
+                continue
+            entries.append((chapter, chunk_base, size, cached))
+        # 按 (chapter, -size, base) 排序：大块在前，小块的包含关系可判
+        entries.sort(key=lambda e: (e[0], -e[2], e[1]))
+        covered: dict[int, list[tuple[int, int]]] = {}
+        for chapter, chunk_base, size, cached in entries:
+            start, end = chunk_base, chunk_base + size
+            ranges = covered.setdefault(chapter, [])
+            if any(lo <= start and end <= hi for lo, hi in ranges):
+                continue
+            ranges.append((start, end))
+            initial_issues = cached.get("initial_issues", [])
+            if initial_issues:
+                self.record_initial_issues(
+                    chapter=chapter,
+                    chunk_base=chunk_base,
+                    issues=initial_issues,
+                )
+            dismissed = cached.get("dismissed", [])
+            if dismissed:
+                self.record_dismissed(
+                    chapter=chapter,
+                    chunk_base=chunk_base,
+                    issues=dismissed,
+                )
+
+    # ── 断点续跑：轮级检查点 ────────────────────────────────────────────
+
+    def save_checkpoint(self, state: dict[str, Any]) -> None:
+        """保存轮级检查点，用于续跑恢复 round 循环状态。"""
+        self._atomic_json(os.path.join(self.run_dir, "checkpoint.json"), state)
+
+    def load_checkpoint(self) -> dict[str, Any] | None:
+        """加载轮级检查点，不存在返回 None。"""
+        path = os.path.join(self.run_dir, "checkpoint.json")
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    @staticmethod
+    def find_resumable(
+        book_run_dir: str,
+        content_digest: str | None = None,
+    ) -> "ReviewRunStore | None":
+        """找到最近一次未完成的 Review 用于续跑，没有则返回 None。
+
+        如果提供 ``content_digest``，只恢复内容指纹一致的会话，
+        防止用户中断后修改译文/术语导致加载陈旧缓存。
+        """
+        review_root = os.path.join(book_run_dir, "reviews")
+        if not os.path.isdir(review_root):
+            return None
+        candidates = sorted(
+            (d for d in os.listdir(review_root) if d.startswith("review-")),
+            reverse=True,
+        )
+        for name in candidates:
+            run_dir = os.path.join(review_root, name)
+            result_path = os.path.join(run_dir, "result.json")
+            if not os.path.isfile(result_path):
+                continue
+            try:
+                with open(result_path, "r", encoding="utf-8") as f:
+                    result = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+            if result.get("status") != "running":
+                continue
+            # 内容指纹校验：防止加载陈旧缓存
+            if content_digest is not None:
+                meta_path = os.path.join(run_dir, "rounds", "metadata.json")
+                if not os.path.isfile(meta_path):
+                    continue
+                try:
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        meta = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    continue
+                if meta.get("reviewed_content_digest") != content_digest:
+                    continue
+            return ReviewRunStore._from_existing(run_dir, name)
+        return None
+
+    @classmethod
+    def _from_existing(cls, run_dir: str, review_id: str) -> "ReviewRunStore":
+        """从已有目录恢复一个 ReviewRunStore 实例。"""
+        inst = cls.__new__(cls)
+        inst.run_dir = run_dir
+        inst.review_id = review_id
+        inst._event_path = os.path.join(run_dir, "events.jsonl")
+        inst._event_lock = Lock()
+        inst._result_lock = Lock()
+        inst._initial_issues = []
+        inst._dismissed_issues = []
+        inst._active_round = None
+        inst._reviewed_content_digest = ""
+        # 恢复事件序号（避免与已有事件重叠）
+        inst._sequence = cls._read_max_seq(inst._event_path)
+        # 优先从 result.json 恢复 started_at（metadata 中无该字段）
+        inst.started_at = ""
+        result_path = os.path.join(run_dir, "result.json")
+        if os.path.isfile(result_path):
+            try:
+                with open(result_path, "r", encoding="utf-8") as f:
+                    existing = json.load(f)
+                inst.started_at = existing.get("started_at", "")
+            except (json.JSONDecodeError, OSError):
+                pass
+        if not inst.started_at:
+            # 兼容早期版本：从 metadata 恢复时间戳
+            meta_path = os.path.join(run_dir, "rounds", "metadata.json")
+            if os.path.isfile(meta_path):
+                try:
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        meta = json.load(f)
+                    inst.started_at = meta.get("started_at", "")
+                except (json.JSONDecodeError, OSError):
+                    inst.started_at = ""
+        return inst
+
+    @staticmethod
+    def _read_max_seq(event_path: str) -> int:
+        """从 events.jsonl 读取最大 seq 值。"""
+        max_seq = 0
+        if not os.path.isfile(event_path):
+            return max_seq
+        try:
+            with open(event_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                        seq = row.get("seq", 0)
+                        if isinstance(seq, int) and seq > max_seq:
+                            max_seq = seq
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+        except OSError:
+            pass
+        return max_seq


### PR DESCRIPTION
Review 审校阶段中断后重跑可续传：已完成的初筛/证据轮/修复轮不再重复调用 LLM。
- 三级缓存：轮级 checkpoint + chunk 级结果缓存 + agent turn 级 trace 复用
- 跳过判定：内容指纹 + 配置快照 + 术语表指纹三者一致才复用，改配置或术语表自动重审
- 中断安全：状态全部落盘，跨进程恢复，多次恢复不重复计数
- 附带修复：空轮次死局、skip 忽略配置变更、usage 回填等问题
测试：108 个 review/orchestrator 测试通过。