### PR TITLE
docs: add AtomGit mirror links to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,9 @@ Translated state directories for public-domain books may be shared through [weny
 ## License
 
 [MIT](LICENSE)
+
+---
+
+## AtomGit (China)
+
+Wenyi is also hosted on AtomGit: [https://gitcode.com/2403_86951519/wenyi](https://gitcode.com/2403_86951519/wenyi)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -228,3 +228,9 @@ Review Fixer 同样会获得风格指南、全书概览、本章梗概、相关�
 ## 许可证
 
 [MIT](../../LICENSE)
+
+---
+
+## 国内 AtomGit 托管
+
+本项目在 AtomGit 亦有镜像：[https://gitcode.com/2403_86951519/wenyi](https://gitcode.com/2403_86951519/wenyi)


### PR DESCRIPTION
Note the China-hosted AtomGit/GitCode copy at the bottom of the English and Chinese READMEs.