### PR TITLE
fix(review): resume progress and lazy chapter glossary matching

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -60,9 +60,17 @@ uv run trans-novel review book.epub
 uv run trans-novel review book.epub --autofix
 ```
 
-The explicit command runs even when `pipeline.review` is disabled. Every invocation
-reviews the complete translated book from the beginning. The Review engine first
-updates a run-local shadow translation. Publishing is enabled by default;
+The explicit command runs even when `pipeline.review` is disabled. Matching completed
+results are reused; an interrupted Review resumes its saved rounds, chunks, and agent
+traces when content, configuration, and glossary fingerprints match. Otherwise, a new
+whole-book Review starts. Cached chunks and completed initial screening skip chapter
+glossary matching; pending reviewer requests share one chapter-wide glossary snapshot.
+The CLI shows chapter loading and checkpoint preparation before reviewing paragraphs.
+Elapsed time measures the current stage of this invocation and continues advancing
+while model requests are pending; paragraph counts advance when a top-level chunk
+finishes, including chunks restored from cache.
+
+The Review engine first updates a run-local shadow translation. Publishing is enabled by default;
 set `pipeline.review_autofix: false` or pass `--no-autofix` to keep Review from
 replacing formal chapter `target` values. The manifest and glossary are never changed.
 The final result, run-local usage delta, events, and internal traces are written to:

--- a/docs/zh/pipeline.md
+++ b/docs/zh/pipeline.md
@@ -61,8 +61,14 @@ uv run trans-novel review book.epub
 uv run trans-novel review book.epub --autofix
 ```
 
-即使关闭 `pipeline.review`，显式调用上述命令仍会执行审校。每次运行都会从头
-审查完整译文。Review 引擎先更新本次运行内存中的影子译文；发布默认开启，设置
+即使关闭 `pipeline.review`，显式调用上述命令仍会执行审校。内容、配置与术语库指纹匹配时，
+复用已完成的结果，或从中断的轮次、审校块与 Agent 记录续跑；不匹配时重新开始全书审校。
+命中审校块缓存或已完成初审记录时跳过章节术语筛选；需要新 Reviewer 请求时，同章请求共享
+一次筛选得到的完整章节术语快照。CLI 在段落审校前显示章节加载和检查点准备阶段。
+耗时显示本次启动中当前阶段的运行时间，等待模型响应时继续走动；段落计数在顶层审校块
+完成时推进，也包括从缓存恢复的块。
+
+Review 引擎先更新本次运行内存中的影子译文；发布默认开启，设置
 `pipeline.review_autofix: false` 或传入 `--no-autofix` 后，不会覆盖正式章节
 的 `target`。manifest 和术语库始终不变。最终结果、本次用量、事件和内部记录写入：
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import unittest
 from unittest.mock import patch
 
 import typer
-from rich.progress import Progress
+from rich.progress import Progress, TimeElapsedColumn
 from typer.testing import CliRunner
 
 from trans_novel.cli import (
@@ -30,6 +30,38 @@ class FakeStore:
 
 
 class TestCliConfig(unittest.TestCase):
+    def test_progress_clock_advances_after_completed_stage(self):
+        now = 10.0
+        progress = Progress(disable=True, get_time=lambda: now)
+        bridge = _RichProgressBridge(progress, "Preparing translation…")
+        bridge(1674, 1674, "Translation complete")
+        self.assertTrue(progress.tasks[0].finished)
+
+        now = 20.0
+        bridge(0, 1674, "Whole-book review R1")
+        bridge(777, 1674, "Whole-book review R1")
+        task = progress.tasks[0]
+        self.assertFalse(task.finished)
+        now = 25.0
+        self.assertEqual(TimeElapsedColumn().render(task).plain, "0:00:05")
+        now = 35.0
+        self.assertEqual(TimeElapsedColumn().render(task).plain, "0:00:15")
+        bridge(778, 1674, "Whole-book review R1")
+        self.assertEqual(TimeElapsedColumn().render(task).plain, "0:00:15")
+
+    def test_indeterminate_progress_updates_preserve_elapsed_time(self):
+        now = 10.0
+        progress = Progress(disable=True, get_time=lambda: now)
+        bridge = _RichProgressBridge(progress, "Preparing review…")
+        bridge(1, 1, "Loading review chapters")
+        bridge(0, 0, "Restoring review checkpoint…")
+        now = 15.0
+        bridge(0, 0, "Restoring review checkpoint…")
+        task = progress.tasks[0]
+        self.assertIsNone(task.total)
+        self.assertFalse(task.finished)
+        self.assertEqual(TimeElapsedColumn().render(task).plain, "0:00:05")
+
     def test_progress_bridge_reuses_one_task_across_review_stages(self):
         progress = Progress(disable=True)
         bridge = _RichProgressBridge(progress, "Preparing whole-book review…")
@@ -45,6 +77,7 @@ class TestCliConfig(unittest.TestCase):
         self.assertEqual(task.description, "Blind whole-book review R2")
         self.assertEqual(task.completed, 0)
         self.assertEqual(task.total, 6386)
+        self.assertFalse(task.finished)
 
     def test_pdf_engine_validation_accepts_both_backends(self):
         self.assertEqual(_validate_pdf_engine("WeasyPrint"), "weasyprint")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1334,6 +1334,16 @@ class TestReviewReporting(unittest.TestCase):
             self.assertEqual([done for done, _ in stage], sorted(done for done, _ in stage))
             self.assertTrue(any(0 < done < total for done, total in stage))
         self.assertEqual(clean, [(1, 2), (2, 2)])
+        loading = [
+            (done, total) for done, total, label in events if label == "Loading review chapters"
+        ]
+        self.assertTrue(loading)
+        self.assertEqual(loading[0][0], 0)
+        self.assertEqual(loading[-1][0], loading[-1][1])
+        labels = [label for _, _, label in events]
+        self.assertLess(
+            labels.index("Restoring review checkpoint…"), labels.index("Whole-book review R1")
+        )
 
     def test_review_accepts_numeric_string_index(self):
         def handler(messages, tier, json_mode):
@@ -1555,7 +1565,11 @@ class TestReviewReporting(unittest.TestCase):
 
             meter = MeteredFakeClient(handler=self._handler())
             orch2 = Orchestrator(cfg, client=meter)
-            orch2.run_review(txt)
+            with patch.object(
+                GlossaryStore, "terms_in", wraps=GlossaryStore.terms_in
+            ) as match_terms:
+                orch2.run_review(txt)
+            match_terms.assert_not_called()
 
             reused_stages = [
                 call["stage"]

--- a/tests/test_review_polish.py
+++ b/tests/test_review_polish.py
@@ -7,10 +7,12 @@ import re
 import tempfile
 import threading
 import unittest
+from unittest.mock import patch
 
 from trans_novel.agents.polisher import Polisher
 from trans_novel.agents.reviewer import Reviewer, ReviewOutputError
 from trans_novel.config import Config
+from trans_novel.glossary.store import GlossaryStore, GlossaryTerm
 from trans_novel.ingest.models import Segment
 from trans_novel.llm.providers.fake import FakeClient
 from trans_novel.pipeline.orchestrator import Orchestrator
@@ -320,6 +322,62 @@ class TestReviewer(unittest.TestCase):
 
         self.assertEqual([it["index"] for it in issues], [0, 1])
         self.assertEqual([it["detail"] for it in issues], ["甲", "乙"])
+
+    def test_fresh_review_blocks_share_chapter_glossary_after_cache_lookup(self):
+        """A pending block still sees terms from cached neighbors in the same chapter."""
+        for scope in ("chapter", "book"):
+            for cache_first in (False, True):
+                with self.subTest(scope=scope, cache_first=cache_first):
+                    cfg = _cfg()
+                    cfg.segment.max_chars_per_batch = 1
+                    cfg.pipeline.review_concurrency = 2
+                    cfg.pipeline.glossary_scope = scope
+                    expected_calls = 1 if cache_first else 2
+                    barrier = threading.Barrier(expected_calls)
+
+                    def handler(messages, tier, json_mode):
+                        barrier.wait(timeout=2)
+                        return _review_response([], 1)
+
+                    orch = Orchestrator(cfg, client=FakeClient(handler=handler))
+                    segments = [
+                        Segment(index=0, source="Ann", target="Anne"),
+                        Segment(index=1, source="Bob", target="Robert"),
+                    ]
+                    terms = [GlossaryTerm(source=s, target=s) for s in ("Ann", "Bob", "Unused")]
+                    completed = []
+                    with tempfile.TemporaryDirectory() as directory:
+                        debug = ReviewRunStore(directory)
+                        if cache_first:
+                            debug.mark_chunk_done(
+                                "r1-ch0-base0-n1",
+                                {"issues": [], "initial_issues": [], "dismissed": []},
+                            )
+                        reviewer = orch._runtime.reviewer
+                        with (
+                            patch.object(
+                                GlossaryStore, "terms_in", wraps=GlossaryStore.terms_in
+                            ) as matching,
+                            patch.object(
+                                reviewer, "review_result", wraps=reviewer.review_result
+                            ) as reviewing,
+                        ):
+                            issues = orch._review.review_chapter(
+                                segments,
+                                terms,
+                                chapter_index=0,
+                                review_round=1,
+                                debug=debug,
+                                on_chunk_finished=completed.append,
+                            )
+
+                    self.assertEqual(issues, [])
+                    self.assertEqual(completed, [1, 1])
+                    self.assertEqual(matching.call_count, 1 if scope == "chapter" else 0)
+                    self.assertEqual(reviewing.call_count, expected_calls)
+                    expected_terms = terms[:2] if scope == "chapter" else terms
+                    for call in reviewing.call_args_list:
+                        self.assertEqual(call.args[2], expected_terms)
 
 
 class TestPolisher(unittest.TestCase):

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -116,10 +116,16 @@ class _RichProgressBridge:
     def __init__(self, progress: Progress, initial_description: str) -> None:
         self.progress = progress
         self.task = progress.add_task(initial_description, total=None)
+        self._stage: tuple[str, int | None] = (initial_description, None)
 
     def __call__(self, done: int, total: int, label: str) -> None:
         """Refresh the current stage and counts without accumulating progress bars."""
+        stage = (label, total if total > 0 else None)
         if total > 0:
+            if stage != self._stage:
+                # A completed Rich task retains its finished time until reset.
+                self.progress.reset(self.task, total=total, completed=done, description=label)
+            self._stage = stage
             self.progress.update(
                 self.task,
                 completed=done,
@@ -127,10 +133,13 @@ class _RichProgressBridge:
                 description=label,
             )
             return
+        if stage == self._stage:
+            return
         # Rich update(total=None) leaves the total unchanged. Recreate the task
         # to restore indeterminate progress and clear the previous stage’s counts.
         self.progress.remove_task(self.task)
         self.task = self.progress.add_task(label, total=None)
+        self._stage = stage
 
 
 def _version_callback(value: bool) -> None:

--- a/trans_novel/pipeline/review_workflow.py
+++ b/trans_novel/pipeline/review_workflow.py
@@ -364,11 +364,6 @@ class ReviewService:
         raw_issues: list[dict[str, Any]] = []
         for chapter in loaded:
             text_segs = chapter.text_segments
-            if self._runtime.config.pipeline.glossary_scope == "chapter":
-                source_text = "\n".join(segment.source for segment in text_segs)
-                term_snapshot = GlossaryStore.terms_in(all_terms, source_text)
-            else:
-                term_snapshot = all_terms
 
             def on_chunk_finished(segment_count: int) -> None:
                 """Advance this round's paragraph progress after a top-level review block
@@ -381,7 +376,7 @@ class ReviewService:
 
             chapter_issues = self.review_chapter(
                 text_segs,
-                term_snapshot,
+                all_terms,
                 chapter_index=chapter.index,
                 evidence=evidence,
                 debug=debug,
@@ -728,8 +723,16 @@ class ReviewService:
             )
 
         chapter_rows = manifest.get("chapters", [])
-        loaded = [store.load_chapter(item["index"]) for item in chapter_rows]
+        if progress:
+            progress(0, len(chapter_rows), "Loading review chapters")
+        loaded = []
+        for position, item in enumerate(chapter_rows, start=1):
+            loaded.append(store.load_chapter(item["index"]))
+            if progress:
+                progress(position, len(chapter_rows), "Loading review chapters")
         total = sum(len(chapter.text_segments) for chapter in loaded)
+        if progress:
+            progress(0, 0, "Restoring review checkpoint…")
         analysis = store.load_analysis() or {}
         reviewed_content_digest = _review_content_digest(loaded)
 
@@ -964,6 +967,8 @@ class ReviewService:
 
         try:
             for review_round in range(start_round, max_review_rounds + 1):
+                if progress:
+                    progress(0, 0, f"Preparing review R{review_round}…")
                 overlay_digest = _review_overlay_digest(loaded, target_overrides)
                 evidence = BookEvidenceIndex(
                     loaded,
@@ -1406,7 +1411,7 @@ class ReviewService:
     def review_chapter(
         self,
         text_segs,
-        terms,
+        terms: list[GlossaryTerm],
         *,
         chapter_index: int | None = None,
         evidence: BookEvidenceIndex | None = None,
@@ -1418,6 +1423,8 @@ class ReviewService:
         """Review contiguous chapter blocks in parallel and return chapter-local issue indices.
         Use blocks around three translation batches to reduce calls and repeated context.
         Convert valid block-local indices by the block offset and reject invalid positions.
+        Filter the chapter glossary only when a fresh reviewer request needs it; completed
+        chunks and initial traces bypass matching. Share one snapshot across workers.
         Read fixed target/glossary snapshots. Recursively bisect malformed output and retry
         single paragraphs a bounded number of times. Merge results in original block order
         for determinism.
@@ -1435,6 +1442,19 @@ class ReviewService:
 
         recovery_events: list[dict[str, Any]] = []
         recovery_lock = Lock()
+        term_snapshot: list[GlossaryTerm] | None = None
+        term_lock = Lock()
+
+        def reviewer_terms() -> list[GlossaryTerm]:
+            """Build the chapter-wide glossary once, after all reusable caches miss."""
+            nonlocal term_snapshot
+            if self._runtime.config.pipeline.glossary_scope != "chapter":
+                return terms
+            with term_lock:
+                if term_snapshot is None:
+                    source_text = "\n".join(segment.source for segment in text_segs)
+                    term_snapshot = GlossaryStore.terms_in(terms, source_text)
+                return term_snapshot
 
         def record_recovery(event: str, **data: Any) -> None:
             """Buffer recovery events under a lock; write them from the main thread after
@@ -1464,18 +1484,17 @@ class ReviewService:
             # Check the chunk cache to skip reviewer and evidence-loop model calls on resume.
             round_prefix = f"r{review_round}-" if review_round is not None else ""
             chunk_id = f"{round_prefix}ch{chapter_index}-base{chunk_base}-n{len(chunk)}"
-            if debug is not None and debug.is_chunk_done(chunk_id):
-                review_debug = debug
-                cached = review_debug.load_chunk_result(chunk_id)
+            if debug is not None:
+                cached = debug.load_chunk_result(chunk_id)
                 if cached is not None:
                     # Restore initial/dismissed aggregation needed by the report.
                     if chapter_index is not None:
-                        review_debug.record_initial_issues(
+                        debug.record_initial_issues(
                             chapter=chapter_index,
                             chunk_base=chunk_base,
                             issues=cached.get("initial_issues", []),
                         )
-                        review_debug.record_dismissed(
+                        debug.record_dismissed(
                             chapter=chapter_index,
                             chunk_base=chunk_base,
                             issues=cached.get("dismissed", []),
@@ -1566,7 +1585,7 @@ class ReviewService:
                     review_result = self._runtime.reviewer.review_result(
                         srcs,
                         tgts,
-                        terms,
+                        reviewer_terms(),
                         trace=trace if debug is not None else None,
                     )
                 except Exception as error:
@@ -1807,11 +1826,10 @@ class ReviewService:
             if not pieces:
                 return []
             chunk_id = f"{round_prefix}ch{chapter_index}-base{base}-n{len(pieces)}"
-            if debug.is_chunk_done(chunk_id):
-                cached = debug.load_chunk_result(chunk_id)
-                if cached is not None:
-                    hits.append((base, cached))
-                    return list(cached.get("issues", []))
+            cached = debug.load_chunk_result(chunk_id)
+            if cached is not None:
+                hits.append((base, cached))
+                return list(cached.get("issues", []))
             if len(pieces) <= 1:
                 return None
             mid = len(pieces) // 2


### PR DESCRIPTION
Reuse matching Review checkpoints with clearer load/restore stages, keep the CLI elapsed clock advancing across stage changes, and build one chapter glossary snapshot only when a fresh reviewer request needs it.