### PR TITLE
fix(llm): use deepseek-flash as the DeepSeek preset model id

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ language:
 
 # ── LLM ──────────────────────────────────────────────────────────────────
 llm:
-  preset: deepseek # All tiers: deepseek-v4-flash, thinking enabled, reasoning_effort high
+  preset: deepseek # All tiers: deepseek-flash, thinking enabled, reasoning_effort high
   # Add providers, models and routes to override individual operations.
   # Inspect effective settings with: trans-novel models list
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ llm:
   preset: deepseek
 ```
 
-This preset expands to connection `default`, profiles `default_strong`, `default_cheap`, and `default_fast`, and all three tier mappings. Its product defaults are `https://api.deepseek.com`, `DEEPSEEK_API_KEY`, `deepseek-v4-flash` for all three tiers, with thinking enabled and `reasoning_effort: high`. The model ID and reasoning defaults follow the [DeepSeek API documentation](https://api-docs.deepseek.com/api/create-chat-completion/). The tiers retain independent mappings for later overrides; presets do not query remote capabilities. `preset: gemini` and `preset: fake` are also available; fake is offline.
+This preset expands to connection `default`, profiles `default_strong`, `default_cheap`, and `default_fast`, and all three tier mappings. Its product defaults are `https://api.deepseek.com`, `DEEPSEEK_API_KEY`, `deepseek-flash` for all three tiers, with thinking enabled and `reasoning_effort: high`. The model ID and reasoning defaults follow the [DeepSeek API documentation](https://api-docs.deepseek.com/api/create-chat-completion/). The tiers retain independent mappings for later overrides; presets do not query remote capabilities. `preset: gemini` and `preset: fake` are also available; fake is offline.
 
 For independent polishing and evidence verification:
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -41,7 +41,7 @@ llm:
   preset: deepseek
 ```
 
-该预设展开为连接 `default`、模型配置 `default_strong` / `default_cheap` / `default_fast`，以及三个档位映射。内置产品默认值为 `https://api.deepseek.com`、环境变量 `DEEPSEEK_API_KEY`；三个档位均使用 `deepseek-v4-flash`，开启 thinking，`reasoning_effort` 为 `high`。模型 ID 与默认推理设置依据 [DeepSeek 官方 API 文档](https://api-docs.deepseek.com/api/create-chat-completion/)。档位保持独立映射，便于之后分别覆盖模型；预设不会自动查询远端能力。也支持 `preset: gemini` 和离线的 `preset: fake`。
+该预设展开为连接 `default`、模型配置 `default_strong` / `default_cheap` / `default_fast`，以及三个档位映射。内置产品默认值为 `https://api.deepseek.com`、环境变量 `DEEPSEEK_API_KEY`；三个档位均使用 `deepseek-flash`，开启 thinking，`reasoning_effort` 为 `high`。模型 ID 与默认推理设置依据 [DeepSeek 官方 API 文档](https://api-docs.deepseek.com/api/create-chat-completion/)。档位保持独立映射，便于之后分别覆盖模型；预设不会自动查询远端能力。也支持 `preset: gemini` 和离线的 `preset: fake`。
 
 例如，单独配置润色与取证模型：
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,9 +28,9 @@ class TestConfigFileCreation(unittest.TestCase):
                 provider_spec("deepseek").adapter_type().default_api_key_env, "DEEPSEEK_API_KEY"
             )
             self.assertEqual(set(cfg.llm.tiers), {"strong", "cheap", "fast"})
-            self.assertEqual(cfg.llm.models[cfg.llm.tiers["strong"]].model, "deepseek-v4-flash")
-            self.assertEqual(cfg.llm.models[cfg.llm.tiers["cheap"]].model, "deepseek-v4-flash")
-            self.assertEqual(cfg.llm.models[cfg.llm.tiers["fast"]].model, "deepseek-v4-flash")
+            self.assertEqual(cfg.llm.models[cfg.llm.tiers["strong"]].model, "deepseek-flash")
+            self.assertEqual(cfg.llm.models[cfg.llm.tiers["cheap"]].model, "deepseek-flash")
+            self.assertEqual(cfg.llm.models[cfg.llm.tiers["fast"]].model, "deepseek-flash")
             self.assertTrue(cfg.llm.models[cfg.llm.tiers["fast"]].options["thinking"])
             for profile in cfg.llm.models.values():
                 self.assertEqual(profile.options["reasoning_effort"], "high")

--- a/tests/test_llm_routing.py
+++ b/tests/test_llm_routing.py
@@ -181,7 +181,7 @@ def test_native_and_compatible_adapters_can_run_together():
             client.complete, [{"role": "user", "content": "draft"}], operation="polish.body"
         )
         assert (first.result(), second.result()) == ("translation", "polished")
-    assert requests["compatible"]["model"] == "deepseek-v4-flash"
+    assert requests["compatible"]["model"] == "deepseek-flash"
     assert requests["native"]["model"] == "native-editor"
     assert requests["native"]["config"]["max_output_tokens"] == 2000
     assert "reasoning_effort" not in requests["native"]["config"]

--- a/tests/test_model_commands.py
+++ b/tests/test_model_commands.py
@@ -26,7 +26,7 @@ def test_preview_needs_no_keys_or_sdk(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     routes = json.loads(result.output)
     assert len(routes) == 17
-    assert {route["model"] for route in routes.values()} == {"deepseek-v4-flash"}
+    assert {route["model"] for route in routes.values()} == {"deepseek-flash"}
     assert routes["synopsis.chapter"]["max_output_tokens"] == 4096
     explained = _invoke(
         tmp_path, {"llm": {"preset": "deepseek"}}, "explain", "--operation", "autofix.verify"

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -30,8 +30,8 @@ class TestTranslatorAlignment(unittest.TestCase):
                 "llm": {
                     "preset": "fake",
                     "models": {
-                        "default_strong": {"provider": "default", "model": "deepseek-v4-pro"},
-                        "default_cheap": {"provider": "default", "model": "deepseek-v4-flash"},
+                        "default_strong": {"provider": "default", "model": "deepseek-pro"},
+                        "default_cheap": {"provider": "default", "model": "deepseek-flash"},
                     },
                 },
                 "pipeline": {"align_retry_limit": 1},

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -303,10 +303,8 @@ class TestDeepSeekProviderDefaults(unittest.TestCase):
 
         self.assertEqual(client.adapter("default").base_url, DEFAULT_BASE_URL)
         self.assertEqual(client.adapter("default").api_key_env, DEFAULT_API_KEY_ENV)
-        self.assertEqual(
-            client.routes["translation.body"].request_model().model, "deepseek-v4-flash"
-        )
-        self.assertEqual(client.routes["review.scan"].request_model().model, "deepseek-v4-flash")
+        self.assertEqual(client.routes["translation.body"].request_model().model, "deepseek-flash")
+        self.assertEqual(client.routes["review.scan"].request_model().model, "deepseek-flash")
         self.assertTrue(client.routes["translation.body"].request_model().options.thinking)
         self.assertTrue(client.routes["synopsis.chapter"].request_model().options.thinking)
 
@@ -330,10 +328,8 @@ class TestDeepSeekProviderDefaults(unittest.TestCase):
         )
 
         self.assertEqual(client.routes["synopsis.chapter"].request_model().model, "custom-fast")
-        self.assertEqual(
-            client.routes["translation.body"].request_model().model, "deepseek-v4-flash"
-        )
-        self.assertEqual(client.routes["review.scan"].request_model().model, "deepseek-v4-flash")
+        self.assertEqual(client.routes["translation.body"].request_model().model, "deepseek-flash")
+        self.assertEqual(client.routes["review.scan"].request_model().model, "deepseek-flash")
 
     def test_provider_option_can_be_overridden_without_repeating_model(self):
         client = RoutedLLMClient(
@@ -344,9 +340,7 @@ class TestDeepSeekProviderDefaults(unittest.TestCase):
             )
         )
 
-        self.assertEqual(
-            client.routes["synopsis.chapter"].request_model().model, "deepseek-v4-flash"
-        )
+        self.assertEqual(client.routes["synopsis.chapter"].request_model().model, "deepseek-flash")
         self.assertTrue(client.routes["synopsis.chapter"].request_model().options.thinking)
 
     def test_unknown_provider_option_is_rejected(self):

--- a/trans_novel/config.py
+++ b/trans_novel/config.py
@@ -21,7 +21,7 @@ language:
 
 # ── LLM ──────────────────────────────────────────────────────────────────
 llm:
-  preset: deepseek # All tiers: deepseek-v4-flash, thinking enabled, reasoning_effort high
+  preset: deepseek # All tiers: deepseek-flash, thinking enabled, reasoning_effort high
   # Add providers, models and routes to override individual operations.
   # Inspect effective settings with: trans-novel models list
 

--- a/trans_novel/llm/providers/deepseek.py
+++ b/trans_novel/llm/providers/deepseek.py
@@ -43,15 +43,15 @@ def preset_models() -> dict[str, ResolvedModel[DeepSeekOptions]]:
     """Return built-in DeepSeek defaults for strong, cheap and fast tiers."""
     return {
         "strong": ResolvedModel(
-            model="deepseek-v4-flash",
+            model="deepseek-flash",
             options=DeepSeekOptions(),
         ),
         "cheap": ResolvedModel(
-            model="deepseek-v4-flash",
+            model="deepseek-flash",
             options=DeepSeekOptions(),
         ),
         "fast": ResolvedModel(
-            model="deepseek-v4-flash",
+            model="deepseek-flash",
             options=DeepSeekOptions(),
         ),
     }


### PR DESCRIPTION
Align sample config, provider presets, docs, and tests with the current DeepSeek API model name.