### PR TITLE
fix(glossary): 登记相左性别事实并约束假名子串匹配

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,6 +592,19 @@ class TestCliConfig(unittest.TestCase):
                 self.assertIn("错误：输入文件内容与现有状态不一致", result.output)
                 self.assertNotIn("Traceback", result.output)
 
+    def test_glossary_resolve_rejects_unknown_or_invalid_gender(self):
+        # 未知标记/乱值不能显式裁定性别：store 会归一为空并保留原值，却
+        # 照常恢复 ok 并关闭未裁决的冲突。校验在加载配置前完成。
+        for bad in ("unknown", "未知", "猫"):
+            with self.subTest(gender=bad):
+                result = CliRunner().invoke(
+                    app,
+                    ["glossary", "resolve", "missing.txt", "白井", "白井",
+                     "--gender", bad],
+                )
+                self.assertEqual(result.exit_code, 1, result.output)
+                self.assertIn("无效性别", result.output)
+
 
 class TestWindowsConsoleEncoding(unittest.TestCase):
     class _Stream:

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import threading
+import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 
@@ -71,6 +72,31 @@ class TestGlossary(unittest.TestCase):
     def test_cyrillic_source_match_respects_word_boundaries(self):
         self.assertTrue(source_matches_text("гад", "Этот гад снова пришёл."))
         self.assertFalse(source_matches_text("гад", "Этот гадкий человек снова пришёл."))
+
+    def test_kana_source_match_respects_kana_run_boundaries(self):
+        # 短假名词嵌在同文字假名串中间时是更长单词的一部分，不应命中。
+        self.assertFalse(source_matches_text("あんな", "あんなに急に変わる。"))
+        self.assertFalse(source_matches_text("メイ", "メインストリートを歩く。"))
+        self.assertFalse(source_matches_text("しょう", "しょうがないから行く。"))
+        # 独立出现的假名词正常命中；中点「・」是分隔符而非片假名延续。
+        self.assertTrue(source_matches_text("メイ", "「メイ、おはよう」"))
+        self.assertTrue(source_matches_text("あんな", "「あんな！」と叫んだ。"))
+        self.assertTrue(source_matches_text("メイ", "メイ・スミスは黙っていた。"))
+        # 片假名词后跟平假名助词属正常接续。
+        self.assertTrue(source_matches_text("メイ", "メイは立ち止まった。"))
+
+    def test_kana_term_not_injected_from_longer_kana_run(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="あんな", target="Anna", type=TYPE_PERSON)
+        )
+        self.store.upsert_term(GlossaryTerm(source="メイ", target="小梅", type=TYPE_PERSON))
+
+        self.assertEqual(self.store.terms_in_text("あんなに慌てなくてもいい。"), [])
+        self.assertEqual(self.store.terms_in_text("メイン料理を注文した。"), [])
+        self.assertEqual(
+            {term.source for term in self.store.terms_in_text("「あんな、メイが呼んでる」")},
+            {"あんな", "メイ"},
+        )
 
     def test_appellation_does_not_match_bare_name_alias(self):
         self.store.upsert_term(
@@ -157,6 +183,137 @@ class TestGlossary(unittest.TestCase):
         self.assertEqual(term.target, "掘北")
         self.assertEqual(term.status, "ok")
         self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_same_target_conflicting_gender_is_flagged_not_overwritten(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", type=TYPE_PERSON, gender="女"),
+            chapter=0,
+        )
+        # 同译法但性别判断相左：保留现有事实并登记冲突，而非静默覆盖。
+        r = self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", type=TYPE_PERSON, gender="男"),
+            chapter=2,
+        )
+        self.assertEqual(r, "conflict")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.status, "conflict")
+        conflicts = self.store.open_conflicts()
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("性别冲突", conflicts[0]["note"])
+
+        self.assertTrue(self.store.resolve_term("白井", "白井"))
+        self.store.mark_conflicts_resolved("白井")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.status, "ok")
+        self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_same_target_same_or_empty_gender_stays_unchanged(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="女"),
+            chapter=0,
+        )
+        r = self.store.upsert_term(GlossaryTerm(source="白井", target="白井", gender="女"))
+        self.assertEqual(r, "unchanged")
+        self.assertEqual(self.store.get_term("白井").status, "ok")
+        # 空 gender 不视为冲突，其它字段照常补全。
+        r = self.store.upsert_term(GlossaryTerm(source="白井", target="白井", note="班长"))
+        self.assertEqual(r, "unchanged")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.note, "班长")
+
+    def test_unknown_gender_markers_are_normalized_at_store_entry(self):
+        # Analyzer 会把 prompt 里的「未知」原样种入；未知不等于矛盾事实。
+        self.store.upsert_term(GlossaryTerm(source="白井", target="白井", gender="未知"))
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "")
+
+        self.store.upsert_term(
+            GlossaryTerm(source="真昼", target="真昼", gender="女"),
+            chapter=0,
+        )
+        r = self.store.upsert_term(
+            GlossaryTerm(source="真昼", target="真昼", gender="不明"),
+            chapter=1,
+        )
+        self.assertEqual(r, "unchanged")
+        term = self.store.get_term("真昼")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.status, "ok")
+        self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_legacy_unknown_gender_value_does_not_create_false_conflict(self):
+        # v0.5.1 时代 Analyzer 把「未知」原样写入库（绕过入口归一模拟旧库）。
+        self.store.conn.execute(
+            """INSERT INTO glossary
+               (source,target,reading,type,gender,aliases,first_chapter,note,
+                status,updated_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?)""",
+            ("白井", "白井", "", TYPE_PERSON, "未知", "[]", 0, "", "ok", time.time()),
+        )
+        self.store.conn.commit()
+
+        r = self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="女"),
+            chapter=1,
+        )
+        self.assertEqual(r, "unchanged")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.status, "ok")
+        self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_resolve_term_treats_unknown_gender_marker_as_keep(self):
+        self.store.upsert_term(GlossaryTerm(source="白井", target="白井", gender="女"))
+        self.assertTrue(self.store.resolve_term("白井", "白井", gender="未知"))
+        self.assertEqual(self.store.get_term("白井").gender, "女")
+
+    def test_resolve_can_adjudicate_gender(self):
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="女"),
+            chapter=0,
+        )
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="男"),
+            chapter=2,
+        )
+        # 不传 gender：确认现有性别，但目标译法与状态照常裁定。
+        self.assertTrue(self.store.resolve_term("白井", "白井"))
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "女")
+        self.assertEqual(term.status, "ok")
+
+        # 传 gender：真正更新性别，冲突可随之关闭。
+        self.store.upsert_term(
+            GlossaryTerm(source="白井", target="白井", gender="男"),
+            chapter=3,
+        )
+        self.assertTrue(self.store.resolve_term("白井", "白井", gender="男"))
+        self.store.mark_conflicts_resolved("白井")
+        term = self.store.get_term("白井")
+        assert term is not None
+        self.assertEqual(term.gender, "男")
+        self.assertEqual(term.status, "ok")
+        self.assertEqual(self.store.open_conflicts(), [])
+
+    def test_hiragana_particle_continuation_is_a_known_precision_tradeoff(self):
+        # 平假名键遇同文字假名延续一律不命中：无分词器时无法区分
+        # 「ゆきは…」（名字+助词）与「あんなに」（更长单词）。本实现选择
+        # precision over recall——宁可少注入一次，也不让错误事实进入
+        # prompt。该规则作用于所有纯平假名词条，不只人物短名；
+        # 改动此行为需要先引入分词。
+        self.store.upsert_term(
+            GlossaryTerm(source="ゆき", target="小雪", type=TYPE_PERSON)
+        )
+        self.assertEqual(self.store.terms_in_text("ゆきは歩いた。"), [])
 
     def test_concurrent_upserts_make_one_atomic_conflict_decision(self):
         path = os.path.join(self.tmp.name, "concurrent.db")

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -726,6 +726,7 @@ def glossary_conflicts(
                 f"  {conflict['source']}: 现有「{conflict['existing_target']}」 vs "
                 f"提议「{conflict['proposed_target']}」"
                 f"（第 {conflict['chapter']} 章）"
+                + (f" — {conflict['note']}" if conflict.get("note") else "")
             )
     finally:
         glossary.close()
@@ -736,11 +737,24 @@ def glossary_resolve(
     input: str = typer.Argument(..., help="已建立翻译状态的源文件"),
     source: str = typer.Argument(..., help="需要裁定的原文术语"),
     target: str = typer.Argument(..., help="今后统一采用的目标语言译名"),
+    gender: str | None = typer.Option(
+        None,
+        "--gender",
+        "-g",
+        help="同时裁定性别（如 男/女）；不传表示确认现有性别",
+    ),
 ) -> None:
     """把一个已有术语裁定为指定译名，并关闭对应冲突。"""
     from .glossary import resolver
     from .glossary.store import GlossaryStore
 
+    if gender is not None and gender.strip() not in ("男", "女"):
+        # 显式裁定只接受确切值；「未知」等标记或乱值会把未裁决的性别
+        # 冲突连同一并关闭，必须拒绝。
+        console.print(
+            f"[red]无效性别：{gender}（可为 男/女；不裁定请省略 --gender）[/]"
+        )
+        raise typer.Exit(1)
     config = _load_config()
     store = _runstore_for_cli(config, input)
     if not store.exists():
@@ -748,10 +762,12 @@ def glossary_resolve(
         raise typer.Exit(1)
     glossary = GlossaryStore(store.glossary_path)
     try:
-        if not resolver.resolve(glossary, source, target):
+        if not resolver.resolve(glossary, source, target, gender=gender):
             console.print(f"[red]术语不存在：{source}[/]")
             raise typer.Exit(1)
-        console.print(f"已裁定 {source} → {target}")
+        console.print(
+            f"已裁定 {source} → {target}" + (f"（性别：{gender}）" if gender else "")
+        )
     finally:
         glossary.close()
 

--- a/trans_novel/glossary/resolver.py
+++ b/trans_novel/glossary/resolver.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 from .store import GlossaryStore
 
 
-def resolve(store: GlossaryStore, source: str, target: str) -> bool:
-    """裁定 source 的最终译法并清除冲突标记，返回术语是否存在。"""
-    if not store.resolve_term(source, target):
+def resolve(store: GlossaryStore, source: str, target: str,
+            gender: str | None = None) -> bool:
+    """裁定 source 的最终译法并清除冲突标记，返回术语是否存在。
+
+    传入 gender 时一并裁定性别；不传表示确认现有性别。
+    """
+    if not store.resolve_term(source, target, gender=gender):
         return False
     store.mark_conflicts_resolved(source)
     return True

--- a/trans_novel/glossary/store.py
+++ b/trans_novel/glossary/store.py
@@ -16,7 +16,7 @@ import sqlite3
 import tempfile
 import time
 import unicodedata
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 # 术语类型
@@ -91,6 +91,16 @@ CREATE TABLE IF NOT EXISTS term_conflicts (
 )
 
 
+# 模型可能返回的性别未知标记；统一归一为空串。"未知" 不等于已知事实，与
+# 既有非空值不一致时不得视为矛盾（Analyzer 会把 prompt 里的「未知」原样种入）。
+_UNKNOWN_GENDERS = {"未知", "不明", "不详", "unknown", "none", "n/a", "?", "？"}
+
+
+def _normalize_gender(gender: str | None) -> str:
+    g = (gender or "").strip()
+    return "" if g.casefold() in _UNKNOWN_GENDERS else g
+
+
 # 与 epub_reader 写入 Segment.source 的振假名标记一致；匹配前剥离以免拆散子串。
 _RUBY_MARK_RE = re.compile(r"〘[^〙]*〙")
 
@@ -108,22 +118,41 @@ def _match_text(text: str) -> str:
 
 _WORD_BOUNDARY_SCRIPTS = ("LATIN", "GREEK", "CYRILLIC")
 
+# 假名连续串字符类。片假名排除中点「・」(U+30FB)：「メイ・スミス」这类写法里
+# 点是分隔符，不应把右侧的姓并入匹配键。
+_HIRAGANA_CLASS = "\\u3041-\\u309f"
+_KATAKANA_CLASS = "\\u30a1-\\u30fa\\u30fc-\\u30ff"
+
 
 def _source_pattern(key: str) -> re.Pattern[str] | None:
-    """为空格分词文字构造边界正则；连续书写文字返回 None 使用子串匹配。"""
+    """为空格分词文字构造边界正则；其余文字返回 None 使用子串匹配。
+
+    假名字符串虽无空格分词，但短假名词条嵌在同文字假名串中间时几乎总是
+    更长单词的一部分（``メイ`` in ``メイン``、``あんな`` in ``あんなに``、
+    ``しょう`` in ``しょうがない``），按同文字假名连续串加边界过滤。含汉字
+    的键仍走子串匹配（无法无分词器地区分 ``母`` 与 ``お母さん``）。
+    """
     if key.isascii():
         return re.compile(rf"(?<![a-z0-9_]){re.escape(key)}(?![a-z0-9_])")
 
     letters = [char for char in key if char.isalpha()]
-    if not letters or not all(
+    if letters and all(
         any(script in unicodedata.name(char, "") for script in _WORD_BOUNDARY_SCRIPTS)
         for char in letters
     ):
-        return None
+        left_boundary = r"(?<!\w)" if key[0].isalnum() else ""
+        right_boundary = r"(?!\w)" if key[-1].isalnum() else ""
+        return re.compile(f"{left_boundary}{re.escape(key)}{right_boundary}")
 
-    left_boundary = r"(?<!\w)" if key[0].isalnum() else ""
-    right_boundary = r"(?!\w)" if key[-1].isalnum() else ""
-    return re.compile(f"{left_boundary}{re.escape(key)}{right_boundary}")
+    if re.fullmatch(rf"[{_HIRAGANA_CLASS}]+", key):
+        return re.compile(
+            rf"(?<![{_HIRAGANA_CLASS}]){re.escape(key)}(?![{_HIRAGANA_CLASS}])"
+        )
+    if re.fullmatch(rf"[{_KATAKANA_CLASS}]+", key):
+        return re.compile(
+            rf"(?<![{_KATAKANA_CLASS}]){re.escape(key)}(?![{_KATAKANA_CLASS}])"
+        )
+    return None
 
 
 def source_matches_text(source: str, text: str) -> bool:
@@ -286,9 +315,13 @@ class GlossaryStore:
         """插入或更新术语，返回 'inserted'|'unchanged'|'conflict'。
 
         同 source 已存在且 target 不同时保留当前译法，把新译法作为候选记录，
-        避免自动提取结果在无人确认时改写术语表。
+        避免自动提取结果在无人确认时改写术语表。target 相同但性别事实相左时
+        同样按冲突处理（保留现有性别并登记），而不是静默覆盖。
         """
         try:
+            # 未知性别标记先在入口归一为空，避免后续分支把「未知」当成
+            # 与既有非空值相左的事实。
+            term = replace(term, gender=_normalize_gender(term.gender))
             # 锁在读取 existing 之前取得，保证两个连接不会同时基于旧快照决策。
             self.conn.execute("BEGIN IMMEDIATE")
             existing = self.get_term(term.source)
@@ -314,6 +347,32 @@ class GlossaryStore:
                 )
                 result = "inserted"
             elif existing.target == term.target:
+                # 存量库可能残留未归一的未知值（旧版本 Analyzer 原样写入
+                # 「未知」）；比较前一并归一，未知与任何已知值都不算矛盾。
+                existing_gender = _normalize_gender(existing.gender)
+                if existing_gender and term.gender and existing_gender != term.gender:
+                    # 同译法但性别判断相左：与 target 冲突同等处理——保留现有
+                    # gender 并登记冲突等待人工裁决，而不是静默覆盖。注意冲突
+                    # 词条仍会照常注入翻译/审校 prompt；把矛盾事实从 prompt 中
+                    # 完整隔离属于术语架构改造，见 issue #87。
+                    self._log_conflict(
+                        term.source,
+                        existing.target,
+                        term.target,
+                        chapter,
+                        note=(
+                            f"性别冲突：现有「{existing_gender}」"
+                            f" vs 提议「{term.gender}」"
+                        ),
+                    )
+                    self.conn.execute(
+                        "UPDATE glossary SET status='conflict', updated_at=? "
+                        "WHERE source=?",
+                        (now, term.source),
+                    )
+                    result = "conflict"
+                    self.conn.commit()
+                    return result
                 # 合并别名 / 补全字段，不算冲突
                 merged_aliases = sorted(set(existing.aliases) | set(term.aliases))
                 self.conn.execute(
@@ -344,21 +403,36 @@ class GlossaryStore:
             self.conn.rollback()
             raise
 
-    def _log_conflict(self, source, existing_target, proposed_target, chapter):
-        """在当前事务中记录一次候选译法冲突。"""
+    def _log_conflict(self, source, existing_target, proposed_target, chapter,
+                      note: str | None = None):
+        """在当前事务中记录一次候选译法/事实冲突。"""
         self.conn.execute(
             """INSERT INTO term_conflicts
-               (source,existing_target,proposed_target,chapter,created_at)
-               VALUES (?,?,?,?,?)""",
-            (source, existing_target, proposed_target, chapter, time.time()),
+               (source,existing_target,proposed_target,chapter,note,created_at)
+               VALUES (?,?,?,?,?,?)""",
+            (source, existing_target, proposed_target, chapter, note, time.time()),
         )
 
-    def resolve_term(self, source: str, target: str) -> bool:
-        """人工裁定最终译法并恢复正常状态，返回术语是否存在。"""
-        cur = self.conn.execute(
-            "UPDATE glossary SET target=?, status='ok', updated_at=? WHERE source=?",
-            (target, time.time(), source),
-        )
+    def resolve_term(self, source: str, target: str,
+                     gender: str | None = None) -> bool:
+        """人工裁定最终译法并恢复正常状态，返回术语是否存在。
+
+        传入非空 gender 时一并裁定性别（「未知」等未知标记视为不裁定，
+        保留现有值）；不传表示确认现有性别。
+        """
+        new_gender = _normalize_gender(gender)
+        if new_gender:
+            cur = self.conn.execute(
+                "UPDATE glossary SET target=?, gender=?, status='ok', updated_at=? "
+                "WHERE source=?",
+                (target, new_gender, time.time(), source),
+            )
+        else:
+            cur = self.conn.execute(
+                "UPDATE glossary SET target=?, status='ok', updated_at=? "
+                "WHERE source=?",
+                (target, time.time(), source),
+            )
         self.conn.commit()
         return cur.rowcount > 0
 


### PR DESCRIPTION
修复 #87 中点名的两个可独立处理的落点（其余架构层问题留给后续国际化重构）。此前误发的 #192 已撤回，本 PR 包含了针对 #192 评审意见的修订。

## 修复 1：假名子串误匹配（store.py ``_source_pattern``）

此前只对拉丁/希腊/西里尔字母做词边界，CJK 一律裸子串，#87 实测的误注入仍然存在：

- ``あんな`` 命中 ``あんなに``
- ``メイ`` 命中 ``メイン``
- ``しょう`` 命中 ``しょうがない``

现在纯假名键要求同文字假名连续串边界（平假名键两侧不能是平假名，片假名键两侧不能是片假名/长音符；中点「・」视为分隔符）。含汉字的键保持原行为。

**明确取舍（precision over recall）**：平假名键后接假名延续时一律不命中，因此 ``ゆきは歩いた``（人名+助词）这类写法会漏注入一次。无分词器时无法区分它与 ``あんなに``，本 PR 选择宁可少注入、不让错误事实进入 prompt。该规则作用于所有纯平假名词条，不只人物短名。已有测试锁定此行为，改动它需要先引入分词。

## 修复 2：同译法更新静默覆盖 gender（store.py ``upsert_term``）

此前同 source 同 target 时新词条的非空 gender 会直接覆盖已有值——``status=ok`` 下事实被悄悄改写，审校随后把矛盾事实当作权威依据。

现在：已有非空 gender 与传入非空 gender 相左时，**保留现有 gender 并登记冲突**（``term_conflicts`` note 注明「性别冲突：现有 X vs 提议 Y」），词条置 ``conflict``，可用新增的 ``glossary resolve --gender`` 裁定。

**边界说明**：冲突词条仍会照常注入翻译/审校 prompt（与既有 target 冲突行为一致）；把矛盾事实从 prompt 中完整隔离属于 #87 的架构层改造，不在本 PR 范围。

配套修复（评审后补入）：

- 性别未知标记（``未知``/``不明``/``unknown`` 等）在 store 入口统一归一为空：传入值与**存量旧值**都归一（旧版本 Analyzer 会把「未知」原样入库，已补旧库回归测试）
- ``--gender`` 只接受 ``男``/``女``，未知标记或非法值会拒绝——否则会把未裁决的性别冲突一并误关
- ``glossary conflicts`` 列表展示冲突 note

## 测试

- 假名边界（含 ``メイ・スミス`` 中点、``ゆきは`` 取舍锁定）、性别冲突登记/裁定、未知值归一（含旧库模拟）、CLI 拒绝非法 ``--gender``，共 7 个新测试
- 全量测试通过：542 passed, 1 skipped

Ref: #87