### PR TITLE
fix(config): align PDF backend default to mineru

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ CLI → Orchestrator → Runtime / Preparation / Translation / Annotation /
 ## 输入与输出约束
 
 - EPUB 修改要同时考虑模板回填、TOC、锚点、内部注释链接、图片、双语原文样式和超长段回并。
-- PDF 默认使用 BabelDOC（外部 AGPL HTTP bridge）；MinerU 用于扫描件或无文本层页面。纯图片且无文本层时应给出可操作提示，不应假装成功解析。
+- PDF 默认使用 MinerU；BabelDOC（外部 AGPL HTTP bridge）用于尽量保留版式的可选路径。纯图片且无文本层时应给出可操作提示，不应假装成功解析。
 - DOCX 修改要保留段落/运行级样式、列表、表格、标题、目录和中英文字体策略。
 - 输出格式或命名变化要覆盖单语、双语、显式 `--out`、默认输出目录和并发导出快照。
 - 标点、术语命中等可确定行为优先实现为纯函数，并使用边界案例单测固定。

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ internal records are written under `state/<book>/targets/<target-language>/revie
 | EPUB, FB2, TXT, Markdown, HTML, PDF, DOCX | EPUB (monolingual / bilingual), TXT, HTML, Markdown, DOCX |
 | SRT (movie / series subtitles) | `.zh.srt` (monolingual) and optional `.zh-bi.srt` (bilingual) |
 
-- PDF input defaults to the BabelDOC bridge. MinerU conversion is optional for scanned pages and requires `MINERU_API_KEY`; that HTML is cached and reused.
+- PDF input defaults to MinerU and requires `MINERU_API_KEY` for the initial conversion; the resulting HTML is cached and reused. The BabelDOC bridge is optional for layout-preserving PDFs.
 - EPUB output attempts to preserve the original book's styles, images, table of contents, and anchors. Vertical layout is converted to horizontal for Chinese reading.
 - Source language is auto-detected by default, or fixed to an ISO 639-1 code in `config.yaml`.
 - `.srt` input is auto-detected by `translate`. It uses a light concurrent path (no glossary, polish, or whole-book review). State lives under `state/srt/<slug>/targets/<target-language>/`; outputs default to the source file's `output/` directory. Details: [Usage guide](docs/usage.md#srt-subtitles).
@@ -236,7 +236,7 @@ Translated state directories for public-domain books may be shared through [weny
 - Multilingual translation is experimental: Chinese, English, Japanese, Korean, French, German, Spanish, Italian, Portuguese, Russian, and selected variants have built-in profiles. Real-model long-form quality still needs evaluation; the CLI and prompt instructions use English, while generated descriptive metadata follows the translation target.
 - Polishing and final review are the most expensive stages. Shadow fixing may
   trigger multiple full-book review passes and additional Fixer calls.
-- PDF input defaults to the BabelDOC bridge. MinerU is optional for scanned pages and requires an API key.
+- PDF input defaults to MinerU and requires an API key for the initial conversion. The BabelDOC bridge is optional for layout-preserving PDFs.
 - SRT translation is a light concurrent path: no glossary, polishing, or whole-book review, and slug collision is possible for identically named files in different folders.
 - Translation quality is bounded by the capabilities of the chosen LLM model.
 - Very long books may produce large state directories; storage requirements grow with book length.

--- a/config.yaml
+++ b/config.yaml
@@ -60,7 +60,7 @@ pipeline:
   review_clean_confirmations: 2 # Require two consecutive clean rounds to accept the shadow translation
   review_autofix: true # Publish review revisions to formal chapters; use --no-autofix for recommendations only
   glossary_scope: chapter # chapter=terms occurring in this chapter (saves tokens); full=entire glossary
-  # PDF backend: babeldoc (default, preserves layout, requires an external AGPL HTTP bridge) | mineru (supports scans)
+  # PDF backend: mineru (default, supports scans) | babeldoc (optional, preserves layout via external AGPL HTTP bridge)
   pdf_backend: mineru
   babeldoc_bridge_url: http://127.0.0.1:8765
   # babeldoc_pages: "15"   # Optional page restriction for the bridge (one-based)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ Selecting `deepseek` is enough for the built-in defaults:
 
 API keys are always read from environment variables so they are not accidentally committed with the configuration. Use `provider: fake` for offline tests that must not make network requests.
 
-When `pipeline.pdf_backend` is `mineru`, the first PDF import also reads `MINERU_API_KEY` to call the MinerU conversion service. This key is independent of the LLM provider and is not written to `config.yaml`. The default BabelDOC backend does not use this key.
+The first PDF import with the default MinerU backend also reads `MINERU_API_KEY` to call the MinerU conversion service. This key is independent of the LLM provider and is not written to `config.yaml`. The optional BabelDOC backend does not use this key.
 
 Add the advanced fields only when you need a proxy, custom environment variable, timeout, retry policy, or model override:
 
@@ -238,7 +238,7 @@ pipeline:
   review_clean_confirmations: 2
   review_autofix: true
   glossary_scope: chapter
-  pdf_backend: babeldoc
+  pdf_backend: mineru
   babeldoc_bridge_url: http://127.0.0.1:8765
   babeldoc_timeout: 600
 ```
@@ -261,7 +261,7 @@ pipeline:
 - `review_clean_confirmations`: consecutive issue-free whole-book Review passes required after shadow fixing, from `1` to `2`; the default is `2`.
 - `review_autofix`: enabled by default. After the read-only Review engine finishes, publish its folded `changes` to a working translation, run the existing bounded Review Agent Loop once more over each remaining issue against that updated text, and pass confirmed issues to the existing Review Fixer. Pass `--no-autofix` or set this to `false` to keep Review from writing formal `target` values. The resulting complete segments replace only the formal chapter `target`; the manifest and glossary remain unchanged. Full before/after chains, issue IDs, decisions, failures, and write status are kept in the Review run's `autofix/index.json` instead of adding history fields to chapter JSON.
 - `glossary_scope`: `chapter` includes terms relevant to the current chapter; `full` includes the complete glossary.
-- `pdf_backend`: default `babeldoc` preserves PDF layout through the external AGPL HTTP bridge. Use `mineru` for scanned pages that have no extractable text layer.
+- `pdf_backend`: default `mineru` converts PDF via MinerU HTML. Use `babeldoc` for layout-preserving export through the external AGPL HTTP bridge.
 - `babeldoc_bridge_url`: BabelDOC bridge base URL; default `http://127.0.0.1:8765`.
 - `babeldoc_timeout`: HTTP timeout in seconds for bridge extract and fillback.
 - `babeldoc_pages`: optional 1-based page selection such as `"15"` or `"6-8"`; omit it to process the whole file.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,25 +104,17 @@ PDF input and PDF output are both experimental.
 
 #### PDF input
 
-Default backend is BabelDOC, which preserves layout through the external
-**BabelDOC bridge** (AGPL, separate repo/process, HTTP only). Use MinerU for
-scanned pages that have no extractable text layer.
+Default backend is MinerU. For layout-preserving export, use the external
+**BabelDOC bridge** (AGPL, separate repo/process, HTTP only):
 
 1. Install/start `wenyi-babeldoc-bridge` (default `http://127.0.0.1:8765`)
-2. The default `config.yaml` already selects BabelDOC:
+2. In `config.yaml`:
 
 ```yaml
 pipeline:
   pdf_backend: babeldoc
   babeldoc_bridge_url: http://127.0.0.1:8765
   # babeldoc_pages: "15"   # optional, 1-based
-```
-
-To use MinerU instead:
-
-```yaml
-pipeline:
-  pdf_backend: mineru
 ```
 
 3. After `translate book.pdf`, `assemble --format pdf` calls bridge `/fillback`.
@@ -137,9 +129,8 @@ pipeline:
    keep `meta.babeldoc_id` for fillback. Books without outlines fall back to one chapter.
 
 BabelDOC is intended for PDFs with an extractable text layer. Before contacting the
-bridge, Wenyi checks the selected pages and stops with a suggestion to switch to
-MinerU (`pipeline.pdf_backend: mineru`) or run OCR first when it finds only scanned
-images and no text layer.
+bridge, Wenyi checks the selected pages and stops with a suggestion to use the default
+MinerU backend or run OCR first when it finds only scanned images and no text layer.
 
 The first MinerU PDF import requires `MINERU_API_KEY`:
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -168,7 +168,7 @@ uv run trans-novel review book.epub --autofix
 | EPUB、FB2、TXT、Markdown、HTML、PDF、DOCX | EPUB（单语 / 双语）、TXT、HTML、Markdown、DOCX |
 | SRT（影视字幕） | 单语 `.zh.srt`，可选双语 `.zh-bi.srt` |
 
-- PDF 输入默认走 BabelDOC bridge。扫描件可改用 MinerU，首次转换需 `MINERU_API_KEY`，生成的 HTML 会缓存复用。
+- PDF 输入默认走 MinerU，首次转换需 `MINERU_API_KEY`，生成的 HTML 会缓存复用。可选 BabelDOC bridge 用于尽量保留版式。
 - EPUB 输出尽量保留原书样式、图片、目录和锚点，竖排转为横排以适配中文阅读。
 - 源语言默认由模型自动识别，也可在 `config.yaml` 中固定为 ISO 639-1 语言代码。
 - `.srt` 由 `translate` 自动识别，走轻量并发路径（无术语库、润色与全书审校）。状态在 `state/srt/<slug>/targets/<目标语言>/`，成品默认写到源文件旁的 `output/`。详见[使用指南](usage.md#srt-字幕)。
@@ -228,7 +228,7 @@ Review Fixer 同样会获得风格指南、全书概览、本章梗概、相关�
 
 ## 憧憬与不足
 
-本项目为作者个人兴趣所开发，旨在为长文本书籍的译介做出一份微薄的努力。现阶段翻译质量仍受限于所选模型的能力：润色和审校阶段会显著增加 token 消耗，开启影子修订后还可能执行多次全书审校与额外 Fixer 调用；极长的书籍可能产生较大的状态目录，PDF 输入默认依赖 BabelDOC bridge，扫描件才走 MinerU。SRT 字幕走轻量并发路径，不建术语库、不做润色与全书审校，不同目录下同名文件也可能共用同一 `state/srt/<slug>/targets/<目标语言>/`。多语言互译现为实验性功能，支持中、英、日、韩、法、德、西、意、葡、俄及部分变体；真实模型长篇质量仍待验证，CLI 和提示词指令统一使用英语，模型生成的说明性元数据使用翻译目标语言。
+本项目为作者个人兴趣所开发，旨在为长文本书籍的译介做出一份微薄的努力。现阶段翻译质量仍受限于所选模型的能力：润色和审校阶段会显著增加 token 消耗，开启影子修订后还可能执行多次全书审校与额外 Fixer 调用；极长的书籍可能产生较大的状态目录，PDF 输入默认依赖 MinerU 外部服务（首次转换需 API Key），可选 BabelDOC bridge 保留版式。SRT 字幕走轻量并发路径，不建术语库、不做润色与全书审校，不同目录下同名文件也可能共用同一 `state/srt/<slug>/targets/<目标语言>/`。多语言互译现为实验性功能，支持中、英、日、韩、法、德、西、意、葡、俄及部分变体；真实模型长篇质量仍待验证，CLI 和提示词指令统一使用英语，模型生成的说明性元数据使用翻译目标语言。
 
 未来想让翻译在够准确的前提下更加顺畅，努力从可读向好读迈进。如果你发现了问题，欢迎提交 [Issue](https://github.com/BigDawnGhost/wenyi/issues)；如果你有想法，欢迎在[讨论区](https://github.com/BigDawnGhost/wenyi/discussions)提出；如果你有一定的编程能力，欢迎提交 PR，让这个项目变得更好。👏
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -48,9 +48,9 @@ llm:
 
 API Key 始终从环境变量读取，避免把密钥写进配置并提交到仓库。离线测试或调试可将 `provider` 改为 `fake`，此时不会发网络请求。
 
-当 `pipeline.pdf_backend` 为 `mineru` 时，PDF 输入的首次解析另外读取
-`MINERU_API_KEY`，用于调用 MinerU 转换服务。该密钥与 LLM provider 配置无关，
-也不写入 `config.yaml`。默认的 BabelDOC 后端不使用此密钥。
+默认 MinerU 后端首次解析 PDF 时另外读取 `MINERU_API_KEY`，用于调用 MinerU
+转换服务。该密钥与 LLM provider 配置无关，也不写入 `config.yaml`。可选的
+BabelDOC 后端不使用此密钥。
 
 需要代理、自定义环境变量或覆盖模型时，可添加高级配置：
 
@@ -254,7 +254,7 @@ pipeline:
   review_clean_confirmations: 2
   review_autofix: true
   glossary_scope: chapter
-  pdf_backend: babeldoc
+  pdf_backend: mineru
   babeldoc_bridge_url: http://127.0.0.1:8765
   babeldoc_timeout: 600
 ```
@@ -277,7 +277,7 @@ pipeline:
 - `review_clean_confirmations`：开启影子 Fix 后，需要连续无问题的全书 Review 次数，范围为 `1` 到 `2`，默认 `2`。
 - `review_autofix`：默认开启。只读 Review 引擎结束后，先把折叠后的 `changes` 叠加到工作译文，再让每段剩余 issue 基于更新后的译文复用现有有界 Review Agent Loop，确认项继续交给现有 Review Fixer。可用 `--no-autofix` 或设为 `false`，避免写回正式 `target`。生成的完整单段译文只覆盖正式章节的 `target`，不修改 manifest 和术语库。完整前后版本链、issue ID、判定、失败原因和写回状态保存在本次 Review 的 `autofix/index.json`，不会给章节 JSON 新增历史字段。
 - `glossary_scope`：`chapter` 仅带本章相关术语，`full` 带全量术语表。
-- `pdf_backend`：默认 `babeldoc`，经外部 AGPL HTTP bridge 保留 PDF 版式。扫描件、无文本层页面请改用 `mineru`。
+- `pdf_backend`：默认 `mineru`，经 MinerU 转 HTML。需要尽量保留版式时改用 `babeldoc`（外部 AGPL HTTP bridge）。
 - `babeldoc_bridge_url`：BabelDOC bridge 地址，默认 `http://127.0.0.1:8765`。
 - `babeldoc_timeout`：bridge extract / fillback 的 HTTP 超时秒数。
 - `babeldoc_pages`：可选的 1-based 页码，如 `"15"` 或 `"6-8"`；省略则处理全书。

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -103,24 +103,16 @@ PDF 输入和 PDF 导出目前均属于实验性支持。
 
 #### PDF 输入
 
-默认走 BabelDOC，经外部 **BabelDOC bridge**（AGPL，独立仓库/进程，HTTP only）保留版式。
-扫描件、无文本层页面请改用 MinerU。
+默认走 MinerU。也可用外部 **BabelDOC bridge**（AGPL，独立仓库/进程，HTTP only）保留版式：
 
 1. 另仓安装并启动 `wenyi-babeldoc-bridge`（默认 `http://127.0.0.1:8765`）
-2. 默认 `config.yaml` 已选择 BabelDOC：
+2. `config.yaml`：
 
 ```yaml
 pipeline:
   pdf_backend: babeldoc
   babeldoc_bridge_url: http://127.0.0.1:8765
   # babeldoc_pages: "15"   # 可选，1-based
-```
-
-改用 MinerU：
-
-```yaml
-pipeline:
-  pdf_backend: mineru
 ```
 
 3. `uv run trans-novel translate book.pdf` 后 `assemble --format pdf` 会经 bridge `/fillback` 出 PDF。  
@@ -132,7 +124,7 @@ pipeline:
    `meta.babeldoc_id` 供回填。无书签时退回单章。
 
 BabelDOC 只适合带可提取文本层的 PDF。选择该后端时，Wenyi 会在请求 bridge 前检查所选页面；
-若页面只有扫描图片而没有文本层，会停止并提示改用 MinerU（`pipeline.pdf_backend: mineru`），或先进行 OCR。
+若页面只有扫描图片而没有文本层，会停止并提示改用默认 MinerU，或先进行 OCR。
 
 首次读取 PDF（MinerU）需设置 `MINERU_API_KEY`：
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ class TestConfigFileCreation(unittest.TestCase):
             self.assertEqual(cfg.pipeline.review_fix_max_rounds, 2)
             self.assertEqual(cfg.pipeline.review_clean_confirmations, 2)
             self.assertTrue(cfg.pipeline.review_autofix)
-            self.assertEqual(cfg.pipeline.pdf_backend, "babeldoc")
+            self.assertEqual(cfg.pipeline.pdf_backend, "mineru")
 
     def test_load_never_overwrites_existing_config(self):
         with tempfile.TemporaryDirectory() as d:
@@ -86,7 +86,7 @@ class TestConfigFileCreation(unittest.TestCase):
         self.assertEqual(cfg.pipeline.review_fix_max_rounds, 2)
         self.assertEqual(cfg.pipeline.review_clean_confirmations, 2)
         self.assertTrue(cfg.pipeline.review_autofix)
-        self.assertEqual(cfg.pipeline.pdf_backend, "babeldoc")
+        self.assertEqual(cfg.pipeline.pdf_backend, "mineru")
 
     def test_about_page_can_be_disabled(self):
         cfg = Config.from_dict({"output": {"about_page": False}})

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -72,8 +72,8 @@ pipeline:
   review_clean_confirmations: 2 # Require two consecutive clean rounds to accept the shadow translation
   review_autofix: true # Publish review revisions to formal chapters; use --no-autofix for recommendations only
   glossary_scope: chapter # chapter=terms relevant to this chapter; full=entire glossary
-  # PDF backend: babeldoc (default, preserves layout, requires an external AGPL HTTP bridge) | mineru (supports scans)
-  pdf_backend: babeldoc
+  # PDF backend: mineru (default, supports scans) | babeldoc (optional, preserves layout via external AGPL HTTP bridge)
+  pdf_backend: mineru
   babeldoc_bridge_url: http://127.0.0.1:8765
   # babeldoc_pages: "15"   # Optional page restriction for the bridge (one-based)
   babeldoc_timeout: 600
@@ -174,8 +174,8 @@ class PipelineConfig(BaseModel):
     glossary_scope: str = (
         "chapter"  # chapter=terms occurring in this chapter (saves tokens); full=entire glossary
     )
-    # PDF: babeldoc=external AGPL HTTP bridge (default, no imports); mineru=HTML path for scans
-    pdf_backend: Literal["mineru", "babeldoc"] = "babeldoc"
+    # PDF: mineru=HTML path for scans (default); babeldoc=external AGPL HTTP bridge (no imports)
+    pdf_backend: Literal["mineru", "babeldoc"] = "mineru"
     babeldoc_bridge_url: str = "http://127.0.0.1:8765"
     babeldoc_pages: str | None = None  # For example "15" / "6-8"; None=whole book
     babeldoc_timeout: float = 600.0

--- a/trans_novel/ingest/segmenter.py
+++ b/trans_novel/ingest/segmenter.py
@@ -117,7 +117,7 @@ def load_document(
     *,
     cache_dir: str | None = None,
     source_hash: str | None = None,
-    pdf_backend: str = "babeldoc",
+    pdf_backend: str = "mineru",
     babeldoc_bridge_url: str = "http://127.0.0.1:8765",
     babeldoc_pages: str | None = None,
     babeldoc_timeout: float = 600.0,


### PR DESCRIPTION
Keep sample YAML comments, generated defaults, Pydantic/segmenter defaults, docs, and config tests consistent with mineru as the default.