### PR TITLE
fix(assemble): default BabelDOC PDF state to PDF export

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,7 +225,7 @@ pipeline:
 - `review_clean_confirmations`: consecutive issue-free whole-book Review passes required after shadow fixing, from `1` to `2`; the default is `2`.
 - `review_autofix`: enabled by default. After the read-only Review engine finishes, publish its folded `changes` to a working translation, run the existing bounded Review Agent Loop once more over each remaining issue against that updated text, and pass confirmed issues to the existing Review Fixer. Pass `--no-autofix` or set this to `false` to keep Review from writing formal `target` values. The resulting complete segments replace only the formal chapter `target`; the manifest and glossary remain unchanged. Full before/after chains, issue IDs, decisions, failures, and write status are kept in the Review run's `autofix/index.json` instead of adding history fields to chapter JSON.
 - `glossary_scope`: `chapter` includes terms relevant to the current chapter; `full` includes the complete glossary.
-- `pdf_backend`: default `mineru` converts PDF via MinerU HTML. Use `babeldoc` for layout-preserving export through the external AGPL HTTP bridge.
+- `pdf_backend`: default `mineru` converts PDF via MinerU HTML. Use `babeldoc` for layout-preserving export through the external AGPL HTTP bridge. PDF state created with BabelDOC defaults to PDF output for both `translate` and `assemble`; MinerU state retains EPUB output. Explicit `--format` overrides this choice, and saved state determines the default on resume.
 - `babeldoc_bridge_url`: BabelDOC bridge base URL; default `http://127.0.0.1:8765`.
 - `babeldoc_timeout`: HTTP timeout in seconds for bridge extract and fillback.
 - `babeldoc_pages`: optional 1-based page selection such as `"15"` or `"6-8"`; omit it to process the whole file.
@@ -255,8 +255,8 @@ output:
   punctuation_normalize: true
 ```
 
-- `mono`: produce a monolingual edition as `<book-name>.<target-language>.epub` (`.zh.epub` by default).
-- `bilingual`: produce a source-and-translation edition as `<book-name>.<target-language>-bi.epub`.
+- `mono`: produce a monolingual edition as `<book-name>.<target-language>.<extension>` (`.zh.epub` normally; `.zh.pdf` for BabelDOC PDF state and `.zh.docx` for DOCX input).
+- `bilingual`: request a source-and-translation edition as `<book-name>.<target-language>-bi.<extension>`, using the same selected format as monolingual output.
 - `bilingual_order`: `target_first` places the translation before the source; `source_first` reverses the order.
 - `bilingual_preserve_source_style`: when `true`, source blocks inherit the book's normal text style instead of using the subdued gray style. This affects EPUB and HTML output only.
 - `about_page`: append an “About this translation” project page to the book; set it to `false` to disable it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,8 +101,8 @@ checksum, approve it in **System Settings → Privacy & Security** if prompted.
 ## Input and output
 
 - Input formats: EPUB, FB2, TXT, Markdown, HTML, PDF, DOCX, and SRT.
-- Default book output: a monolingual `<book-name>.zh.epub` under the source file's `output/` directory (`.docx` inputs default to `<book-name>.zh.docx` instead). The bilingual `*.zh-bi.*` edition is optional.
-- `--format epub|txt|html|markdown|pdf|docx`: export the selected format for book inputs. When omitted, `.docx` → `docx` and other books → `epub`. This flag does not apply to SRT.
+- Default book output: a monolingual `<book-name>.zh.epub` under the source file's `output/` directory (`.docx` inputs default to `<book-name>.zh.docx`, and BabelDOC PDF state defaults to `<book-name>.zh.pdf`). The bilingual `*.zh-bi.*` edition is optional.
+- `--format epub|txt|html|markdown|pdf|docx`: export the selected format for book inputs. When omitted, BabelDOC PDF state → `pdf`, `.docx` → `docx`, and other books (including MinerU PDF state) → `epub`. An explicit format always takes precedence; PDF defaults follow the saved backend, even if the current `pdf_backend` setting has changed. This flag does not apply to SRT.
 - For EPUB input, Wenyi attempts to write translated text back into the original XHTML templates while preserving styles, images, the table of contents, and anchors.
 - The bilingual edition displays the translation and source text together. The source is visually subdued by default; set `output.bilingual_preserve_source_style: true` to inherit the book's normal text style. Their order is controlled by `output.bilingual_order`.
 - EPUB output includes an “About this translation” page by default. Set `output.about_page: false` to disable it.
@@ -127,7 +127,7 @@ pipeline:
   # babeldoc_pages: "15"   # optional, 1-based
 ```
 
-3. After `translate book.pdf`, `assemble --format pdf` calls bridge `/fillback`.
+3. `translate book.pdf` automatically exports PDF through bridge `/fillback`. Later, `assemble book.pdf` also defaults to PDF for that saved BabelDOC state; `--format pdf` is optional. Use an explicit `--format` to select another format.
    The fillback PDF omits BabelDOC layout overlay boxes and role labels
    such as ``plain text`` / ``title`` by default.
    The bridge freezes the post-extraction IL as a durable session snapshot. It can

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -225,7 +225,7 @@ pipeline:
 - `review_clean_confirmations`：开启影子 Fix 后，需要连续无问题的全书 Review 次数，范围为 `1` 到 `2`，默认 `2`。
 - `review_autofix`：默认开启。只读 Review 引擎结束后，先把折叠后的 `changes` 叠加到工作译文，再让每段剩余 issue 基于更新后的译文复用现有有界 Review Agent Loop，确认项继续交给现有 Review Fixer。可用 `--no-autofix` 或设为 `false`，避免写回正式 `target`。生成的完整单段译文只覆盖正式章节的 `target`，不修改 manifest 和术语库。完整前后版本链、issue ID、判定、失败原因和写回状态保存在本次 Review 的 `autofix/index.json`，不会给章节 JSON 新增历史字段。
 - `glossary_scope`：`chapter` 仅带本章相关术语，`full` 带全量术语表。
-- `pdf_backend`：默认 `mineru`，经 MinerU 转 HTML。需要尽量保留版式时改用 `babeldoc`（外部 AGPL HTTP bridge）。
+- `pdf_backend`：默认 `mineru`，经 MinerU 转 HTML。需要尽量保留版式时改用 `babeldoc`（外部 AGPL HTTP bridge）。经 BabelDOC 创建的 PDF 状态，在 `translate` 和 `assemble` 中均默认导出 PDF；MinerU 状态仍默认导出 EPUB。显式 `--format` 优先，续跑默认格式以已保存的后端为准。
 - `babeldoc_bridge_url`：BabelDOC bridge 地址，默认 `http://127.0.0.1:8765`。
 - `babeldoc_timeout`：bridge extract / fillback 的 HTTP 超时秒数。
 - `babeldoc_pages`：可选的 1-based 页码，如 `"15"` 或 `"6-8"`；省略则处理全书。
@@ -252,8 +252,8 @@ output:
   punctuation_normalize: true
 ```
 
-- `mono`：生成单语译本，文件名为 `<书名>.<目标语言>.epub`（默认 `.zh.epub`）。
-- `bilingual`：生成原文与译文对照版，文件名为 `<书名>.<目标语言>-bi.epub`。
+- `mono`：生成单语译本，文件名为 `<书名>.<目标语言>.<扩展名>`（通常为 `.zh.epub`，BabelDOC PDF 状态为 `.zh.pdf`，DOCX 输入为 `.zh.docx`）。
+- `bilingual`：请求原文与译文对照版，文件名为 `<书名>.<目标语言>-bi.<扩展名>`，使用与单语输出相同的选定格式。
 - `bilingual_order`：`target_first` 表示译文在上，`source_first` 表示原文在上。
 - `bilingual_preserve_source_style`：设为 `true` 时，原文继承书籍正文样式，不使用灰色淡化背景；仅影响 EPUB 和 HTML。
 - `about_page`：在书籍末尾附加“关于此翻译”项目说明页；设为 `false` 可关闭。

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -100,8 +100,8 @@ notarization。macOS 仍可能隔离下载的程序；确认校验和无误后�
 ## 输入与输出
 
 - 输入格式：EPUB、FB2、TXT、Markdown、HTML、PDF、DOCX、SRT。
-- 书籍默认输出：源文件旁 `output/` 下的单语版 `<书名>.zh.epub`（`.docx` 输入默认改为 `<书名>.zh.docx`）；双语版 `*.zh-bi.*` 按需开启。
-- `--format epub|txt|html|markdown|pdf|docx`：书籍导出格式；未指定时 `.docx`→`docx`，其它书籍→`epub`。该选项不适用于 SRT。
+- 书籍默认输出：源文件旁 `output/` 下的单语版 `<书名>.zh.epub`（`.docx` 输入默认为 `<书名>.zh.docx`，BabelDOC PDF 状态默认为 `<书名>.zh.pdf`）；双语版 `*.zh-bi.*` 按需开启。
+- `--format epub|txt|html|markdown|pdf|docx`：书籍导出格式；未指定时 BabelDOC PDF 状态→`pdf`，`.docx`→`docx`，其它书籍（含 MinerU PDF 状态）→`epub`。显式格式始终优先；PDF 默认格式依据已保存的后端信息，即使当前 `pdf_backend` 配置改变也不会改用另一套默认值。该选项不适用于 SRT。
 - EPUB 输入会尽量按原 XHTML 模板回填译文，保留样式、图片、目录和锚点。
 - 双语版按段展示译文与原文，原文默认淡化；设置 `output.bilingual_preserve_source_style: true` 可改为继承书籍正文样式。排列顺序由 `output.bilingual_order` 控制。
 - EPUB 默认在书末附加“关于此翻译”说明，可通过 `output.about_page: false` 关闭。
@@ -125,7 +125,7 @@ pipeline:
   # babeldoc_pages: "15"   # 可选，1-based
 ```
 
-3. `uv run trans-novel translate book.pdf` 后 `assemble --format pdf` 会经 bridge `/fillback` 出 PDF。  
+3. `uv run trans-novel translate book.pdf` 会自动经 bridge `/fillback` 导出 PDF。之后执行 `assemble book.pdf` 也会根据已保存的 BabelDOC 状态默认导出 PDF，无需指定 `--format pdf`；需要其它格式时显式指定 `--format`。
    回填 PDF 默认不绘制 BabelDOC 的版面定位框，也不输出 plain text / title 等角色标签。  
    bridge 会把抽取后的原始 IL 冻结为持久 session 快照；只要保留 session 目录并使用完全
    相同的 Python/BabelDOC 版本，服务重启后可按原 session ID 懒恢复，不会重跑版面识别。

--- a/tests/test_pdf_export_defaults.py
+++ b/tests/test_pdf_export_defaults.py
@@ -1,0 +1,196 @@
+"""Default PDF export follows persisted BabelDOC metadata and snapshot boundaries."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tests.fake_llm import routing_handler
+from trans_novel.assemble.writer import assemble
+from trans_novel.cli import app
+from trans_novel.config import Config
+from trans_novel.ingest.models import Chapter, Document, Segment
+from trans_novel.llm.providers.fake import FakeClient
+from trans_novel.pipeline.orchestrator import Orchestrator
+from trans_novel.pipeline.runstore import RunStore
+
+
+@pytest.fixture
+def pdf_project(tmp_path, monkeypatch):
+    source = tmp_path / "book.PDF"
+    source.write_bytes(b"%PDF-1.4 offline fixture")
+    config = Config.from_dict(
+        {
+            "language": {"source": "en", "target": "zh"},
+            "llm": {"preset": "fake"},
+            "pipeline": {
+                "pdf_backend": "babeldoc",
+                "book_understanding": False,
+                "polish": False,
+                "review": False,
+                "annotation_alignment": False,
+            },
+            "paths": {"state_dir": str(tmp_path / "state")},
+        }
+    )
+    document = Document(
+        title="book",
+        source_lang="en",
+        target_lang="zh",
+        source_path=str(source),
+        fmt="pdf",
+        meta={
+            "babeldoc": True,
+            "pdf_export": "babeldoc",
+            "babeldoc_session_id": "offline-session",
+            "babeldoc_bridge_url": "http://bridge.invalid",
+        },
+        chapters=[
+            Chapter(
+                index=0,
+                title="Chapter one",
+                # Supply a template so explicit EPUB overrides can use the existing renderer.
+                template='<html><body><p data-tn-id="p0">A short source.</p></body></html>',
+                segments=[
+                    Segment(
+                        index=0,
+                        source="A short source.",
+                        anchor="p0",
+                        meta={"babeldoc_id": "0:0"},
+                    )
+                ],
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "trans_novel.pipeline.preparation.load_document",
+        lambda *a, **kw: document.model_copy(deep=True),
+    )
+    monkeypatch.setattr("trans_novel.cli._load_config", lambda: config)
+    monkeypatch.setattr(
+        "trans_novel.pipeline.runtime.build_client",
+        lambda cfg: FakeClient(handler=routing_handler, config=cfg.llm),
+    )
+    requests = []
+
+    def fillback(self, session_id, translations, *, out_path):
+        requests.append((session_id, dict(translations), out_path))
+        Path(out_path).write_bytes(b"%PDF-1.4 offline fillback")
+        return str(out_path)
+
+    monkeypatch.setattr("trans_novel.pdf_bridge.BabeldocBridgeClient.fillback", fillback)
+    return config, source, requests
+
+
+@pytest.mark.parametrize("command", ["translate", "assemble"])
+@pytest.mark.parametrize(
+    "mono,bilingual,explicit_out",
+    [(True, False, False), (False, True, False), (True, True, False), (True, True, True)],
+)
+def test_cli_defaults_to_pdf_for_mono_and_bilingual_outputs(
+    pdf_project, tmp_path, command, mono, bilingual, explicit_out
+):
+    config, source, requests = pdf_project
+    config.output.mono = mono
+    config.output.bilingual = bilingual
+    if command == "assemble":
+        Orchestrator(config).run(str(source))
+    arguments = [command, str(source)]
+    if explicit_out:
+        arguments += ["--out", str(tmp_path / "custom" / "result.pdf")]
+
+    result = CliRunner().invoke(app, arguments)
+
+    assert result.exit_code == 0, result.output
+    if explicit_out:
+        expected = [tmp_path / "custom" / "result.pdf", tmp_path / "custom" / "result-bi.pdf"]
+    else:
+        expected = []
+        if mono:
+            expected.append(tmp_path / "output" / "book.zh.pdf")
+        if bilingual:
+            expected.append(tmp_path / "output" / "book.zh-bi.pdf")
+    assert [Path(request[2]) for request in requests] == expected
+    assert all(path.read_bytes().startswith(b"%PDF-") for path in expected)
+    assert all(request[:2] == ("offline-session", {"0:0": "译0"}) for request in requests)
+
+
+@pytest.mark.parametrize("command", ["translate", "assemble"])
+@pytest.mark.parametrize("fmt", ["epub", "txt"])
+def test_explicit_format_overrides_babeldoc_default(pdf_project, command, fmt):
+    config, source, requests = pdf_project
+    if command == "assemble":
+        Orchestrator(config).run(str(source))
+
+    result = CliRunner().invoke(app, [command, str(source), "--format", fmt])
+
+    assert result.exit_code == 0, result.output
+    assert (source.parent / "output" / f"book.zh.{fmt}").is_file()
+    assert requests == []
+
+
+def test_chapter_only_translation_does_not_treat_pdf_default_as_explicit_format(pdf_project):
+    _, source, requests = pdf_project
+    result = CliRunner().invoke(app, ["translate", str(source), "--chapter", "0"])
+    assert result.exit_code == 0, result.output
+    assert requests == []
+    assert not (source.parent / "output").exists()
+
+
+def test_saved_babeldoc_state_defaults_to_pdf_after_config_switches_to_mineru(pdf_project):
+    config, source, requests = pdf_project
+    Orchestrator(config).run(str(source))
+    config.pipeline.pdf_backend = "mineru"
+
+    result = CliRunner().invoke(app, ["assemble", str(source)])
+
+    assert result.exit_code == 0, result.output
+    assert len(requests) == 1
+    assert Path(requests[0][2]).suffix == ".pdf"
+
+
+def test_saved_non_babeldoc_pdf_still_defaults_to_epub(pdf_project):
+    config, source, requests = pdf_project
+    store = Orchestrator(config).run(str(source))
+    manifest = store.load_manifest()
+    manifest["meta"] = {"mineru": True}
+    store.save_manifest(manifest)
+
+    result = CliRunner().invoke(app, ["assemble", str(source)])
+
+    assert result.exit_code == 0, result.output
+    assert (source.parent / "output" / "book.zh.epub").is_file()
+    assert requests == []
+
+
+def test_direct_writer_and_whole_workflow_share_babeldoc_default(pdf_project):
+    config, source, requests = pdf_project
+    result = Orchestrator(config).run_all(str(source))
+    assert result["outputs"] == [str(source.parent / "output" / "book.zh.pdf")]
+    output = assemble(result["store"], str(source))
+    assert output == result["outputs"][0]
+    assert len(requests) == 2
+
+
+def test_default_format_and_targets_come_from_the_same_export_snapshot(pdf_project, monkeypatch):
+    config, source, requests = pdf_project
+    store = Orchestrator(config).run(str(source))
+    create_snapshot = RunStore.create_export_snapshot
+
+    def change_live_state_after_snapshot(self, **kwargs):
+        snapshot = create_snapshot(self, **kwargs)
+        with store.lock():
+            manifest = store.load_manifest()
+            manifest["meta"] = {"mineru": True}
+            chapter = store.load_chapter(0)
+            chapter.segments[0].target = "Later live translation"
+            store.save_chapter(chapter)
+            store.save_manifest(manifest)
+        return snapshot
+
+    monkeypatch.setattr(RunStore, "create_export_snapshot", change_live_state_after_snapshot)
+    result = Orchestrator(config).run_assemble(str(source))
+
+    assert result["outputs"] == [str(source.parent / "output" / "book.zh.pdf")]
+    assert requests[0][1] == {"0:0": "译0"}
+    assert store.load_chapter(0).segments[0].target == "Later live translation"

--- a/trans_novel/assemble/writer.py
+++ b/trans_novel/assemble/writer.py
@@ -24,6 +24,7 @@ from .writer_common import (
     _ensure_parent_dir,
     _epub_lang,
     _manifest_target_lang,
+    default_output_format,
 )
 
 __all__ = ["assemble"]
@@ -33,7 +34,7 @@ def assemble(
     store: RunStore,
     source_path: str,
     out_path: str | None = None,
-    out_format: str = "epub",
+    out_format: str | None = None,
     *,
     bilingual: bool = False,
     order: str = "target_first",
@@ -43,7 +44,7 @@ def assemble(
     babeldoc_timeout: float = 600.0,
     punctuation_normalize: bool = False,
 ) -> str:
-    """Generate translated output, defaulting to EPUB.
+    """Generate translated output, defaulting to PDF for BabelDOC state and EPUB otherwise.
     EPUB input reuses the original layout and resources; template-free input produces a
     standard EPUB with headings and paragraphs. TXT and Markdown rebuild chapters. HTML
     prefers source templates and otherwise rebuilds chapters. PDF renders print HTML with
@@ -52,12 +53,14 @@ def assemble(
     reuses original styles instead of muted CSS. about_page appends the translation about
     page. punctuation_normalize changes only export copies, never chapter target state.
     """
-    if out_format not in _OUT_EXT:
+    if out_format is not None and out_format not in _OUT_EXT:
         supported = " / ".join(_OUT_EXT)
         raise ValueError(f"Unsupported output format: {out_format} (supported: {supported})")
 
     store = ExportViewStore(store, punctuation_normalize=punctuation_normalize)
     m = store.load_manifest()
+    if out_format is None:
+        out_format = default_output_format(m)
     target_lang = _manifest_target_lang(m)
     if out_format == "txt":
         out_path = out_path or _default_out(

--- a/trans_novel/assemble/writer_common.py
+++ b/trans_novel/assemble/writer_common.py
@@ -20,6 +20,15 @@ _OUT_EXT = {
 }
 
 
+def default_output_format(manifest: dict) -> str:
+    """Select the export format from the backend recorded in the same state snapshot."""
+    raw_meta = manifest.get("meta")
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
+    if meta.get("pdf_export") == "babeldoc" or meta.get("babeldoc"):
+        return "pdf"
+    return "epub"
+
+
 def _sanitize_filename(name: str, fallback: str = "translated") -> str:
     """Remove characters invalid in cross-platform filenames and limit name length."""
     name = _ILLEGAL_FN.sub(" ", name or "").strip().strip(".")

--- a/trans_novel/cli.py
+++ b/trans_novel/cli.py
@@ -247,10 +247,12 @@ def _validate_output_format(fmt: str) -> str:
     return normalized
 
 
-def _resolve_output_format(input_path: str, fmt: str | None) -> str:
-    """Default to DOCX for .docx input and EPUB otherwise when --format is absent."""
+def _resolve_output_format(input_path: str, fmt: str | None) -> str | None:
+    """Defer PDF defaults to saved backend metadata; keep DOCX and EPUB defaults."""
     if fmt is not None and str(fmt).strip():
         return _validate_output_format(str(fmt))
+    if os.path.splitext(input_path)[1].lower() == ".pdf":
+        return None
     if os.path.splitext(input_path)[1].lower() == ".docx":
         return "docx"
     return "epub"
@@ -422,7 +424,7 @@ def _translate_impl_or_raise(
         config.output.bilingual = bilingual
     if chapter is not None:
         ignored: list[str] = []
-        if fmt != "epub":
+        if fmt not in {None, "epub"}:
             ignored.append("--format")
         if out is not None:
             ignored.append("--out")
@@ -590,7 +592,7 @@ def translate(
     fmt: str | None = typer.Option(
         None,
         "--format",
-        help="Output format: epub / txt / html / markdown / pdf / docx; default: docx for .docx input, epub otherwise",
+        help="Output format: epub / txt / html / markdown / pdf / docx; default: pdf for BabelDOC PDF state, docx for .docx input, epub otherwise",
     ),
     out: str | None = typer.Option(
         None,
@@ -841,7 +843,7 @@ def assemble(
     fmt: str | None = typer.Option(
         None,
         "--format",
-        help="Output format: epub / txt / html / markdown / pdf / docx; default: docx for .docx input, epub otherwise",
+        help="Output format: epub / txt / html / markdown / pdf / docx; default: pdf for BabelDOC PDF state, docx for .docx input, epub otherwise",
     ),
     pdf_engine: str = typer.Option(
         "weasyprint",

--- a/trans_novel/pipeline/finalization.py
+++ b/trans_novel/pipeline/finalization.py
@@ -126,16 +126,20 @@ class AssemblyService:
         *,
         input_path: str,
         progress: ProgressFn | None,
-        out_format: str,
+        out_format: str | None,
         out_path: str | None,
         pdf_engine: str,
     ) -> list[str]:
         """Export under the book run lock, adding the assembly lock to serialize output
         writers.
         """
+        from ..assemble.writer_common import default_output_format
+
         with store.assemble_lock():
             # Export rereads the source template; validate before and after to detect replacement during the run.
             self._runtime.ensure_store_source(store, input_path)
+            if out_format is None:
+                out_format = default_output_format(store.load_manifest())
             outputs = self.assemble_outputs(
                 store,
                 input_path=input_path,
@@ -154,16 +158,20 @@ class AssemblyService:
         *,
         input_path: str,
         progress: ProgressFn | None,
-        out_format: str,
+        out_format: str | None,
         out_path: str | None,
         pdf_engine: str,
     ) -> list[str]:
         """Capture an immutable snapshot under the assembly lock and validate source hashes
         around rendering.
         """
+        from ..assemble.writer_common import default_output_format
+
         with store.assemble_lock():
             snapshot = store.create_export_snapshot(actual_sha256=source_sha256(input_path))
             self._runtime.apply_manifest_languages(snapshot.load_manifest())
+            if out_format is None:
+                out_format = default_output_format(snapshot.load_manifest())
 
             # The source may change while waiting for another export; validate again immediately before rendering.
             self._runtime.ensure_store_source(store, input_path)

--- a/trans_novel/pipeline/orchestrator.py
+++ b/trans_novel/pipeline/orchestrator.py
@@ -168,7 +168,7 @@ class Orchestrator:
         steps: set[str],
         *,
         progress: ProgressFn | None,
-        out_format: str = "epub",
+        out_format: str | None = None,
         out_path: str | None = None,
         pdf_engine: str = "weasyprint",
     ) -> dict[str, Any]:
@@ -204,7 +204,7 @@ class Orchestrator:
         self,
         input_path: str,
         *,
-        out_format: str = "epub",
+        out_format: str | None = None,
         out_path: str | None = None,
         pdf_engine: str = "weasyprint",
         progress: ProgressFn | None = None,
@@ -245,7 +245,7 @@ class Orchestrator:
         steps,
         *,
         progress: ProgressFn | None = None,
-        out_format: str = "epub",
+        out_format: str | None = None,
         out_path: str | None = None,
         pdf_engine: str = "weasyprint",
     ) -> dict[str, Any]:
@@ -298,7 +298,7 @@ class Orchestrator:
         steps: set[str],
         run_steps_input: list[str],
         progress: ProgressFn | None,
-        out_format: str,
+        out_format: str | None,
         out_path: str | None,
         pdf_engine: str,
     ) -> dict[str, Any]:
@@ -378,7 +378,7 @@ class Orchestrator:
         input_path: str,
         *,
         progress: ProgressFn | None = None,
-        out_format: str = "epub",
+        out_format: str | None = None,
         out_path: str | None = None,
         pdf_engine: str = "weasyprint",
     ) -> dict[str, Any]:


### PR DESCRIPTION
Choose pdf from saved BabelDOC metadata when --format is omitted for translate and assemble, keep MinerU and other books on EPUB, and honor explicit formats. Document the snapshot-based default in bilingual usage and configuration notes.