### PR TITLE
feat(pdf): add HTTP client for external BabelDOC bridge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,11 @@ pipeline:
   review_fix_max_rounds: 2 # 最多生成两轮临时替换；完整 Review 轮数另受连续 clean 确认影响
   review_clean_confirmations: 2 # 连续两轮未发现问题才视为影子译文通过
   glossary_scope: chapter # chapter=只注入本章出现的词条（长书省 token）；full=全量表
+  # PDF 后端：mineru（默认，支持扫描件）| babeldoc（可选，外部 AGPL HTTP bridge）
+  pdf_backend: mineru
+  babeldoc_bridge_url: http://127.0.0.1:8765
+  # babeldoc_pages: "15"   # 可选；限制 bridge 处理页（1-based）
+  babeldoc_timeout: 600
 
 # ── 敬称策略（日语源文本时生效，其它语言通常不会用到）────────────────────
 honorific:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,6 +102,10 @@ pipeline:
    babeldoc. Chapters are split from the PDF outline (bookmarks); segments keep
    `meta.babeldoc_id` for fillback. Books without outlines fall back to one chapter.
 
+BabelDOC is intended for PDFs with an extractable text layer. Before contacting the
+bridge, Wenyi checks the selected pages and stops with a suggestion to use the default
+MinerU backend or run OCR first when it finds only scanned images and no text layer.
+
 The first MinerU PDF import requires `MINERU_API_KEY`:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,8 @@ pipeline:
 
 3. After `translate book.pdf`, `assemble --format pdf` calls bridge `/fillback`.
    Keep the same bridge process alive for the whole session. Wenyi never imports
-   babeldoc.
+   babeldoc. Chapters are split from the PDF outline (bookmarks); segments keep
+   `meta.babeldoc_id` for fillback. Books without outlines fall back to one chapter.
 
 The first MinerU PDF import requires `MINERU_API_KEY`:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,7 +84,24 @@ PDF input and PDF output are both experimental.
 
 #### PDF input
 
-The first PDF import requires `MINERU_API_KEY`:
+Default backend is MinerU. For layout-preserving export, use the external
+**BabelDOC bridge** (AGPL, separate repo/process, HTTP only):
+
+1. Install/start `wenyi-babeldoc-bridge` (default `http://127.0.0.1:8765`)
+2. In `config.yaml`:
+
+```yaml
+pipeline:
+  pdf_backend: babeldoc
+  babeldoc_bridge_url: http://127.0.0.1:8765
+  # babeldoc_pages: "15"   # optional, 1-based
+```
+
+3. After `translate book.pdf`, `assemble --format pdf` calls bridge `/fillback`.
+   Keep the same bridge process alive for the whole session. Wenyi never imports
+   babeldoc.
+
+The first MinerU PDF import requires `MINERU_API_KEY`:
 
 ```bash
 export MINERU_API_KEY=...

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -96,7 +96,8 @@ pipeline:
 ```
 
 3. `uv run trans-novel translate book.pdf` 后 `assemble --format pdf` 会经 bridge `/fillback` 出 PDF。  
-   **须在同一 bridge 进程生命周期内完成翻译与导出**（session 在内存）。主仓不 import babeldoc。
+   **须在同一 bridge 进程生命周期内完成翻译与导出**（session 在内存）。主仓不 import babeldoc。  
+   章节按 **PDF 内置 TOC（书签）** 断章；段落仍带 `meta.babeldoc_id` 供回填。无书签时退回单章。
 
 首次读取 PDF（MinerU）需设置 `MINERU_API_KEY`：
 

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -83,7 +83,22 @@ PDF 输入和 PDF 导出目前均属于实验性支持。
 
 #### PDF 输入
 
-首次读取 PDF 需设置 `MINERU_API_KEY`：
+默认走 MinerU。也可用外部 **BabelDOC bridge**（AGPL，独立仓库/进程，HTTP only）保留版式：
+
+1. 另仓安装并启动 `wenyi-babeldoc-bridge`（默认 `http://127.0.0.1:8765`）
+2. `config.yaml`：
+
+```yaml
+pipeline:
+  pdf_backend: babeldoc
+  babeldoc_bridge_url: http://127.0.0.1:8765
+  # babeldoc_pages: "15"   # 可选，1-based
+```
+
+3. `uv run trans-novel translate book.pdf` 后 `assemble --format pdf` 会经 bridge `/fillback` 出 PDF。  
+   **须在同一 bridge 进程生命周期内完成翻译与导出**（session 在内存）。主仓不 import babeldoc。
+
+首次读取 PDF（MinerU）需设置 `MINERU_API_KEY`：
 
 ```bash
 export MINERU_API_KEY=...

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -99,6 +99,9 @@ pipeline:
    **须在同一 bridge 进程生命周期内完成翻译与导出**（session 在内存）。主仓不 import babeldoc。  
    章节按 **PDF 内置 TOC（书签）** 断章；段落仍带 `meta.babeldoc_id` 供回填。无书签时退回单章。
 
+BabelDOC 只适合带可提取文本层的 PDF。选择该后端时，Wenyi 会在请求 bridge 前检查所选页面；
+若页面只有扫描图片而没有文本层，会停止并提示改用默认 MinerU，或先进行 OCR。
+
 首次读取 PDF（MinerU）需设置 `MINERU_API_KEY`：
 
 ```bash

--- a/tests/test_babeldoc_bridge_client.py
+++ b/tests/test_babeldoc_bridge_client.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from trans_novel.ingest.pdf_babeldoc import read_pdf_babeldoc
+from trans_novel.ingest.pdf_babeldoc import _is_image_only_pdf, read_pdf_babeldoc
 from trans_novel.pdf_bridge.client import BabeldocBridgeClient, BabeldocBridgeError
 
 
@@ -94,6 +94,43 @@ class BabeldocBridgeClientTests(unittest.TestCase):
             self.assertTrue(cache.is_file())
             saved = json.loads(cache.read_text(encoding="utf-8"))
             self.assertEqual(saved["session_id"], "sess1")
+
+    def test_image_only_pdf_is_rejected_before_bridge_request(self):
+        with (
+            patch("trans_novel.ingest.pdf_babeldoc._is_image_only_pdf", return_value=True),
+            patch("trans_novel.ingest.pdf_babeldoc.BabeldocBridgeClient") as client,
+            self.assertRaisesRegex(BabeldocBridgeError, "只有扫描图片.*MinerU"),
+        ):
+            read_pdf_babeldoc(
+                "scan.pdf",
+                "en",
+                "zh",
+                bridge_url="http://bridge.test",
+            )
+
+        client.assert_not_called()
+
+    def test_image_only_detection_accepts_an_ocr_text_layer(self):
+        page = MagicMock()
+        page.extract_text.return_value = "Recognized text"
+        reader = MagicMock()
+        reader.pages = [page]
+
+        with patch("pypdf.PdfReader", return_value=reader):
+            self.assertFalse(_is_image_only_pdf("ocr.pdf"))
+
+    def test_image_only_detection_honors_selected_pages(self):
+        text_page = MagicMock()
+        text_page.extract_text.return_value = "Digital text"
+        image_page = MagicMock()
+        image_page.extract_text.return_value = ""
+        image_page.get.return_value = {"/XObject": {"/scan": {"/Subtype": "/Image"}}}
+        reader = MagicMock()
+        reader.pages = [text_page, image_page]
+
+        with patch("pypdf.PdfReader", return_value=reader):
+            self.assertTrue(_is_image_only_pdf("mixed.pdf", pages="2"))
+            self.assertFalse(_is_image_only_pdf("mixed.pdf"))
 
     def test_toc_splits_chapters_by_page(self):
         from trans_novel.ingest.pdf_babeldoc import _chapters_from_paragraphs

--- a/tests/test_babeldoc_bridge_client.py
+++ b/tests/test_babeldoc_bridge_client.py
@@ -73,6 +73,7 @@ class BabeldocBridgeClientTests(unittest.TestCase):
         fake.extract.return_value = payload
         with (
             patch("trans_novel.ingest.pdf_babeldoc.BabeldocBridgeClient", return_value=fake),
+            patch("trans_novel.ingest.pdf_babeldoc.toc_chapter_starts", return_value=[]),
             tempfile_directory() as cache_dir,
         ):
             doc = read_pdf_babeldoc(
@@ -85,6 +86,7 @@ class BabeldocBridgeClientTests(unittest.TestCase):
             )
             self.assertTrue(doc.meta.get("babeldoc"))
             self.assertEqual(doc.meta.get("babeldoc_session_id"), "sess1")
+            self.assertEqual(len(doc.chapters), 1)
             self.assertEqual(len(doc.chapters[0].segments), 2)
             self.assertEqual(doc.chapters[0].segments[0].kind, "heading")
             self.assertEqual(doc.chapters[0].segments[0].meta.get("babeldoc_id"), "14:1")
@@ -92,6 +94,58 @@ class BabeldocBridgeClientTests(unittest.TestCase):
             self.assertTrue(cache.is_file())
             saved = json.loads(cache.read_text(encoding="utf-8"))
             self.assertEqual(saved["session_id"], "sess1")
+
+    def test_toc_splits_chapters_by_page(self):
+        from trans_novel.ingest.pdf_babeldoc import _chapters_from_paragraphs
+
+        paragraphs = [
+            {
+                "id": "5:0",
+                "source": "Author bio text here.",
+                "page": 5,
+                "layout_label": "plain text",
+            },
+            {
+                "id": "6:0",
+                "source": "Brief contents line.",
+                "page": 6,
+                "layout_label": "plain text",
+            },
+            {
+                "id": "14:0",
+                "source": "Preface body paragraph.",
+                "page": 14,
+                "layout_label": "plain text",
+            },
+            {
+                "id": "14:1",
+                "source": "More preface text here.",
+                "page": 14,
+                "layout_label": "plain text",
+            },
+        ]
+        starts = [(5, "About the Author"), (6, "Brief Contents"), (14, "Preface")]
+        chapters = _chapters_from_paragraphs(paragraphs, book_title="Book", toc_starts=starts)
+        self.assertEqual(
+            [c.title for c in chapters], ["About the Author", "Brief Contents", "Preface"]
+        )
+        self.assertEqual([len(c.segments) for c in chapters], [1, 1, 2])
+        self.assertEqual(chapters[2].segments[1].meta.get("babeldoc_id"), "14:1")
+
+    def test_toc_chapter_starts_reads_weaver(self):
+        from trans_novel.ingest.pdf_babeldoc import toc_chapter_starts
+
+        pdf = Path("Molecular Biology (5th Ed) (Robert F. Weaver) (z.pdf")
+        if not pdf.is_file():
+            self.skipTest("Weaver sample PDF not present")
+        starts = toc_chapter_starts(pdf)
+        self.assertGreater(len(starts), 5)
+        titles = [t for _p, t in starts]
+        self.assertTrue(any("Preface" in t for t in titles))
+        self.assertTrue(any("About the Author" in t for t in titles))
+        # Preface bookmark should land on 0-based page 14 for this book.
+        preface_pages = [p for p, t in starts if "Preface" in t]
+        self.assertIn(14, preface_pages)
 
 
 class tempfile_directory:

--- a/tests/test_babeldoc_bridge_client.py
+++ b/tests/test_babeldoc_bridge_client.py
@@ -1,0 +1,109 @@
+"""Tests for MIT-side BabelDOC bridge HTTP client (no babeldoc import)."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from trans_novel.ingest.pdf_babeldoc import read_pdf_babeldoc
+from trans_novel.pdf_bridge.client import BabeldocBridgeClient, BabeldocBridgeError
+
+
+class BabeldocBridgeClientTests(unittest.TestCase):
+    def test_health_wraps_connection_errors(self):
+        client = BabeldocBridgeClient("http://127.0.0.1:9")
+        with patch("trans_novel.pdf_bridge.client.httpx.get", side_effect=OSError("down")):
+            with self.assertRaises(BabeldocBridgeError):
+                client.health()
+
+    def test_extract_posts_multipart(self):
+        client = BabeldocBridgeClient("http://bridge.test")
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
+            handle.write(b"%PDF-1.4 mock")
+            pdf_path = Path(handle.name)
+        try:
+            health = MagicMock()
+            health.raise_for_status = MagicMock()
+            health.json.return_value = {"ok": True}
+            extract = MagicMock()
+            extract.status_code = 200
+            extract.json.return_value = {
+                "session_id": "abc",
+                "paragraphs": {"paragraphs": [{"id": "0:1", "source": "Hello world here"}]},
+            }
+            with (
+                patch("trans_novel.pdf_bridge.client.httpx.get", return_value=health),
+                patch("trans_novel.pdf_bridge.client.httpx.post", return_value=extract) as post,
+            ):
+                payload = client.extract(pdf_path, pages="15")
+            self.assertEqual(payload["session_id"], "abc")
+            args, kwargs = post.call_args
+            self.assertTrue(str(args[0]).endswith("/extract"))
+            self.assertEqual(kwargs["data"].get("pages"), "15")
+        finally:
+            pdf_path.unlink(missing_ok=True)
+
+    def test_read_pdf_babeldoc_builds_segments(self):
+        payload = {
+            "session_id": "sess1",
+            "paragraphs": {
+                "paragraphs": [
+                    {
+                        "id": "14:1",
+                        "source": "Organization",
+                        "layout_label": "title",
+                        "page": 14,
+                        "index": 1,
+                    },
+                    {
+                        "id": "14:2",
+                        "source": "This chapter introduces methods.",
+                        "layout_label": "plain text",
+                        "page": 14,
+                        "index": 2,
+                    },
+                ]
+            },
+        }
+        fake = MagicMock()
+        fake.extract.return_value = payload
+        with (
+            patch("trans_novel.ingest.pdf_babeldoc.BabeldocBridgeClient", return_value=fake),
+            tempfile_directory() as cache_dir,
+        ):
+            doc = read_pdf_babeldoc(
+                "book.pdf",
+                "en",
+                "zh",
+                bridge_url="http://bridge.test",
+                pages="15",
+                cache_dir=cache_dir,
+            )
+            self.assertTrue(doc.meta.get("babeldoc"))
+            self.assertEqual(doc.meta.get("babeldoc_session_id"), "sess1")
+            self.assertEqual(len(doc.chapters[0].segments), 2)
+            self.assertEqual(doc.chapters[0].segments[0].kind, "heading")
+            self.assertEqual(doc.chapters[0].segments[0].meta.get("babeldoc_id"), "14:1")
+            cache = Path(cache_dir) / "babeldoc_extract.json"
+            self.assertTrue(cache.is_file())
+            saved = json.loads(cache.read_text(encoding="utf-8"))
+            self.assertEqual(saved["session_id"], "sess1")
+
+
+class tempfile_directory:
+    def __enter__(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        return self._tmp.name
+
+    def __exit__(self, *args):
+        self._tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ from trans_novel.cli import (
 )
 from trans_novel.config import Config
 from trans_novel.ingest.errors import MinerUError
+from trans_novel.pdf_bridge import BabeldocBridgeError
 
 
 class FakeStore:
@@ -492,6 +493,7 @@ class TestCliConfig(unittest.TestCase):
 
         for error in (
             MinerUError("未设置 MINERU_API_KEY"),
+            BabeldocBridgeError("BabelDOC 检测到纯图片 PDF，请改用 MinerU"),
             ValueError("不支持的输出格式：xml"),
         ):
             with self.subTest(error=type(error).__name__):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,7 @@ class TestConfigFileCreation(unittest.TestCase):
             self.assertTrue(cfg.pipeline.review_fix_loop)
             self.assertEqual(cfg.pipeline.review_fix_max_rounds, 2)
             self.assertEqual(cfg.pipeline.review_clean_confirmations, 2)
+            self.assertEqual(cfg.pipeline.pdf_backend, "mineru")
 
     def test_load_never_overwrites_existing_config(self):
         with tempfile.TemporaryDirectory() as d:
@@ -80,6 +81,7 @@ class TestConfigFileCreation(unittest.TestCase):
         self.assertTrue(cfg.pipeline.review_fix_loop)
         self.assertEqual(cfg.pipeline.review_fix_max_rounds, 2)
         self.assertEqual(cfg.pipeline.review_clean_confirmations, 2)
+        self.assertEqual(cfg.pipeline.pdf_backend, "mineru")
 
     def test_about_page_can_be_disabled(self):
         cfg = Config.from_dict({"output": {"about_page": False}})

--- a/trans_novel/assemble/pdf_writer.py
+++ b/trans_novel/assemble/pdf_writer.py
@@ -311,6 +311,16 @@ def _assemble_pdf_fpdf2(
     return out_path
 
 
+def _assemble_pdf_babeldoc(store: RunStore, out_path: str) -> str:
+    """Fill back translations through the external BabelDOC HTTP bridge."""
+    from ..ingest.pdf_babeldoc import translations_from_store
+    from ..pdf_bridge import BabeldocBridgeClient
+
+    session_id, bridge_url, mapping = translations_from_store(store)
+    client = BabeldocBridgeClient(bridge_url)
+    return client.fillback(session_id, mapping, out_path=out_path)
+
+
 def _assemble_pdf(
     store: RunStore,
     source_path: str,
@@ -322,6 +332,11 @@ def _assemble_pdf(
     preserve_source_style: bool = False,
 ) -> str:
     """Dispatch PDF output to the selected rendering backend."""
+    manifest = store.load_manifest() or {}
+    raw_meta = manifest.get("meta")
+    meta: dict = raw_meta if isinstance(raw_meta, dict) else {}
+    if meta.get("pdf_export") == "babeldoc" or meta.get("babeldoc"):
+        return _assemble_pdf_babeldoc(store, out_path)
     if engine == "weasyprint":
         return _assemble_pdf_weasyprint(
             store,

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -67,6 +67,11 @@ pipeline:
   review_fix_max_rounds: 2 # 最多生成两轮临时替换；完整 Review 轮数另受连续 clean 确认影响
   review_clean_confirmations: 2 # 连续两轮未发现问题才视为影子译文通过
   glossary_scope: chapter # chapter=本章相关词条；full=全量表
+  # PDF 后端：mineru（默认）| babeldoc（外部 AGPL HTTP bridge，主仓不引入 babeldoc）
+  pdf_backend: mineru
+  babeldoc_bridge_url: http://127.0.0.1:8765
+  # babeldoc_pages: "15"   # 可选；限制 bridge 处理页（1-based）
+  babeldoc_timeout: 600
 
 # ── 敬称策略（日语源文本时生效，其它语言通常不会用到）────────────────────
 honorific:
@@ -148,6 +153,11 @@ class PipelineConfig(BaseModel):
     review_fix_max_rounds: int = Field(default=2, ge=0, le=4)
     review_clean_confirmations: int = Field(default=2, ge=1, le=2)
     glossary_scope: str = "chapter"  # chapter=只注入本章出现的词条（省 token）；full=全量表
+    # PDF：mineru=现有 HTML 路径；babeldoc=外部 AGPL bridge（HTTP，主仓不 import babeldoc）
+    pdf_backend: Literal["mineru", "babeldoc"] = "mineru"
+    babeldoc_bridge_url: str = "http://127.0.0.1:8765"
+    babeldoc_pages: str | None = None  # 如 "15" / "6-8"；None=全书
+    babeldoc_timeout: float = 600.0
 
 
 class OutputConfig(BaseModel):

--- a/trans_novel/ingest/pdf_babeldoc.py
+++ b/trans_novel/ingest/pdf_babeldoc.py
@@ -18,6 +18,106 @@ BABELDOC_META = "babeldoc"
 BABELDOC_ID_META = "babeldoc_id"
 
 
+def _selected_page_indices(pages: str | None, page_count: int) -> list[int]:
+    """Expand BabelDOC's 1-based page selection syntax into 0-based indices."""
+    if not pages or not pages.strip():
+        return list(range(page_count))
+
+    selected: set[int] = set()
+    try:
+        for raw_token in pages.split(","):
+            token = raw_token.strip()
+            if not token:
+                continue
+            if token.isdigit():
+                page = int(token)
+                if 1 <= page <= page_count:
+                    selected.add(page - 1)
+                continue
+
+            match = re.fullmatch(r"(\d*)-(\d*)", token)
+            if match is None or not any(match.groups()):
+                return []
+            start = int(match.group(1)) if match.group(1) else 1
+            end = int(match.group(2)) if match.group(2) else page_count
+            if start < 1 or end < 1 or start > end:
+                return []
+            selected.update(range(max(1, start) - 1, min(page_count, end)))
+    except ValueError:
+        return []
+    return sorted(selected)
+
+
+def _resolved_pdf_object(value):
+    get_object = getattr(value, "get_object", None)
+    return get_object() if callable(get_object) else value
+
+
+def _resources_have_image(resources, *, seen: set[int] | None = None) -> bool:
+    """Return whether PDF resources contain an image, including nested forms."""
+    resources = _resolved_pdf_object(resources)
+    if not hasattr(resources, "get"):
+        return False
+    if seen is None:
+        seen = set()
+    identity = id(resources)
+    if identity in seen:
+        return False
+    seen.add(identity)
+
+    xobjects = _resolved_pdf_object(resources.get("/XObject"))
+    if not hasattr(xobjects, "values"):
+        return False
+    for reference in xobjects.values():
+        xobject = _resolved_pdf_object(reference)
+        if not hasattr(xobject, "get"):
+            continue
+        subtype = str(xobject.get("/Subtype") or "")
+        if subtype == "/Image":
+            return True
+        if subtype == "/Form" and _resources_have_image(xobject.get("/Resources"), seen=seen):
+            return True
+    return False
+
+
+def _page_has_image(page) -> bool:
+    if _resources_have_image(page.get("/Resources")):
+        return True
+    try:
+        content = page.get_contents()
+        return content is not None and any(
+            operator == b"INLINE IMAGE" for _operands, operator in content.operations
+        )
+    except Exception:
+        return False
+
+
+def _is_image_only_pdf(path: str | Path, *, pages: str | None = None) -> bool:
+    """Best-effort detection of selected pages containing images but no text layer.
+
+    Detection failures deliberately fall through to BabelDOC, which remains the
+    authority for parsing unusual or damaged PDFs.
+    """
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(str(path))
+        indices = _selected_page_indices(pages, len(reader.pages))
+        if not indices:
+            return False
+
+        found_image = False
+        for index in indices:
+            page = reader.pages[index]
+            text = page.extract_text() or ""
+            if text.strip():
+                return False
+            found_image = found_image or _page_has_image(page)
+        return found_image
+    except Exception:
+        return False
+
+
 def toc_chapter_starts(pdf_path: str | Path) -> list[tuple[int, str]]:
     """Read PDF bookmarks and return ``(0-based page, title)`` chapter starts.
 
@@ -177,6 +277,12 @@ def read_pdf_babeldoc(
     timeout: float = 600.0,
 ) -> Document:
     """Call bridge ``/extract`` and map paragraphs into TOC-based chapters."""
+    if _is_image_only_pdf(path, pages=pages):
+        raise BabeldocBridgeError(
+            "BabelDOC 后端检测到所选 PDF 页面只有扫描图片，没有可提取的文本层，"
+            "无法可靠解析。请改用默认 MinerU 后端（pipeline.pdf_backend: mineru），"
+            "或先用 OCR 工具生成可搜索文本层后再选择 babeldoc。"
+        )
     client = BabeldocBridgeClient(bridge_url, timeout=timeout)
     payload = client.extract(path, pages=pages)
     session_id = payload.get("session_id")

--- a/trans_novel/ingest/pdf_babeldoc.py
+++ b/trans_novel/ingest/pdf_babeldoc.py
@@ -1,12 +1,14 @@
 """PDF ingest via external BabelDOC bridge (HTTP only).
 
 Builds a Wenyi Document whose segments carry ``meta.babeldoc_id`` for fillback.
+Chapters are split by the PDF outline (TOC bookmarks) via pypdf.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 from ..pdf_bridge import BabeldocBridgeClient, BabeldocBridgeError
@@ -14,6 +16,154 @@ from .models import KIND_HEADING, KIND_TEXT, Chapter, Document, Segment
 
 BABELDOC_META = "babeldoc"
 BABELDOC_ID_META = "babeldoc_id"
+
+
+def toc_chapter_starts(pdf_path: str | Path) -> list[tuple[int, str]]:
+    """Read PDF bookmarks and return ``(0-based page, title)`` chapter starts.
+
+    Prefer level-2 entries when present (e.g. CHAPTER under PART); otherwise
+    level-1. Same page keeps the deeper title. Uses pypdf only (MIT path).
+    """
+    try:
+        from pypdf import PdfReader
+    except ImportError as error:
+        raise BabeldocBridgeError(
+            "读取 PDF TOC 需要 pypdf（项目已声明依赖）。请先 uv sync。"
+        ) from error
+
+    reader = PdfReader(str(pdf_path))
+    flat: list[tuple[int, str, int]] = []  # depth, title, page0
+
+    def walk(items, depth: int) -> None:
+        for item in items or []:
+            if isinstance(item, list):
+                walk(item, depth + 1)
+                continue
+            title = getattr(item, "title", None)
+            if not isinstance(title, str) or not title.strip():
+                continue
+            try:
+                page0 = reader.get_destination_page_number(item)
+            except Exception:
+                continue
+            if not isinstance(page0, int) or page0 < 0:
+                continue
+            flat.append((depth, title.strip(), page0))
+
+    walk(reader.outline, 0)
+    if not flat:
+        return []
+
+    # pypdf nesting: top entries depth 0; prefer depth<=1 when subsections exist.
+    has_level1 = any(depth >= 1 for depth, _t, _p in flat)
+    max_depth = 1 if has_level1 else 0
+    by_page: dict[int, tuple[int, str]] = {}
+    for depth, title, page0 in flat:
+        if depth > max_depth:
+            continue
+        previous = by_page.get(page0)
+        if previous is None or depth >= previous[0]:
+            by_page[page0] = (depth, title)
+
+    return sorted((page0, title) for page0, (_depth, title) in by_page.items())
+
+
+def _paragraph_page(para: dict) -> int | None:
+    page = para.get("page")
+    if isinstance(page, int) and page >= 0:
+        return page
+    pid = str(para.get("id") or "")
+    match = re.match(r"^(\d+):", pid)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _assign_chapter_index(page: int, starts: list[tuple[int, str]]) -> int:
+    """Latest TOC start with start_page <= page; 0 if before first bookmark."""
+    index = 0
+    for i, (start_page, _title) in enumerate(starts):
+        if page >= start_page:
+            index = i
+        else:
+            break
+    return index
+
+
+def _chapters_from_paragraphs(
+    paragraphs: list[dict],
+    *,
+    book_title: str,
+    toc_starts: list[tuple[int, str]],
+) -> list[Chapter]:
+    if not toc_starts:
+        segments: list[Segment] = []
+        for index, para in enumerate(paragraphs):
+            segment = _segment_from_para(index, para)
+            if segment is not None:
+                segments.append(segment)
+        for i, segment in enumerate(segments):
+            segment.index = i
+        return [Chapter(index=0, title=book_title, segments=segments, meta={BABELDOC_META: True})]
+
+    buckets: list[list[Segment]] = [[] for _ in toc_starts]
+    # Paras before the first TOC page still go into chapter 0.
+    for para in paragraphs:
+        if not isinstance(para, dict):
+            continue
+        page = _paragraph_page(para)
+        if page is None:
+            page = toc_starts[0][0]
+        chapter_i = _assign_chapter_index(page, toc_starts)
+        segment = _segment_from_para(len(buckets[chapter_i]), para)
+        if segment is not None:
+            buckets[chapter_i].append(segment)
+
+    chapters: list[Chapter] = []
+    out_index = 0
+    for (start_page, title), segs in zip(toc_starts, buckets, strict=True):
+        if not segs:
+            continue
+        for i, segment in enumerate(segs):
+            segment.index = i
+        chapters.append(
+            Chapter(
+                index=out_index,
+                title=title,
+                segments=segs,
+                meta={
+                    BABELDOC_META: True,
+                    "pdf_toc_page": start_page,
+                    "pdf_toc_title": title,
+                },
+            )
+        )
+        out_index += 1
+
+    if not chapters:
+        return _chapters_from_paragraphs(paragraphs, book_title=book_title, toc_starts=[])
+    return chapters
+
+
+def _segment_from_para(index: int, para: dict) -> Segment | None:
+    source = str(para.get("source") or "").strip()
+    pid = str(para.get("id") or "").strip()
+    if not source or not pid:
+        return None
+    layout = para.get("layout_label")
+    kind = KIND_HEADING if layout == "title" else KIND_TEXT
+    return Segment(
+        index=index,
+        source=source,
+        kind=kind,
+        meta={
+            BABELDOC_ID_META: pid,
+            "layout_label": layout,
+            "debug_id": para.get("debug_id"),
+            "page": para.get("page"),
+            "para_index": para.get("index"),
+        },
+    )
 
 
 def read_pdf_babeldoc(
@@ -26,7 +176,7 @@ def read_pdf_babeldoc(
     cache_dir: str | None = None,
     timeout: float = 600.0,
 ) -> Document:
-    """Call bridge ``/extract`` and map paragraphs to a single-chapter Document."""
+    """Call bridge ``/extract`` and map paragraphs into TOC-based chapters."""
     client = BabeldocBridgeClient(bridge_url, timeout=timeout)
     payload = client.extract(path, pages=pages)
     session_id = payload.get("session_id")
@@ -44,45 +194,33 @@ def read_pdf_babeldoc(
             json.dump(payload, handle, ensure_ascii=False, indent=2)
 
     title = Path(path).stem
-    segments: list[Segment] = []
-    for index, para in enumerate(paragraphs):
-        if not isinstance(para, dict):
-            continue
-        source = str(para.get("source") or "").strip()
-        pid = str(para.get("id") or "").strip()
-        if not source or not pid:
-            continue
-        layout = para.get("layout_label")
-        kind = KIND_HEADING if layout == "title" else KIND_TEXT
-        segments.append(
-            Segment(
-                index=index,
-                source=source,
-                kind=kind,
-                meta={
-                    BABELDOC_ID_META: pid,
-                    "layout_label": layout,
-                    "debug_id": para.get("debug_id"),
-                    "page": para.get("page"),
-                    "para_index": para.get("index"),
-                },
-            )
-        )
+    try:
+        toc_starts = toc_chapter_starts(path)
+    except BabeldocBridgeError:
+        toc_starts = []
+    except Exception:
+        toc_starts = []
 
-    chapter = Chapter(index=0, title=title, segments=segments, meta={BABELDOC_META: True})
+    chapters = _chapters_from_paragraphs(
+        [p for p in paragraphs if isinstance(p, dict)],
+        book_title=title,
+        toc_starts=toc_starts,
+    )
+
     return Document(
         title=title,
         source_lang=source_lang,
         target_lang=target_lang,
         fmt="pdf",
         source_path=str(Path(path).resolve()),
-        chapters=[chapter],
+        chapters=chapters,
         meta={
             BABELDOC_META: True,
             "babeldoc_session_id": session_id,
             "babeldoc_bridge_url": bridge_url.rstrip("/"),
             "babeldoc_pages": pages,
             "pdf_export": "babeldoc",
+            "pdf_toc_chapters": len(toc_starts),
         },
     )
 
@@ -94,11 +232,6 @@ def translations_from_store(store) -> tuple[str, str, dict[str, str]]:
     session_id = meta.get("babeldoc_session_id")
     bridge_url = meta.get("babeldoc_bridge_url")
     if not session_id or not bridge_url:
-        # Fallback: scan chapter/document meta persisted on chapters.
-        for info in manifest.get("chapters") or []:
-            chapter = store.load_chapter(info["index"])
-            # no session on chapter; keep looking in segment-less case
-            _ = chapter
         raise BabeldocBridgeError(
             "状态中缺少 babeldoc_session_id / babeldoc_bridge_url；"
             "请用 pdf_backend=babeldoc 重新解析，并保持 bridge 进程不退出。"

--- a/trans_novel/ingest/pdf_babeldoc.py
+++ b/trans_novel/ingest/pdf_babeldoc.py
@@ -1,0 +1,122 @@
+"""PDF ingest via external BabelDOC bridge (HTTP only).
+
+Builds a Wenyi Document whose segments carry ``meta.babeldoc_id`` for fillback.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from ..pdf_bridge import BabeldocBridgeClient, BabeldocBridgeError
+from .models import KIND_HEADING, KIND_TEXT, Chapter, Document, Segment
+
+BABELDOC_META = "babeldoc"
+BABELDOC_ID_META = "babeldoc_id"
+
+
+def read_pdf_babeldoc(
+    path: str,
+    source_lang: str,
+    target_lang: str,
+    *,
+    bridge_url: str,
+    pages: str | None = None,
+    cache_dir: str | None = None,
+    timeout: float = 600.0,
+) -> Document:
+    """Call bridge ``/extract`` and map paragraphs to a single-chapter Document."""
+    client = BabeldocBridgeClient(bridge_url, timeout=timeout)
+    payload = client.extract(path, pages=pages)
+    session_id = payload.get("session_id")
+    paragraphs_doc = payload.get("paragraphs") or {}
+    paragraphs = paragraphs_doc.get("paragraphs") or []
+    if not isinstance(session_id, str) or not session_id:
+        raise BabeldocBridgeError("bridge extract 未返回 session_id")
+    if not isinstance(paragraphs, list) or not paragraphs:
+        raise BabeldocBridgeError("bridge extract 未返回段落")
+
+    if cache_dir:
+        os.makedirs(cache_dir, exist_ok=True)
+        cache_path = os.path.join(cache_dir, "babeldoc_extract.json")
+        with open(cache_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+    title = Path(path).stem
+    segments: list[Segment] = []
+    for index, para in enumerate(paragraphs):
+        if not isinstance(para, dict):
+            continue
+        source = str(para.get("source") or "").strip()
+        pid = str(para.get("id") or "").strip()
+        if not source or not pid:
+            continue
+        layout = para.get("layout_label")
+        kind = KIND_HEADING if layout == "title" else KIND_TEXT
+        segments.append(
+            Segment(
+                index=index,
+                source=source,
+                kind=kind,
+                meta={
+                    BABELDOC_ID_META: pid,
+                    "layout_label": layout,
+                    "debug_id": para.get("debug_id"),
+                    "page": para.get("page"),
+                    "para_index": para.get("index"),
+                },
+            )
+        )
+
+    chapter = Chapter(index=0, title=title, segments=segments, meta={BABELDOC_META: True})
+    return Document(
+        title=title,
+        source_lang=source_lang,
+        target_lang=target_lang,
+        fmt="pdf",
+        source_path=str(Path(path).resolve()),
+        chapters=[chapter],
+        meta={
+            BABELDOC_META: True,
+            "babeldoc_session_id": session_id,
+            "babeldoc_bridge_url": bridge_url.rstrip("/"),
+            "babeldoc_pages": pages,
+            "pdf_export": "babeldoc",
+        },
+    )
+
+
+def translations_from_store(store) -> tuple[str, str, dict[str, str]]:
+    """Collect ``{babeldoc_id: target}`` from a RunStore; return session/url/map."""
+    manifest = store.load_manifest()
+    meta = manifest.get("meta") if isinstance(manifest.get("meta"), dict) else {}
+    session_id = meta.get("babeldoc_session_id")
+    bridge_url = meta.get("babeldoc_bridge_url")
+    if not session_id or not bridge_url:
+        # Fallback: scan chapter/document meta persisted on chapters.
+        for info in manifest.get("chapters") or []:
+            chapter = store.load_chapter(info["index"])
+            # no session on chapter; keep looking in segment-less case
+            _ = chapter
+        raise BabeldocBridgeError(
+            "状态中缺少 babeldoc_session_id / babeldoc_bridge_url；"
+            "请用 pdf_backend=babeldoc 重新解析，并保持 bridge 进程不退出。"
+        )
+
+    mapping: dict[str, str] = {}
+    for info in manifest.get("chapters") or []:
+        chapter = store.load_chapter(info["index"])
+        for segment in chapter.segments:
+            pid = None
+            if isinstance(segment.meta, dict):
+                pid = segment.meta.get(BABELDOC_ID_META)
+            if not pid:
+                continue
+            text = segment.target if segment.target is not None else segment.source
+            if text is None or not str(text).strip():
+                continue
+            mapping[str(pid)] = str(text)
+    if not mapping:
+        raise BabeldocBridgeError("没有带 babeldoc_id 的译文可回填")
+    return str(session_id), str(bridge_url), mapping

--- a/trans_novel/ingest/segmenter.py
+++ b/trans_novel/ingest/segmenter.py
@@ -115,6 +115,10 @@ def load_document(
     *,
     cache_dir: str | None = None,
     source_hash: str | None = None,
+    pdf_backend: str = "mineru",
+    babeldoc_bridge_url: str = "http://127.0.0.1:8765",
+    babeldoc_pages: str | None = None,
+    babeldoc_timeout: float = 600.0,
 ) -> Document:
     """按文件扩展名读取文档，并按需拆分超过上限的翻译段。"""
     ext = os.path.splitext(path)[1].lower()
@@ -129,13 +133,26 @@ def load_document(
     elif ext == ".pdf":
         if cache_dir is None:
             raise ValueError("PDF 读取需要指定运行状态缓存目录")
-        doc = read_pdf(
-            path,
-            source_lang,
-            target_lang,
-            cache_dir=cache_dir,
-            source_hash=source_hash,
-        )
+        if pdf_backend == "babeldoc":
+            from .pdf_babeldoc import read_pdf_babeldoc
+
+            doc = read_pdf_babeldoc(
+                path,
+                source_lang,
+                target_lang,
+                bridge_url=babeldoc_bridge_url,
+                pages=babeldoc_pages,
+                cache_dir=cache_dir,
+                timeout=babeldoc_timeout,
+            )
+        else:
+            doc = read_pdf(
+                path,
+                source_lang,
+                target_lang,
+                cache_dir=cache_dir,
+                source_hash=source_hash,
+            )
     elif ext == ".docx":
         from .docx_reader import read_docx
 
@@ -145,7 +162,8 @@ def load_document(
             f"不支持的格式：{ext}（支持 .epub / .txt / .md / .fb2 / .html / .xhtml / .pdf / .docx）"
         )
 
-    if split_segments and split_segments > 0:
+    # BabelDOC 段 id 与排版绑定，禁止再按字符拆碎。
+    if split_segments and split_segments > 0 and not (doc.meta or {}).get("babeldoc"):
         split_long_segments(doc.chapters, split_segments)
     return doc
 

--- a/trans_novel/pdf_bridge/__init__.py
+++ b/trans_novel/pdf_bridge/__init__.py
@@ -1,0 +1,8 @@
+"""HTTP client for the external Wenyi BabelDOC bridge (AGPL service).
+
+This package must never import babeldoc / pdf2zh. It only talks HTTP.
+"""
+
+from .client import BabeldocBridgeClient, BabeldocBridgeError
+
+__all__ = ["BabeldocBridgeClient", "BabeldocBridgeError"]

--- a/trans_novel/pdf_bridge/client.py
+++ b/trans_novel/pdf_bridge/client.py
@@ -1,0 +1,92 @@
+"""Minimal HTTP client for wenyi-babeldoc-bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+class BabeldocBridgeError(RuntimeError):
+    """Raised when the external BabelDOC bridge cannot complete a request."""
+
+
+class BabeldocBridgeClient:
+    """Talk to an AGPL bridge process. Wenyi stays MIT-only."""
+
+    def __init__(self, base_url: str, *, timeout: float = 600.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def health(self) -> dict[str, Any]:
+        try:
+            response = httpx.get(f"{self.base_url}/health", timeout=min(30.0, self.timeout))
+            response.raise_for_status()
+            return response.json()
+        except Exception as error:
+            raise BabeldocBridgeError(
+                f"无法连接 BabelDOC bridge（{self.base_url}）：{error}\n"
+                "请先在独立仓库启动：wenyi-babeldoc-bridge"
+            ) from error
+
+    def extract(self, pdf_path: str | Path, *, pages: str | None = None) -> dict[str, Any]:
+        pdf_path = Path(pdf_path)
+        if not pdf_path.is_file():
+            raise BabeldocBridgeError(f"PDF 不存在：{pdf_path}")
+        self.health()
+        data: dict[str, str] = {}
+        if pages:
+            data["pages"] = pages
+        try:
+            with pdf_path.open("rb") as handle:
+                files = {"file": (pdf_path.name, handle, "application/pdf")}
+                response = httpx.post(
+                    f"{self.base_url}/extract",
+                    data=data,
+                    files=files,
+                    timeout=self.timeout,
+                )
+            if response.status_code >= 400:
+                raise BabeldocBridgeError(
+                    f"extract 失败 HTTP {response.status_code}: {response.text[:500]}"
+                )
+            return response.json()
+        except BabeldocBridgeError:
+            raise
+        except Exception as error:
+            raise BabeldocBridgeError(f"extract 请求失败：{error}") from error
+
+    def fillback(
+        self,
+        session_id: str,
+        translations: dict[str, str],
+        *,
+        out_path: str | Path,
+    ) -> str:
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        self.health()
+        try:
+            response = httpx.post(
+                f"{self.base_url}/fillback",
+                json={"session_id": session_id, "translations": translations},
+                timeout=self.timeout,
+            )
+            if response.status_code >= 400:
+                raise BabeldocBridgeError(
+                    f"fillback 失败 HTTP {response.status_code}: {response.text[:500]}"
+                )
+            out_path.write_bytes(response.content)
+            return str(out_path)
+        except BabeldocBridgeError:
+            raise
+        except Exception as error:
+            raise BabeldocBridgeError(f"fillback 请求失败：{error}") from error
+
+    def delete_session(self, session_id: str) -> None:
+        try:
+            httpx.delete(f"{self.base_url}/session/{session_id}", timeout=min(30.0, self.timeout))
+        except Exception:
+            # Best-effort cleanup.
+            return

--- a/trans_novel/pdf_bridge/client.py
+++ b/trans_novel/pdf_bridge/client.py
@@ -7,8 +7,10 @@ from typing import Any
 
 import httpx
 
+from ..ingest.errors import IngestError
 
-class BabeldocBridgeError(RuntimeError):
+
+class BabeldocBridgeError(IngestError):
     """Raised when the external BabelDOC bridge cannot complete a request."""
 
 

--- a/trans_novel/pipeline/preparation.py
+++ b/trans_novel/pipeline/preparation.py
@@ -110,6 +110,7 @@ class PreparationService:
                 source_hash = self._runtime.initial_source_sha256(input_path)
                 # 转换失败也要留下同源初始化标记，确保重试保留失败运行账本。
                 store.begin_initialization(source_hash)
+                pipeline = self._runtime.config.pipeline
                 doc = load_document(
                     input_path,
                     self._runtime.config.source_lang,
@@ -117,6 +118,10 @@ class PreparationService:
                     split_segments=self._runtime.config.segment.max_chars_per_segment,
                     cache_dir=store.source_dir,
                     source_hash=source_hash,
+                    pdf_backend=pipeline.pdf_backend,
+                    babeldoc_bridge_url=pipeline.babeldoc_bridge_url,
+                    babeldoc_pages=pipeline.babeldoc_pages,
+                    babeldoc_timeout=pipeline.babeldoc_timeout,
                 )
                 if self._runtime.source_sha256(input_path) != source_hash:
                     raise ValueError("PDF 在解析期间发生变化；请确认文件稳定后重试。")


### PR DESCRIPTION
Integrate layout-preserving PDF via a separate AGPL bridge process: Wenyi only calls extract/fillback over HTTP, keeps MIT boundaries, and documents mineru vs babeldoc backends.