### PR TITLE
test(review): keep orchestrator review tests read-only

### DIFF
--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -134,7 +134,7 @@ def _config(state_dir: str):
                 "provider": "fake",
                 "tiers": {"strong": {"model": "p"}, "cheap": {"model": "f"}},
             },
-            "pipeline": {"review": True, "polish": True},
+            "pipeline": {"review": True, "review_autofix": False, "polish": True},
             "paths": {"state_dir": state_dir},
         }
     )

--- a/tests/test_bilingual.py
+++ b/tests/test_bilingual.py
@@ -239,6 +239,7 @@ def _config(state_dir: str, output: dict | None = None):
         },
         "pipeline": {
             "review": True,
+            "review_autofix": False,
             "polish": False,
         },
         "paths": {"state_dir": state_dir},

--- a/tests/test_newfeatures.py
+++ b/tests/test_newfeatures.py
@@ -273,6 +273,7 @@ class TestRunAll(unittest.TestCase):
                     },
                     "pipeline": {
                         "review": True,
+                        "review_autofix": False,
                         "polish": True,
                     },
                     "paths": {"state_dir": state},

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -85,6 +85,7 @@ def _config(state_dir: str):
             "segment": {"max_chars_per_batch": 1800},
             "pipeline": {
                 "review": True,
+                "review_autofix": False,
                 "polish": True,
             },
             "paths": {"state_dir": state_dir},


### PR DESCRIPTION
review_autofix now defaults to true, which published shadow fixes and created autofix/agents artifacts. Pin the existing review helpers to review_autofix: false so they still assert a read-only Review run.