### PR TITLE
fix(glossary): 拦截矛盾性别事实与假名子串误匹配

### DIFF
--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -72,6 +72,31 @@ class TestGlossary(unittest.TestCase):
         self.assertTrue(source_matches_text("гад", "Этот гад снова пришёл."))
         self.assertFalse(source_matches_text("гад", "Этот гадкий человек снова пришёл."))
 
+    def test_kana_source_match_respects_kana_run_boundaries(self):
+        # 短假名词嵌在同文字假名串中间时是更长单词的一部分，不应命中。
+        self.assertFalse(source_matches_text("あんな", "あんなに急に変わる。"))
+        self.assertFalse(source_matches_text("メイ", "メインストリートを歩く。"))
+        self.assertFalse(source_matches_text("しょう", "しょうがないから行く。"))
+        # 独立出现的假名词正常命中；中点「・」是分隔符而非片假名延续。
+        self.assertTrue(source_matches_text("メイ", "「メイ、おはよう」"))
+        self.assertTrue(source_matches_text("あんな", "「あんな！」と叫んだ。"))
+        self.assertTrue(source_matches_text("メイ", "メイ・スミスは黙っていた。"))
+        # 片假名词后跟平假名助词属正常接续。
+        self.assertTrue(source_matches_text("メイ", "メイは立ち止まった。"))
+
+    def test_kana_term_not_injected_from_longer_kana_run(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="あんな", target="Anna", type=TYPE_PERSON)
+        )
+        self.store.upsert_term(GlossaryTerm(source="メイ", target="小梅", type=TYPE_PERSON))
+
+        self.assertEqual(self.store.terms_in_text("あんなに慌てなくてもいい。"), [])
+        self.assertEqual(self.store.terms_in_text("メイン料理を注文した。"), [])
+        self.assertEqual(
+            {term.source for term in self.store.terms_in_text("「あんな、メイが呼んでる」")},
+            {"あんな", "メイ"},
+        )
+
     def test_appellation_does_not_match_bare_name_alias(self):
         self.store.upsert_term(
             GlossaryTerm(
@@ -157,6 +182,48 @@ class TestGlossary(unittest.TestCase):
         self.assertEqual(term.target, "掘北")
         self.assertEqual(term.status, "ok")
         self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_same_target_conflicting_gender_is_flagged_not_overwritten(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", type=TYPE_PERSON, gender="女"),
+            chapter=0,
+        )
+        # 同译法但性别判断相左：保留现有事实并登记冲突，而非静默覆盖。
+        r = self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", type=TYPE_PERSON, gender="男"),
+            chapter=2,
+        )
+        self.assertEqual(r, "conflict")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.status, "conflict")
+        conflicts = self.store.open_conflicts()
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("性别冲突", conflicts[0]["note"])
+
+        self.assertTrue(self.store.resolve_term("白井", "白井"))
+        self.store.mark_conflicts_resolved("白井")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.status, "ok")
+        self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_same_target_same_or_empty_gender_stays_unchanged(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="女"),
+            chapter=0,
+        )
+        r = self.store.upsert_term(GlossaryTerm(source="白井", target="白井", gender="女"))
+        self.assertEqual(r, "unchanged")
+        self.assertEqual(self.store.get_term("白井").status, "ok")
+        # 空 gender 不视为冲突，其它字段照常补全。
+        r = self.store.upsert_term(GlossaryTerm(source="白井", target="白井", note="班长"))
+        self.assertEqual(r, "unchanged")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.note, "班长")
 
     def test_concurrent_upserts_make_one_atomic_conflict_decision(self):
         path = os.path.join(self.tmp.name, "concurrent.db")

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -726,6 +726,7 @@ def glossary_conflicts(
                 f"  {conflict['source']}: 现有「{conflict['existing_target']}」 vs "
                 f"提议「{conflict['proposed_target']}」"
                 f"（第 {conflict['chapter']} 章）"
+                + (f" — {conflict['note']}" if conflict.get("note") else "")
             )
     finally:
         glossary.close()

--- a/trans_novel/glossary/store.py
+++ b/trans_novel/glossary/store.py
@@ -108,22 +108,41 @@ def _match_text(text: str) -> str:
 
 _WORD_BOUNDARY_SCRIPTS = ("LATIN", "GREEK", "CYRILLIC")
 
+# 假名连续串字符类。片假名排除中点「・」(U+30FB)：「メイ・スミス」这类写法里
+# 点是分隔符，不应把右侧的姓并入匹配键。
+_HIRAGANA_CLASS = "\\u3041-\\u309f"
+_KATAKANA_CLASS = "\\u30a1-\\u30fa\\u30fc-\\u30ff"
+
 
 def _source_pattern(key: str) -> re.Pattern[str] | None:
-    """为空格分词文字构造边界正则；连续书写文字返回 None 使用子串匹配。"""
+    """为空格分词文字构造边界正则；其余文字返回 None 使用子串匹配。
+
+    假名字符串虽无空格分词，但短假名词条嵌在同文字假名串中间时几乎总是
+    更长单词的一部分（``メイ`` in ``メイン``、``あんな`` in ``あんなに``、
+    ``しょう`` in ``しょうがない``），按同文字假名连续串加边界过滤。含汉字
+    的键仍走子串匹配（无法无分词器地区分 ``母`` 与 ``お母さん``）。
+    """
     if key.isascii():
         return re.compile(rf"(?<![a-z0-9_]){re.escape(key)}(?![a-z0-9_])")
 
     letters = [char for char in key if char.isalpha()]
-    if not letters or not all(
+    if letters and all(
         any(script in unicodedata.name(char, "") for script in _WORD_BOUNDARY_SCRIPTS)
         for char in letters
     ):
-        return None
+        left_boundary = r"(?<!\w)" if key[0].isalnum() else ""
+        right_boundary = r"(?!\w)" if key[-1].isalnum() else ""
+        return re.compile(f"{left_boundary}{re.escape(key)}{right_boundary}")
 
-    left_boundary = r"(?<!\w)" if key[0].isalnum() else ""
-    right_boundary = r"(?!\w)" if key[-1].isalnum() else ""
-    return re.compile(f"{left_boundary}{re.escape(key)}{right_boundary}")
+    if re.fullmatch(rf"[{_HIRAGANA_CLASS}]+", key):
+        return re.compile(
+            rf"(?<![{_HIRAGANA_CLASS}]){re.escape(key)}(?![{_HIRAGANA_CLASS}])"
+        )
+    if re.fullmatch(rf"[{_KATAKANA_CLASS}]+", key):
+        return re.compile(
+            rf"(?<![{_KATAKANA_CLASS}]){re.escape(key)}(?![{_KATAKANA_CLASS}])"
+        )
+    return None
 
 
 def source_matches_text(source: str, text: str) -> bool:
@@ -286,7 +305,8 @@ class GlossaryStore:
         """插入或更新术语，返回 'inserted'|'unchanged'|'conflict'。
 
         同 source 已存在且 target 不同时保留当前译法，把新译法作为候选记录，
-        避免自动提取结果在无人确认时改写术语表。
+        避免自动提取结果在无人确认时改写术语表。target 相同但性别事实相左时
+        同样按冲突处理（保留现有性别并登记），而不是静默覆盖。
         """
         try:
             # 锁在读取 existing 之前取得，保证两个连接不会同时基于旧快照决策。
@@ -314,6 +334,28 @@ class GlossaryStore:
                 )
                 result = "inserted"
             elif existing.target == term.target:
+                if existing.gender and term.gender and existing.gender != term.gender:
+                    # 同译法但性别判断相左：与 target 冲突同等处理，保留现有事实，
+                    # 登记冲突等待人工裁决，绝不静默覆盖（矛盾的性别事实一旦入库，
+                    # 后续章节的审校会把它当作权威依据，产生互相排斥的判定）。
+                    self._log_conflict(
+                        term.source,
+                        existing.target,
+                        term.target,
+                        chapter,
+                        note=(
+                            f"性别冲突：现有「{existing.gender}」"
+                            f" vs 提议「{term.gender}」"
+                        ),
+                    )
+                    self.conn.execute(
+                        "UPDATE glossary SET status='conflict', updated_at=? "
+                        "WHERE source=?",
+                        (now, term.source),
+                    )
+                    result = "conflict"
+                    self.conn.commit()
+                    return result
                 # 合并别名 / 补全字段，不算冲突
                 merged_aliases = sorted(set(existing.aliases) | set(term.aliases))
                 self.conn.execute(
@@ -344,13 +386,14 @@ class GlossaryStore:
             self.conn.rollback()
             raise
 
-    def _log_conflict(self, source, existing_target, proposed_target, chapter):
-        """在当前事务中记录一次候选译法冲突。"""
+    def _log_conflict(self, source, existing_target, proposed_target, chapter,
+                      note: str | None = None):
+        """在当前事务中记录一次候选译法/事实冲突。"""
         self.conn.execute(
             """INSERT INTO term_conflicts
-               (source,existing_target,proposed_target,chapter,created_at)
-               VALUES (?,?,?,?,?)""",
-            (source, existing_target, proposed_target, chapter, time.time()),
+               (source,existing_target,proposed_target,chapter,note,created_at)
+               VALUES (?,?,?,?,?,?)""",
+            (source, existing_target, proposed_target, chapter, note, time.time()),
         )
 
     def resolve_term(self, source: str, target: str) -> bool:


### PR DESCRIPTION
修复 #87 中点名的两个可独立处理的落点（其余架构层问题留给后续国际化重构）。

## 修复 1：假名子串误匹配（store.py `_source_pattern`）

此前只对拉丁/希腊/西里尔字母做词边界，CJK 一律裸子串，导致 #87 实测的误注入仍然存在：

- ``あんな`` 命中 ``あんなに``
- ``メイ`` 命中 ``メイン``
- ``しょう`` 命中 ``しょうがない``

现在纯假名键要求同文字假名连续串边界（平假名键两侧不能是平假名，片假名键两侧不能是片假名/长音符；中点「・」视为分隔符）。含汉字的键保持原行为——``母`` 与 ``お母さん`` 这类边界无分词器无法可靠区分，留待后续。

对匹配语义的影响集中在误报侧：``メイン``/``あんなに``/``しょうがない`` 这类常见词不再注入术语表；``メイは``、``「メイ…」``、``メイ・スミス`` 等正常写法仍命中。日语助词直连平假名短词（``ゆきは``）理论上会漏匹配，本 PR 选择宁缺勿滥——错误事实注入 prompt 的危害大于少注入一次。

## 修复 2：同译法更新静默覆盖 gender（store.py `upsert_term`）

此前同 source 同 target 时走 ``gender=COALESCE(NULLIF(?,''),gender)``，新词条只要带一个非空 gender 就会直接覆盖已有值——``status=ok`` 下事实被悄悄改写，审校随后把矛盾事实当作权威依据。

现在已有非空 gender 与传入非空 gender 不一致时按 target 冲突同等处理：保留现有性别、词条置 ``conflict``、``term_conflicts`` 登记一行（note 注明「性别冲突：现有 X vs 提议 Y」），``glossary conflicts`` CLI 会展示该 note。空 gender / 相同 gender 行为不变。

## 测试

- ``test_kana_source_match_respects_kana_run_boundaries`` / ``test_kana_term_not_injected_from_longer_kana_run``
- ``test_same_target_conflicting_gender_is_flagged_not_overwritten`` / ``test_same_target_same_or_empty_gender_stays_unchanged``
- 全量测试通过：536 passed, 1 skipped

Ref: #87