### PR TITLE
Fix models compare crash on invalid roles and pin routing/interrupt test contracts

### DIFF
--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import json
 import re
 
+from trans_novel.llm.providers.fake import FakeClient
+from trans_novel.llm.usage import UsageSample
+
+METERED_TOTAL_TOKENS = 8  # prompt 5 + completion 3, recorded by MeteredFakeClient per call.
+
 
 def _count_numbered(text: str) -> int:
     return len(re.findall(r"^\[(\d+)\]", text, re.MULTILINE))
@@ -65,3 +70,32 @@ def routing_handler(messages, tier, json_mode):
         return "全书概览：主线与人物关系，整体基调。"
 
     return "{}" if json_mode else ""
+
+
+class MeteredFakeClient(FakeClient):
+    """Record fixed small usage per offline call so tests can assert stage-level accounting."""
+
+    def complete(
+        self,
+        messages,
+        *,
+        operation,
+        json_mode=False,
+        max_tokens=None,
+    ):
+        self.usage.record(
+            self.routes[operation].tier or "direct",
+            UsageSample(
+                prompt_tokens=5,
+                completion_tokens=3,
+                total_tokens=8,
+                cache_miss_tokens=5,
+            ),
+            operation,
+        )
+        return super().complete(
+            messages,
+            operation=operation,
+            json_mode=json_mode,
+            max_tokens=max_tokens,
+        )

--- a/tests/test_llm_routing.py
+++ b/tests/test_llm_routing.py
@@ -266,14 +266,22 @@ def test_router_freezes_original_config_and_direct_selection(monkeypatch):
         client.complete([], operation="translation.typo")
 
 
-def test_dynamic_output_hint_respects_explicit_profile_cap():
+def test_dynamic_output_hint_respects_explicit_profile_cap(monkeypatch):
     client = RoutedLLMClient(_graph())
     observed = []
     client.set_event_sink(
         lambda event, **data: observed.append(data) if event == "llm_request_started" else None
     )
+    requested = []
+
+    def request(self, messages, model, *, json_mode, context):
+        requested.append(context.max_tokens)
+        return "ok"
+
+    monkeypatch.setattr(FakeProvider, "_request", request)
     client.complete([], operation="annotation.align", max_tokens=999)
     assert client.routes["annotation.align"].max_output_tokens == 256
+    assert requested == [256]
     config = Config.from_dict({"llm": {"preset": "deepseek"}})
     assert resolve_routes(config.llm)["synopsis.chapter"].max_output_tokens == 4096
     with pytest.raises(ValueError, match="Thinking mode"):
@@ -341,6 +349,28 @@ def test_only_explicit_stateless_failover_is_used(monkeypatch):
     calls.clear()
     with pytest.raises(TimeoutError):
         client.complete([], operation="polish.body")
+    assert calls == ["first"]
+
+
+class _ProviderDeniedError(Exception):
+    status_code = 401
+
+
+@pytest.mark.parametrize(
+    "error", [_ProviderDeniedError, ValueError], ids=["http-401", "local-value-error"]
+)
+def test_non_retryable_errors_neither_retry_nor_fail_over(monkeypatch, error):
+    config = _graph(routes={"translation.body": {"model": "one", "fallbacks": ["two"]}})
+    client = RoutedLLMClient(config)
+    calls = []
+
+    def request(self, messages, model, **kw):
+        calls.append(model.model)
+        raise error("denied")
+
+    monkeypatch.setattr(FakeProvider, "_request", request)
+    with pytest.raises(error):
+        client.complete([], operation="translation.body")
     assert calls == ["first"]
 
 

--- a/tests/test_llm_routing.py
+++ b/tests/test_llm_routing.py
@@ -268,10 +268,6 @@ def test_router_freezes_original_config_and_direct_selection(monkeypatch):
 
 def test_dynamic_output_hint_respects_explicit_profile_cap(monkeypatch):
     client = RoutedLLMClient(_graph())
-    observed = []
-    client.set_event_sink(
-        lambda event, **data: observed.append(data) if event == "llm_request_started" else None
-    )
     requested = []
 
     def request(self, messages, model, *, json_mode, context):

--- a/tests/test_model_commands.py
+++ b/tests/test_model_commands.py
@@ -150,3 +150,27 @@ def test_comparison_records_each_model_and_its_usage(tmp_path, monkeypatch):
     assert [row["output"] for row in report["results"]] == ["model-one", "model-two"]
     assert report["usage"]["totals"]["total_tokens"] == 14
     assert all(row["usage"]["totals"]["calls"] == 1 for row in report["results"])
+
+
+@pytest.mark.parametrize("role", [[], {"role": "user"}, None, 1, ("user",)])
+def test_comparison_rejects_non_string_roles_before_crashing(tmp_path, role):
+    prompts = tmp_path / "messages.json"
+    prompts.write_text(json.dumps([{"role": role, "content": "A short public test fixture."}]))
+    output = tmp_path / "comparison.json"
+    result = _invoke(
+        tmp_path,
+        {"llm": {"preset": "fake"}},
+        "compare",
+        "--operation",
+        "translation.body",
+        "--model",
+        "default",
+        "--messages",
+        str(prompts),
+        "--out",
+        str(output),
+    )
+    assert result.exit_code == 1
+    assert "Messages must be a nonempty array of role/content objects" in result.output
+    assert "Traceback" not in result.output
+    assert not output.exists()

--- a/tests/test_model_commands.py
+++ b/tests/test_model_commands.py
@@ -152,10 +152,9 @@ def test_comparison_records_each_model_and_its_usage(tmp_path, monkeypatch):
     assert all(row["usage"]["totals"]["calls"] == 1 for row in report["results"])
 
 
-@pytest.mark.parametrize("role", [[], {"role": "user"}, None, 1, ("user",)])
-def test_comparison_rejects_non_string_roles_before_crashing(tmp_path, role):
+def test_comparison_rejects_non_string_roles_before_crashing(tmp_path):
     prompts = tmp_path / "messages.json"
-    prompts.write_text(json.dumps([{"role": role, "content": "A short public test fixture."}]))
+    prompts.write_text(json.dumps([{"role": [], "content": "A short public test fixture."}]))
     output = tmp_path / "comparison.json"
     result = _invoke(
         tmp_path,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from tests.fake_llm import routing_handler
+from tests.fake_llm import MeteredFakeClient, routing_handler
 from tests.sample_data import write_sample_epub, write_sample_txt
 from trans_novel.agents.reviewer import ReviewOutputError
 from trans_novel.config import Config
@@ -96,35 +96,6 @@ def _config(state_dir: str):
             "paths": {"state_dir": state_dir},
         }
     )
-
-
-class MeteredFakeClient(FakeClient):
-    """Record small usage per offline call to verify review accounting isolation."""
-
-    def complete(
-        self,
-        messages,
-        *,
-        operation,
-        json_mode=False,
-        max_tokens=None,
-    ):
-        self.usage.record(
-            self.routes[operation].tier or "direct",
-            UsageSample(
-                prompt_tokens=5,
-                completion_tokens=3,
-                total_tokens=8,
-                cache_miss_tokens=5,
-            ),
-            operation,
-        )
-        return super().complete(
-            messages,
-            operation=operation,
-            json_mode=json_mode,
-            max_tokens=max_tokens,
-        )
 
 
 class TestOrchestrator(unittest.TestCase):
@@ -1793,7 +1764,7 @@ class TestReviewReporting(unittest.TestCase):
             review_dir = os.path.join(store.reviews_dir, sorted(os.listdir(store.reviews_dir))[-1])
             run1_review_calls = len(client1.calls) - translated_calls
             # The interrupted call still reached the transport and must be billed once.
-            self.assertGreaterEqual(run1_review_calls, 2)
+            self.assertEqual(run1_review_calls, 3)
             with open(os.path.join(review_dir, "usage.json"), encoding="utf-8") as file:
                 interrupted_usage = json.load(file)
             self.assertEqual(interrupted_usage["totals"]["calls"], run1_review_calls)
@@ -1817,7 +1788,6 @@ class TestReviewReporting(unittest.TestCase):
                 run1_review_calls + run2_review_calls,
             )
             book_usage = store.load_usage()
-            self.assertIsNotNone(book_usage)
             assert book_usage is not None
             self.assertEqual(
                 book_usage["totals"]["calls"],

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1753,6 +1753,77 @@ class TestReviewReporting(unittest.TestCase):
             self.assertEqual((store.load_usage() or {})["by_stage"]["review.scan"]["calls"], 1)
             self.assertEqual(client.usage_summary()["by_stage"]["review.scan"]["calls"], 1)
 
+    def test_review_interrupt_saves_usage_and_resumes_without_recounting(self):
+        """A KeyboardInterrupt after one completed reviewer response must flush the review
+        usage ledger and review_interrupted event, and a fresh orchestrator must resume
+        the same run dir without counting any call twice.
+        """
+
+        def interrupting_handler(messages, tier, json_mode):
+            if "translation reviewer" in messages[0]["content"]:
+                if reviewer_calls:
+                    raise KeyboardInterrupt
+                reviewer_calls.append("answered")
+                return _review_json(
+                    messages[-1]["content"],
+                    [
+                        {
+                            "index": 0,
+                            "type": "missing",
+                            "detail": "漏了一句",
+                            "suggestion": "补上",
+                        }
+                    ],
+                )
+            return routing_handler(messages, tier, json_mode)
+
+        reviewer_calls: list[str] = []
+        with tempfile.TemporaryDirectory() as d:
+            txt = os.path.join(d, "novel.txt")
+            write_sample_txt(txt)
+            cfg = _config(os.path.join(d, "state"))
+            client1 = MeteredFakeClient(handler=interrupting_handler)
+            orch1 = Orchestrator(cfg, client=client1)
+            store = orch1.run(txt)
+            translated_calls = len(client1.calls)
+
+            with self.assertRaises(KeyboardInterrupt):
+                orch1.run_review(txt)
+
+            review_dir = os.path.join(store.reviews_dir, sorted(os.listdir(store.reviews_dir))[-1])
+            run1_review_calls = len(client1.calls) - translated_calls
+            # The interrupted call still reached the transport and must be billed once.
+            self.assertGreaterEqual(run1_review_calls, 2)
+            with open(os.path.join(review_dir, "usage.json"), encoding="utf-8") as file:
+                interrupted_usage = json.load(file)
+            self.assertEqual(interrupted_usage["totals"]["calls"], run1_review_calls)
+            with open(os.path.join(review_dir, "events.jsonl"), encoding="utf-8") as file:
+                events = [json.loads(line)["event"] for line in file if line.strip()]
+            self.assertIn("review_interrupted", events)
+
+            client2 = MeteredFakeClient(handler=self._handler())
+            result = Orchestrator(cfg, client=client2).run_review(txt)
+
+            self.assertEqual(result["review_dir"], review_dir)
+            self.assertEqual(result["review_result"]["status"], "completed")
+            with open(os.path.join(review_dir, "events.jsonl"), encoding="utf-8") as file:
+                events = [json.loads(line)["event"] for line in file if line.strip()]
+            self.assertIn("review_resumed_from_checkpoint", events)
+            run2_review_calls = sum(call["stage"].startswith("review.") for call in client2.calls)
+            with open(os.path.join(review_dir, "usage.json"), encoding="utf-8") as file:
+                resumed_usage = json.load(file)
+            self.assertEqual(
+                resumed_usage["totals"]["calls"],
+                run1_review_calls + run2_review_calls,
+            )
+            book_usage = store.load_usage()
+            self.assertIsNotNone(book_usage)
+            assert book_usage is not None
+            self.assertEqual(
+                book_usage["totals"]["calls"],
+                len(client1.calls) + len(client2.calls),
+            )
+
     def test_run_steps_records_review_usage_on_success_and_failure(self):
         """Combined workflows persist pre-review and review usage at their respective stage
         boundaries.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1762,9 +1762,17 @@ class TestReviewReporting(unittest.TestCase):
                 orch1.run_review(txt)
 
             review_dir = os.path.join(store.reviews_dir, sorted(os.listdir(store.reviews_dir))[-1])
-            run1_review_calls = len(client1.calls) - translated_calls
-            # The interrupted call still reached the transport and must be billed once.
-            self.assertEqual(run1_review_calls, 3)
+            run1_review_stages = [
+                call["stage"]
+                for call in client1.calls[translated_calls:]
+                if call["stage"].startswith("review.")
+            ]
+            # scan issue → verify → second scan (KeyboardInterrupt after transport billed it).
+            self.assertEqual(
+                run1_review_stages,
+                ["review.scan", "review.verify", "review.scan"],
+            )
+            run1_review_calls = len(run1_review_stages)
             with open(os.path.join(review_dir, "usage.json"), encoding="utf-8") as file:
                 interrupted_usage = json.load(file)
             self.assertEqual(interrupted_usage["totals"]["calls"], run1_review_calls)

--- a/tests/test_review_autofix.py
+++ b/tests/test_review_autofix.py
@@ -9,10 +9,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock
 
+from tests.fake_llm import METERED_TOTAL_TOKENS, MeteredFakeClient
 from trans_novel.config import Config
 from trans_novel.ingest.models import Chapter, Segment
 from trans_novel.llm.providers.fake import FakeClient
-from trans_novel.llm.usage import UsageSample
 from trans_novel.pipeline.orchestrator import Orchestrator
 from trans_novel.pipeline.runstore import STATUS_DONE, RunStore
 from trans_novel.review.run_store import ReviewOutcome, ReviewRunStore
@@ -126,30 +126,6 @@ def _fix_json(user: str, replacement: str) -> str:
         },
         ensure_ascii=False,
     )
-
-
-class MeteredFakeClient(FakeClient):
-    """Record small usage per offline call to verify autofix accounting across interruptions."""
-
-    def complete(
-        self,
-        messages,
-        *,
-        operation,
-        json_mode=False,
-        max_tokens=None,
-    ):
-        self.usage.record(
-            self.routes[operation].tier or "direct",
-            UsageSample(prompt_tokens=5, completion_tokens=3, total_tokens=8),
-            operation,
-        )
-        return super().complete(
-            messages,
-            operation=operation,
-            json_mode=json_mode,
-            max_tokens=max_tokens,
-        )
 
 
 class TestReviewAutofix(unittest.TestCase):
@@ -443,11 +419,9 @@ class TestReviewAutofix(unittest.TestCase):
             self.assertFalse(Path(outcome.run_dir, "autofix/index.json").exists())
             debug = ReviewRunStore.open_existing(outcome.run_dir)
             interrupted_usage = debug.load_usage()
-            self.assertIsNotNone(interrupted_usage)
             assert interrupted_usage is not None
             self.assertEqual(interrupted_usage["totals"]["calls"], 2)
             book_usage = store.load_usage()
-            self.assertIsNotNone(book_usage)
             assert book_usage is not None
             self.assertEqual(book_usage["totals"]["calls"], 2)
 
@@ -462,12 +436,10 @@ class TestReviewAutofix(unittest.TestCase):
             # The finished agent trace is reused; only the interrupted fixer is retried.
             self.assertEqual(fixer_calls, 2)
             resumed_usage = debug.load_usage()
-            self.assertIsNotNone(resumed_usage)
             assert resumed_usage is not None
             self.assertEqual(resumed_usage["totals"]["calls"], 3)
-            self.assertEqual(resumed_usage["totals"]["total_tokens"], 24)
+            self.assertEqual(resumed_usage["totals"]["total_tokens"], 3 * METERED_TOTAL_TOKENS)
             book_usage = store.load_usage()
-            self.assertIsNotNone(book_usage)
             assert book_usage is not None
             self.assertEqual(book_usage["totals"]["calls"], 3)
 

--- a/tests/test_review_autofix.py
+++ b/tests/test_review_autofix.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 from trans_novel.config import Config
 from trans_novel.ingest.models import Chapter, Segment
 from trans_novel.llm.providers.fake import FakeClient
+from trans_novel.llm.usage import UsageSample
 from trans_novel.pipeline.orchestrator import Orchestrator
 from trans_novel.pipeline.runstore import STATUS_DONE, RunStore
 from trans_novel.review.run_store import ReviewOutcome, ReviewRunStore
@@ -125,6 +126,30 @@ def _fix_json(user: str, replacement: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+class MeteredFakeClient(FakeClient):
+    """Record small usage per offline call to verify autofix accounting across interruptions."""
+
+    def complete(
+        self,
+        messages,
+        *,
+        operation,
+        json_mode=False,
+        max_tokens=None,
+    ):
+        self.usage.record(
+            self.routes[operation].tier or "direct",
+            UsageSample(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+            operation,
+        )
+        return super().complete(
+            messages,
+            operation=operation,
+            json_mode=json_mode,
+            max_tokens=max_tokens,
+        )
 
 
 class TestReviewAutofix(unittest.TestCase):
@@ -365,6 +390,86 @@ class TestReviewAutofix(unittest.TestCase):
             saved_index = debug.load_json("autofix/index.json")
             assert isinstance(saved_index, dict)
             self.assertEqual(saved_index["status"], "completed")
+
+    def test_interrupt_flushes_usage_and_resume_does_not_recount(self):
+        """A KeyboardInterrupt inside the autofix fixer must still flush the usage delta,
+        leave a resumable fixer trace, and let a re-run finish publication without
+        counting any call twice.
+        """
+        fixer_calls = 0
+
+        def handler(messages, tier, json_mode):
+            system = messages[0]["content"]
+            user = messages[-1]["content"]
+            if "evidence-based review agent" in system:
+                return _agent_final(user)
+            if "cautious revision editor" in system:
+                nonlocal fixer_calls
+                fixer_calls += 1
+                if fixer_calls == 1:
+                    raise KeyboardInterrupt
+                return _fix_json(user, "Agent 终局译文。")
+            return "{}"
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = _store(directory)
+            issue = {
+                "issue_id": "review-00001",
+                "issue_key": "issue-1",
+                "chapter": 0,
+                "index": 0,
+                "type": "mistranslation",
+                "detail": "信息不完整",
+                "suggestion": "补全信息",
+                "evidence_refs": [],
+            }
+            outcome = _outcome(store, issues=[issue])
+            service = Orchestrator(
+                _config(str(Path(directory, "state"))),
+                client=MeteredFakeClient(handler=handler),
+            )._review_autofix
+
+            with self.assertRaises(KeyboardInterrupt):
+                service.run(store, outcome, [])
+
+            # The finally block must have persisted both model calls, including the
+            # interrupted one, into the review and book ledgers.
+            self.assertEqual(fixer_calls, 1)
+            self.assertEqual(store.load_chapter(0).text_segments[0].target, "正式译文。")
+            trace = json.loads(
+                Path(outcome.run_dir, "autofix/fixers/ch0-text0.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(trace["status"], "running")
+            self.assertFalse(Path(outcome.run_dir, "autofix/index.json").exists())
+            debug = ReviewRunStore.open_existing(outcome.run_dir)
+            interrupted_usage = debug.load_usage()
+            self.assertIsNotNone(interrupted_usage)
+            assert interrupted_usage is not None
+            self.assertEqual(interrupted_usage["totals"]["calls"], 2)
+            book_usage = store.load_usage()
+            self.assertIsNotNone(book_usage)
+            assert book_usage is not None
+            self.assertEqual(book_usage["totals"]["calls"], 2)
+
+            fixed = service.run(store, outcome, [])
+
+            self.assertEqual(store.load_chapter(0).text_segments[0].target, "Agent 终局译文。")
+            self.assertEqual(fixed.result["autofix"]["status"], "completed")
+            index = json.loads(
+                Path(outcome.run_dir, "autofix/index.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(index["status"], "completed")
+            # The finished agent trace is reused; only the interrupted fixer is retried.
+            self.assertEqual(fixer_calls, 2)
+            resumed_usage = debug.load_usage()
+            self.assertIsNotNone(resumed_usage)
+            assert resumed_usage is not None
+            self.assertEqual(resumed_usage["totals"]["calls"], 3)
+            self.assertEqual(resumed_usage["totals"]["total_tokens"], 24)
+            book_usage = store.load_usage()
+            self.assertIsNotNone(book_usage)
+            assert book_usage is not None
+            self.assertEqual(book_usage["totals"]["calls"], 3)
 
     def test_newer_review_prevents_publishing_an_older_pending_index(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/trans_novel/model_commands.py
+++ b/trans_novel/model_commands.py
@@ -173,6 +173,7 @@ def register_model_commands(
                 or any(
                     not isinstance(row, dict)
                     or set(row) != {"role", "content"}
+                    or not isinstance(row["role"], str)
                     or row["role"] not in {"system", "user", "assistant"}
                     or not isinstance(row["content"], str)
                     for row in payload


### PR DESCRIPTION
Closes #223

## 变更摘要

对应 issue 的 4 个事项：1 处产品代码修复 + 3 组测试补充。

1. **修复 `models compare` 在不可哈希 role 上的崩溃**（`trans_novel/model_commands.py`）
   `row["role"] not in {"system", "user", "assistant"}` 在 role 为 list/dict 时抛出 `TypeError: unhashable type: 'list'`，绕过命令的 `(OSError, ValueError, RuntimeError)` 异常处理并向 CLI 打印 traceback。现在在集合成员检查**之前**加入 `not isinstance(row["role"], str)` 守卫，使非法 role 落入既有的 `ValueError("Messages must be a nonempty array of role/content objects")` 路径——红色错误消息、退出码 1、无 traceback。

2. **锁定实际请求的输出上限**（`tests/test_llm_routing.py`）
   `test_dynamic_output_hint_respects_explicit_profile_cap` 此前只断言静态路由配置。现在同时捕获发送给 provider 的 `RequestContext`，断言实际请求携带路由上限 `256`，而非调用方传入的 `max_tokens=999` 提示。

3. **锁定不可重试错误的 failover 边界**（`tests/test_llm_routing.py`）
   新增 `test_non_retryable_errors_neither_retry_nor_fail_over`：401 级 provider 错误（鸭子类型识别 `status_code`）与普通 `ValueError` 都必须立即上抛且 `calls == ["first"]`——不重试、不切换备用模型。此后把 `is_retryable_provider_error` 改成恒 True 无法再通过测试套件。

4. **覆盖中断后的用量落盘与续跑**
   - `tests/test_orchestrator.py`：首个 reviewer 响应完成后抛 `KeyboardInterrupt`，必须已落盘 review 用量账本、记录 `review_interrupted` 事件；在同一 state 上新建 `Orchestrator` 重跑必须恢复同一运行目录至 `completed`，且 review 与全书两个账本的累计用量与实际调用数精确一致（无重复计数）。
   - `tests/test_review_autofix.py`：autofix 发布器的同样保证——fixer 阶段抛 `KeyboardInterrupt` 仍经 `finally` 落盘用量增量、留下可续跑的 `running` fixer trace；重跑复用已完成的 agent trace，只重试被中断的 fixer，用量恰好计一次。

未改动 `retrying.py` / `router.py` 逻辑——issue 已确认当前实现符合约定，这些测试只负责把它们固定下来。

## 验证

- `uv run pytest -q` — 677 passed, 1 skipped（基线 672 passed, 1 skipped；新增 5 个用例。Review 后精简测试脚手架：`MeteredFakeClient` 收敛至 `tests/fake_llm.py` 共享、parametrize 收敛为计划内单用例，用例数较初版 -4）
- `uv run ruff check .` — 通过
- `uv run ruff format --check .` — 通过
- `git diff --check .` — 通过

所有修复均先写失败的回归测试（compare 修复前该输入复现为 `TypeError`；两个中断测试在未改任何产品代码前即断言 flush/续跑不变量）。
