### PR TITLE
fix(pdf): allow empty MinerU translations without aborting

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -105,12 +105,35 @@ class TestTranslatorAlignment(unittest.TestCase):
 
     def test_empty_per_segment_fallback_is_rejected(self):
         client = FakeClient(
-            handler=lambda messages, tier, json_mode: json.dumps({"translations": []})
+            handler=lambda messages, tier, json_mode: json.dumps({"translations": [""]})
         )
         translator = Translator(client, self._config())
 
         with self.assertRaisesRegex(Exception, "failed at paragraph 0"):
             translator.translate_batch(["あ", "い"])
+
+    def test_mineru_allows_empty_string_translations(self):
+        """MinerU may persist blank targets when the model returns empty OCR-junk refusals."""
+
+        def handler(messages, tier, json_mode):
+            n = _count_segments(messages[-1]["content"])
+            return json.dumps({"translations": [""] * n})
+
+        translator = Translator(FakeClient(handler=handler), self._config())
+        out = translator.translate_batch(
+            ["The OCR result should be empty according to Rule 2.", "正文"],
+            allow_empty_translations=True,
+        )
+        self.assertEqual(out, ["", ""])
+
+    def test_mineru_empty_allowance_still_rejects_non_string(self):
+        client = FakeClient(
+            handler=lambda messages, tier, json_mode: json.dumps({"translations": [None]})
+        )
+        translator = Translator(client, self._config())
+
+        with self.assertRaisesRegex(Exception, "failed at paragraph 0"):
+            translator.translate_batch(["あ"], allow_empty_translations=True)
 
     def test_non_string_translation_is_rejected(self):
         client = FakeClient(
@@ -135,6 +158,24 @@ class TestTranslatorAlignment(unittest.TestCase):
             translator.translate_batch(["あ", "い"])
 
         self.assertEqual(len(client.calls), 1)
+
+
+class TestMinerUEmptyTargetResume(unittest.TestCase):
+    def test_blank_target_counts_as_translated_for_resume_batches(self):
+        from trans_novel.ingest.models import Segment
+        from trans_novel.pipeline.translation import _is_mineru_pdf, _resume_batches
+
+        self.assertTrue(_is_mineru_pdf({"fmt": "pdf", "meta": {}}))
+        self.assertFalse(_is_mineru_pdf({"fmt": "pdf", "meta": {"babeldoc": True}}))
+        self.assertFalse(_is_mineru_pdf({"fmt": "epub", "meta": {}}))
+
+        segments = [
+            Segment(index=0, kind="p", source="a", target="译"),
+            Segment(index=1, kind="p", source="junk", target=""),
+            Segment(index=2, kind="p", source="b", target=None),
+        ]
+        batches = _resume_batches(segments, max_chars=10_000)
+        self.assertEqual([[s.index for s in batch] for batch in batches], [[0, 1], [2]])
 
 
 class TestTranslatorPromptOrder(unittest.TestCase):

--- a/trans_novel/agents/translator.py
+++ b/trans_novel/agents/translator.py
@@ -82,8 +82,14 @@ class Translator(Agent):
         chapter_digest: str = "",
         annotation_contexts: list[list[dict[str, str]]] | None = None,
         next_source: str = "",
+        *,
+        allow_empty_translations: bool = False,
     ) -> list[str]:
-        """Translate one batch and strictly validate output types, count and nonempty content."""
+        """Translate one batch and validate output types, count and (by default) nonempty content.
+
+        When ``allow_empty_translations`` is true (MinerU PDF path), blank strings are kept as
+        formal targets so VLM OCR junk that the model refuses to translate does not abort the run.
+        """
         n = len(sources)
         system = render(
             "translator_system",
@@ -124,7 +130,9 @@ class Translator(Agent):
             raise AlignmentError(
                 f"Translation count mismatch: expected {n} paragraphs, got {len(items)}"
             )
-        if any(not isinstance(item, str) or not item.strip() for item in items):
+        if any(not isinstance(item, str) for item in items):
+            raise AlignmentError("The model returned a non-string translation")
+        if not allow_empty_translations and any(not item.strip() for item in items):
             raise AlignmentError("The model returned an empty or non-string translation")
         return items
 
@@ -138,6 +146,8 @@ class Translator(Agent):
         chapter_digest,
         annotation_context,
         next_source: str,
+        *,
+        allow_empty_translations: bool = False,
     ) -> str:
         """Use the batch protocol for one paragraph as the final alignment fallback."""
         out = self._call_batch(
@@ -149,6 +159,7 @@ class Translator(Agent):
             chapter_digest,
             [annotation_context],
             next_source=next_source,
+            allow_empty_translations=allow_empty_translations,
         )
         return out[0]
 
@@ -163,6 +174,7 @@ class Translator(Agent):
         chapter_digest: str = "",
         annotation_contexts: list[list[dict[str, str]]] | None = None,
         next_source: str = "",
+        allow_empty_translations: bool = False,
     ) -> list[str]:
         """Translate aligned paragraphs with one following source segment as reference only."""
         glossary_terms = glossary_terms or []
@@ -196,6 +208,7 @@ class Translator(Agent):
                     chapter_digest,
                     translated_annotation_contexts,
                     next_source=batch_next_source,
+                    allow_empty_translations=allow_empty_translations,
                 )
                 targets = list(sources)
                 for index, target in zip(translated_indices, translated):
@@ -206,7 +219,8 @@ class Translator(Agent):
                 continue
 
         # Fall back to individual paragraphs. If any still fails, stop explicitly and preserve saved
-        # batches for resume. Empty placeholders would incorrectly mark the chapter complete.
+        # batches for resume. Without allow_empty_translations, empty placeholders must not mark
+        # the chapter complete; MinerU may persist "" when the model returns a blank string.
         targets = list(sources)
         for index, source, annotation_context in zip(
             translated_indices,
@@ -223,6 +237,7 @@ class Translator(Agent):
                     chapter_digest,
                     annotation_context,
                     next_source=sources[index + 1] if index + 1 < n else next_source,
+                    allow_empty_translations=allow_empty_translations,
                 )
             except Exception as error:
                 raise AlignmentError(

--- a/trans_novel/pipeline/translation.py
+++ b/trans_novel/pipeline/translation.py
@@ -31,18 +31,27 @@ if TYPE_CHECKING:
 ProgressFn = Callable[[int, int, str], None]
 
 
+def _is_mineru_pdf(manifest: dict[str, Any]) -> bool:
+    """True for MinerU PDF state (fmt=pdf without BabelDOC markers)."""
+    if manifest.get("fmt") != "pdf":
+        return False
+    raw_meta = manifest.get("meta")
+    meta: dict[str, Any] = raw_meta if isinstance(raw_meta, dict) else {}
+    return not bool(meta.get("babeldoc")) and meta.get("pdf_export") != "babeldoc"
+
+
 def _resume_batches(segments, max_chars: int) -> list[list]:
     """Split character-budget batches again at completed/pending boundaries.
-    A changed budget may mix saved translations and empty targets in one batch. Group by
+    A changed budget may mix saved translations and unset targets in one batch. Group by
     completion state to translate only missing paragraphs and avoid overwriting confirmed
-    content.
+    content. ``target is not None`` (including blank ``""``) counts as translated.
     """
     batches: list[list] = []
     for raw_batch in batch_segments(segments, max_chars):
         current: list = []
         current_done: bool | None = None
         for segment in raw_batch:
-            done = bool(segment.target and segment.target.strip())
+            done = segment.target is not None
             if current and done != current_done:
                 batches.append(current)
                 current = []
@@ -80,6 +89,7 @@ class TranslationService:
             min_recent_keep=max(40, self._runtime.config.pipeline.rolling_context_segments),
         )
         style = self._runtime.analyzer.style_brief(store.load_analysis() or {})
+        allow_empty_translations = _is_mineru_pdf(manifest)
 
         if only_chapter is not None:
             targets = [only_chapter]
@@ -96,6 +106,7 @@ class TranslationService:
             only_chapter=only_chapter,
             chapters=targets,
             total_segments=total,
+            allow_empty_translations=allow_empty_translations,
         )
         try:
             for ci in targets:
@@ -112,6 +123,7 @@ class TranslationService:
                     progress=progress,
                     done=done,
                     total=total,
+                    allow_empty_translations=allow_empty_translations,
                 )
                 store.save_context(context.to_dict())
                 self._runtime.flush_usage(store, scope="chapter")
@@ -179,8 +191,8 @@ class TranslationService:
     def progress_counts(self, store: RunStore, chapter_indices: list[int]) -> tuple[int, int]:
         """Compute progress from batch checkpoints, starting resume at completed translation
         counts.
-        Count a batch as done only when all its targets exist. Counting partial batches
-        early would duplicate completion counts if the batch reruns.
+        Count a batch as done only when every target is not None (blank ``""`` counts). Counting
+        partial batches early would duplicate completion counts if the batch reruns.
         """
         total = 0
         done = 0
@@ -190,7 +202,7 @@ class TranslationService:
             for batch in _resume_batches(
                 segments, self._runtime.config.segment.max_chars_per_batch
             ):
-                if all(segment.target and segment.target.strip() for segment in batch):
+                if all(segment.target is not None for segment in batch):
                     done += len(batch)
         return total, done
 
@@ -209,6 +221,7 @@ class TranslationService:
         progress: ProgressFn | None = None,
         done: int = 0,
         total: int = 0,
+        allow_empty_translations: bool = False,
     ) -> int:
         """Translate, polish, extract and persist one chapter; return the updated
         completed-paragraph count.
@@ -246,9 +259,9 @@ class TranslationService:
         for b in batches:
             batch_start = seg_base
             glossary_key = store.batch_glossary_key(batch_start, len(b))
-            existing_targets = [s.target for s in b if s.target and s.target.strip()]
-            if len(existing_targets) == len(b):
+            if all(s.target is not None for s in b):
                 # Reuse a batch translated at this position/context, rebuild rolling context and skip it.
+                # Blank "" is a completed MinerU allowance; only None means not yet translated.
                 self._annotations.align_annotations_after_batch(
                     ci,
                     chapter,
@@ -324,6 +337,7 @@ class TranslationService:
                 chapter_digest,
                 annotation_contexts=annotation_contexts[batch_start : batch_start + len(b)],
                 next_source=next_source,
+                allow_empty_translations=allow_empty_translations,
             )
             for s, t in zip(b, targets):
                 s.target = t
@@ -478,7 +492,7 @@ class TranslationService:
         sees current formal text.
         """
         prefix = segments[: max(0, min(end, len(segments)))]
-        if not prefix or any(not (segment.target and segment.target.strip()) for segment in prefix):
+        if not prefix or any(segment.target is None for segment in prefix):
             return
         targets = [segment.target or "" for segment in prefix]
         retained = min(len(targets), len(context.recent_targets))
@@ -754,6 +768,8 @@ class TranslationService:
         chapter_digest: str = "",
         annotation_contexts: list[list[dict[str, str]]] | None = None,
         next_source: str = "",
+        *,
+        allow_empty_translations: bool = False,
     ) -> list[str]:
         """Translate then polish one batch.
         Translate every paragraph in its own context without reusing text across positions.
@@ -771,6 +787,7 @@ class TranslationService:
             chapter_digest=chapter_digest,
             annotation_contexts=annotation_contexts,
             next_source=next_source,
+            allow_empty_translations=allow_empty_translations,
         )
         # Strip pronunciation markers accidentally copied from source into the model's translation.
         targets = [strip_ruby_markers(target) for target in targets]


### PR DESCRIPTION
MinerU VLM OCR junk often yields blank model output; accept "" on that path and treat non-None targets as resume-complete so runs can continue.